### PR TITLE
Add support for query parameters in WebSocket URL construction

### DIFF
--- a/engine.io/v4/client/transport/websocket/transport.go
+++ b/engine.io/v4/client/transport/websocket/transport.go
@@ -65,8 +65,7 @@ func (c *Transport) buildWsUrl() *url.URL {
 
 	q, err := url.ParseQuery(c.url.RawQuery)
 	if err != nil {
-		c.log.Errorf("buildWsUrl: %s", err)
-		return nil
+		c.log.Errorf("malformed query on url: %s", err)
 	}
 
 	query := wsURL.Query()

--- a/engine.io/v4/client/transport/websocket/transport.go
+++ b/engine.io/v4/client/transport/websocket/transport.go
@@ -63,7 +63,17 @@ func (c *Transport) buildWsUrl() *url.URL {
 		wsURL.Scheme = "wss"
 	}
 
+	q, err := url.ParseQuery(c.url.RawQuery)
+	if err != nil {
+		c.log.Errorf("buildWsUrl: %s", err)
+		return nil
+	}
+
 	query := wsURL.Query()
+
+	for k, v := range q {
+		query[k] = v
+	}
 
 	query.Set("transport", "websocket")
 	query.Set("EIO", "4")

--- a/engine.io/v4/client/transport/websocket/transport_test.go
+++ b/engine.io/v4/client/transport/websocket/transport_test.go
@@ -130,6 +130,12 @@ func TestTransport_buildWsUrl(t *testing.T) {
 			sid:      "test-sid",
 			expected: "wss://example.com/socket.io/?EIO=4&sid=test-sid&transport=websocket",
 		},
+		{
+			name:     "HTTPS URL with query",
+			url:      &url.URL{Scheme: "https", Host: "example.com", Path: "/socket.io/", RawQuery: "query=foo"},
+			sid:      "test-sid",
+			expected: "wss://example.com/socket.io/?EIO=4&query=foo&sid=test-sid&transport=websocket",
+		},
 	}
 
 	for _, tt := range tests {

--- a/engine.io/v4/client/transport/websocket/transport_test.go
+++ b/engine.io/v4/client/transport/websocket/transport_test.go
@@ -112,11 +112,16 @@ func TestTransport_SetHandshake(t *testing.T) {
 func TestTransport_buildWsUrl(t *testing.T) {
 	t.Parallel()
 
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	tests := []struct {
-		name     string
-		url      *url.URL
-		sid      string
-		expected string
+		name                       string
+		url                        *url.URL
+		sid                        string
+		expected                   string
+		expectedErrorLog           string
+		expectedErrorLogParameters []interface{}
 	}{
 		{
 			name:     "HTTP URL",
@@ -136,13 +141,28 @@ func TestTransport_buildWsUrl(t *testing.T) {
 			sid:      "test-sid",
 			expected: "wss://example.com/socket.io/?EIO=4&query=foo&sid=test-sid&transport=websocket",
 		},
+		{
+			name:                       "HTTPS URL with malformed query",
+			url:                        &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/", RawQuery: "key1=value1&key2=%ZZ"},
+			sid:                        "test-sid",
+			expected:                   "ws://example.com/socket.io/?EIO=4&key1=value1&sid=test-sid&transport=websocket",
+			expectedErrorLog:           "malformed query on url: %s",
+			expectedErrorLogParameters: []interface{}{gomock.Any()},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			mockLogger := mock_engineio_v4_client_transport.NewMockLogger(ctrl)
+
+			if tt.expectedErrorLog != "" {
+				mockLogger.EXPECT().Errorf(tt.expectedErrorLog, tt.expectedErrorLogParameters...).Times(1)
+			}
+
 			transport := &Transport{
 				url: tt.url,
 				sid: tt.sid,
+				log: mockLogger,
 			}
 			result := transport.buildWsUrl()
 			assert.Equal(t, tt.expected, result.String())

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hakankutluay/go.socket.io
+module github.com/maldikhan/go.socket.io
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/maldikhan/go.socket.io
+module github.com/hakankutluay/go.socket.io
 
 go 1.18
 


### PR DESCRIPTION
This PR adds query string parameter support on Raw Url

closes #8 