### PR TITLE
fix: resolve race conditions in transport upgrade and event dispatch

### DIFF
--- a/engine.io/v4/client/client.go
+++ b/engine.io/v4/client/client.go
@@ -34,6 +34,11 @@ type Client struct {
 	transportClosed     chan error
 	afterConnect        func()
 	messages            chan []byte
+
+	// transportMu serializes access to the transport field and
+	// the waitUpgrade / waitHandshake channels so that Send() never
+	// races with transportUpgrade() or Close().
+	transportMu sync.RWMutex
 }
 
 func (c *Client) Connect(ctx context.Context) error {
@@ -51,8 +56,11 @@ func (c *Client) Connect(ctx context.Context) error {
 		return err
 	}
 
+	c.transportMu.Lock()
 	c.hadHandshake = sync.Once{}
 	c.waitHandshake = make(chan struct{}, 1)
+	c.transportMu.Unlock()
+
 	err = c.transport.RequestHandshake()
 	if err != nil {
 		return err
@@ -84,10 +92,14 @@ func (c *Client) messageLoop(messages <-chan []byte) {
 }
 
 func (c *Client) transportUpgrade(transport Transport) error {
+	// Lock while mutating state that Send() reads.
+	c.transportMu.Lock()
 	c.hadUpgrade = sync.Once{}
 	c.waitUpgrade = make(chan struct{}, 1)
+
 	err := c.transport.Stop()
 	if err != nil {
+		c.transportMu.Unlock()
 		c.log.Errorf("stop transport: %s", err)
 		return err
 	}
@@ -98,9 +110,11 @@ func (c *Client) transportUpgrade(transport Transport) error {
 	err = c.transport.Run(c.ctx, c.url, c.sid, c.messages, c.transportClosed)
 	if err != nil {
 		close(c.transportClosed)
+		c.transportMu.Unlock()
 		c.log.Errorf("run transport: %s", err)
 		return err
 	}
+	c.transportMu.Unlock()
 
 	return c.sendPacket(&engineio_v4.Message{
 		Type: engineio_v4.PacketPing,
@@ -140,23 +154,32 @@ func (c *Client) handleHandshake(data []byte) error {
 		close(c.waitHandshake)
 	})
 
-	// Call onConnect hook
-	if c.afterConnect != nil {
-		c.afterConnect()
-	}
-
-	// Perform protocol upgrade
+	// Perform protocol upgrade before calling afterConnect so that any
+	// Send() triggered by the callback will observe the new transport
+	// and properly wait for the upgrade probe to complete.
 	if len(handshakeResp.Upgrades) > 0 {
 		for _, newTransportName := range handshakeResp.Upgrades {
 			if c.transport.Transport() == engineio_v4.EngineIOTransport(newTransportName) {
 				break
 			}
 			if newTransport, found := c.supportedTransports[engineio_v4.EngineIOTransport(newTransportName)]; found {
-				return c.transportUpgrade(newTransport)
+				err = c.transportUpgrade(newTransport)
+				if err != nil {
+					return err
+				}
+
+				break
 			} else {
 				c.log.Warnf("unsupported upgrade: %s", handshakeResp.Upgrades[0])
 			}
 		}
+	}
+
+	// Call onConnect hook after the transport upgrade has completed so
+	// that the new transport is fully ready before any callback tries
+	// to send data.
+	if c.afterConnect != nil {
+		c.afterConnect()
 	}
 
 	return nil
@@ -230,12 +253,23 @@ func (c *Client) sendPacket(packet *engineio_v4.Message) error {
 }
 
 func (c *Client) Send(message []byte) error {
-	if c.waitHandshake != nil {
-		<-c.waitHandshake
+	// Snapshot wait channels under the lock so that we never miss a
+	// channel created by a concurrent transportUpgrade or Connect.
+	c.transportMu.RLock()
+	wh := c.waitHandshake
+	wu := c.waitUpgrade
+	c.transportMu.RUnlock()
+
+	if wh != nil {
+		<-wh
 	}
-	if c.waitUpgrade != nil {
-		<-c.waitUpgrade
+	if wu != nil {
+		<-wu
 	}
+
+	// Re-acquire the lock to read the current transport safely.
+	c.transportMu.RLock()
+	defer c.transportMu.RUnlock()
 
 	return c.sendPacket(&engineio_v4.Message{
 		Type: engineio_v4.PacketMessage,
@@ -255,7 +289,11 @@ func (c *Client) On(event string, handler func([]byte)) {
 }
 
 func (c *Client) Close() error {
-	err := c.transport.Stop()
+	c.transportMu.Lock()
+	t := c.transport
+	c.transportMu.Unlock()
+
+	err := t.Stop()
 	if err != nil {
 		return err
 	}

--- a/engine.io/v4/client/client.go
+++ b/engine.io/v4/client/client.go
@@ -97,11 +97,20 @@ func (c *Client) transportUpgrade(transport Transport) error {
 	c.hadUpgrade = sync.Once{}
 	c.waitUpgrade = make(chan struct{}, 1)
 
+	// failUpgrade closes the upgrade gate so that Send() callers waiting
+	// on waitUpgrade are unblocked even when the upgrade fails.
+	failUpgrade := func(err error) error {
+		c.hadUpgrade.Do(func() {
+			close(c.waitUpgrade)
+		})
+		c.transportMu.Unlock()
+		return err
+	}
+
 	err := c.transport.Stop()
 	if err != nil {
-		c.transportMu.Unlock()
 		c.log.Errorf("stop transport: %s", err)
-		return err
+		return failUpgrade(err)
 	}
 	<-c.transportClosed
 	c.transport = transport
@@ -110,16 +119,24 @@ func (c *Client) transportUpgrade(transport Transport) error {
 	err = c.transport.Run(c.ctx, c.url, c.sid, c.messages, c.transportClosed)
 	if err != nil {
 		close(c.transportClosed)
-		c.transportMu.Unlock()
 		c.log.Errorf("run transport: %s", err)
-		return err
+		return failUpgrade(err)
 	}
 	c.transportMu.Unlock()
 
-	return c.sendPacket(&engineio_v4.Message{
+	err = c.sendPacket(&engineio_v4.Message{
 		Type: engineio_v4.PacketPing,
 		Data: []byte("probe"),
 	})
+	if err != nil {
+		// Probe failed — unblock Send() callers waiting on the upgrade gate.
+		c.transportMu.Lock()
+		c.hadUpgrade.Do(func() {
+			close(c.waitUpgrade)
+		})
+		c.transportMu.Unlock()
+	}
+	return err
 }
 
 func (c *Client) handleHandshake(data []byte) error {
@@ -149,14 +166,10 @@ func (c *Client) handleHandshake(data []byte) error {
 		c.pingTimeout = time.Duration(handshakeResp.PingTimeout) * time.Millisecond
 	}
 
-	// close handshake
-	c.hadHandshake.Do(func() {
-		close(c.waitHandshake)
-	})
-
-	// Perform protocol upgrade before calling afterConnect so that any
-	// Send() triggered by the callback will observe the new transport
-	// and properly wait for the upgrade probe to complete.
+	// Perform protocol upgrade BEFORE unblocking Send() callers so that
+	// waitUpgrade is published before waitHandshake is closed. Otherwise
+	// a Send() waiting on waitHandshake would wake with waitUpgrade == nil
+	// and write on the old transport during the upgrade window.
 	if len(handshakeResp.Upgrades) > 0 {
 		for _, newTransportName := range handshakeResp.Upgrades {
 			if c.transport.Transport() == engineio_v4.EngineIOTransport(newTransportName) {
@@ -174,6 +187,12 @@ func (c *Client) handleHandshake(data []byte) error {
 			}
 		}
 	}
+
+	// Close the handshake gate AFTER the upgrade gate (waitUpgrade) is
+	// already published so Send() sees both gates atomically.
+	c.hadHandshake.Do(func() {
+		close(c.waitHandshake)
+	})
 
 	// Call onConnect hook after the transport upgrade has completed so
 	// that the new transport is fully ready before any callback tries
@@ -269,7 +288,12 @@ func (c *Client) Send(message []byte) error {
 
 	// Re-acquire the lock to read the current transport safely.
 	c.transportMu.RLock()
-	defer c.transportMu.RUnlock()
+	t := c.transport
+	c.transportMu.RUnlock()
+
+	if t == nil {
+		return errors.New("client is closed")
+	}
 
 	return c.sendPacket(&engineio_v4.Message{
 		Type: engineio_v4.PacketMessage,
@@ -289,9 +313,18 @@ func (c *Client) On(event string, handler func([]byte)) {
 }
 
 func (c *Client) Close() error {
-	c.transportMu.RLock()
+	// Write-lock to prevent new Send() calls from acquiring the transport
+	// while we are tearing it down. Setting transport to nil ensures that
+	// any Send() arriving after Close releases the lock will see nil and
+	// fail fast instead of writing on a stopped transport.
+	c.transportMu.Lock()
 	t := c.transport
-	c.transportMu.RUnlock()
+	c.transport = nil
+	c.transportMu.Unlock()
+
+	if t == nil {
+		return nil
+	}
 
 	err := t.Stop()
 	if err != nil {

--- a/engine.io/v4/client/client.go
+++ b/engine.io/v4/client/client.go
@@ -46,7 +46,7 @@ func (c *Client) Connect(ctx context.Context) error {
 
 	// Run main loop
 	c.messages = make(chan []byte, 100)
-	go c.messageLoop(c.messages)
+	go c.messageLoop(ctx, c.messages)
 
 	// Run transport
 	c.transportClosed = make(chan error, 1)
@@ -69,7 +69,7 @@ func (c *Client) Connect(ctx context.Context) error {
 	return nil
 }
 
-func (c *Client) messageLoop(messages <-chan []byte) {
+func (c *Client) messageLoop(ctx context.Context, messages <-chan []byte) {
 	if messages == nil {
 		c.log.Errorf("messages channel is nil, can't read transport messages")
 		return
@@ -84,7 +84,7 @@ func (c *Client) messageLoop(messages <-chan []byte) {
 			if err != nil {
 				c.log.Errorf("handle packet error: %s", err)
 			}
-		case <-c.ctx.Done():
+		case <-ctx.Done():
 			c.log.Warnf("context done, engine.io client stopped processing messages")
 			return
 		}
@@ -289,9 +289,9 @@ func (c *Client) On(event string, handler func([]byte)) {
 }
 
 func (c *Client) Close() error {
-	c.transportMu.Lock()
+	c.transportMu.RLock()
 	t := c.transport
-	c.transportMu.Unlock()
+	c.transportMu.RUnlock()
 
 	err := t.Stop()
 	if err != nil {

--- a/engine.io/v4/client/client_test.go
+++ b/engine.io/v4/client/client_test.go
@@ -332,6 +332,42 @@ func TestClient_handleHandshake(t *testing.T) {
 		assert.Equal(t, "test-sid", client.sid)
 	})
 
+	t.Run("afterConnect called after upgrade", func(t *testing.T) {
+		handshakeResp := &engineio_v4.HandshakeResponse{
+			Sid:          "test-sid",
+			PingInterval: 25000,
+			PingTimeout:  5000,
+			Upgrades:     []string{"websocket"},
+		}
+		data, _ := json.Marshal(handshakeResp)
+
+		client.transport = mockTransportPolling
+
+		mockTransportPolling.EXPECT().SetHandshake(handshakeResp)
+		mockTransportPolling.EXPECT().Stop().Do(func() {
+			client.transportClosed = make(chan error)
+			close(client.transportClosed)
+		})
+		mockTransportWs.EXPECT().SetHandshake(handshakeResp)
+		mockTransportWs.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		mockParser.EXPECT().Serialize(gomock.Any()).Return([]byte("probe"), nil)
+		mockTransportWs.EXPECT().SendMessage([]byte("probe")).Return(nil)
+
+		// Track the order: afterConnect must observe the websocket
+		// transport (i.e. the upgrade must have finished already).
+		var transportDuringCallback Transport
+		client.afterConnect = func() {
+			transportDuringCallback = client.transport
+		}
+
+		client.hadHandshake = sync.Once{}
+		client.waitHandshake = make(chan struct{})
+		err := client.handleHandshake(data)
+		require.NoError(t, err)
+		assert.Equal(t, mockTransportWs, transportDuringCallback,
+			"afterConnect must be called after transport upgrade")
+	})
+
 	t.Run("Successful handshake with wrong upgrade", func(t *testing.T) {
 		handshakeResp := &engineio_v4.HandshakeResponse{
 			Sid:          "test-sid",
@@ -618,6 +654,53 @@ func TestClient_Send(t *testing.T) {
 			assert.Fail(t, "message have not been sent after handshake was completed")
 		}
 	})
+}
+
+func TestClient_Send_waits_for_upgrade(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := mocks.NewMockLogger(ctrl)
+	mockParser := mocks.NewMockParser(ctrl)
+	mockTransport := mocks.NewMockTransport(ctrl)
+
+	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+
+	client := &Client{
+		log:       mockLogger,
+		parser:    mockParser,
+		transport: mockTransport,
+	}
+
+	// Simulate an in-progress upgrade: waitUpgrade is set but not yet closed.
+	client.transportMu.Lock()
+	client.waitUpgrade = make(chan struct{})
+	client.transportMu.Unlock()
+
+	sendDone := make(chan error, 1)
+	mockParser.EXPECT().Serialize(gomock.Any()).Return([]byte("msg"), nil).AnyTimes()
+	mockTransport.EXPECT().SendMessage([]byte("msg")).Return(nil).AnyTimes()
+
+	go func() {
+		sendDone <- client.Send([]byte("test"))
+	}()
+
+	// Verify Send blocks while upgrade is pending.
+	select {
+	case <-sendDone:
+		t.Fatal("Send should block while upgrade is in progress")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Complete the upgrade.
+	close(client.waitUpgrade)
+
+	select {
+	case err := <-sendDone:
+		assert.NoError(t, err)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Send should complete after upgrade finishes")
+	}
 }
 
 func TestClient_On(t *testing.T) {

--- a/engine.io/v4/client/client_test.go
+++ b/engine.io/v4/client/client_test.go
@@ -102,6 +102,9 @@ func TestClient_Connect(t *testing.T) {
 	})
 
 	t.Run("Transport run error", func(t *testing.T) {
+		// Reset transport after previous Close() nil'd it out.
+		client.transport = mockTransport
+
 		mockTransport.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("run error"))
 		mockTransport.EXPECT().Stop()
 		err := client.Connect(ctx)
@@ -123,6 +126,9 @@ func TestClient_Connect(t *testing.T) {
 	})
 
 	t.Run("Handshake request error", func(t *testing.T) {
+		// Reset transport after previous Close() nil'd it out.
+		client.transport = mockTransport
+
 		ctx := context.Background()
 		mockTransport.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		mockTransport.EXPECT().RequestHandshake().Return(errors.New("handshake error"))
@@ -234,21 +240,59 @@ func TestClient_transportUpgrade(t *testing.T) {
 		assert.Equal(t, mockNewTransport, client.transport)
 	})
 
-	t.Run("stop transport error", func(t *testing.T) {
+	t.Run("stop transport error unblocks waitUpgrade", func(t *testing.T) {
 		client.transport = mockOldTransport
 		mockOldTransport.EXPECT().Stop().Return(errors.New("oops"))
 		err := client.transportUpgrade(mockNewTransport)
 		assert.ErrorContains(t, err, "oops")
 		assert.Equal(t, mockOldTransport, client.transport)
+
+		// waitUpgrade must be closed so Send() callers don't hang forever.
+		select {
+		case <-client.waitUpgrade:
+			// closed — correct
+		default:
+			t.Fatal("waitUpgrade must be closed on Stop() failure")
+		}
 	})
 
-	t.Run("start new transport error", func(t *testing.T) {
+	t.Run("start new transport error unblocks waitUpgrade", func(t *testing.T) {
+		client.transport = mockOldTransport
 		mockOldTransport.EXPECT().Stop().Return(nil)
 		client.transportClosed <- nil
 		mockNewTransport.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("oops"))
 		err := client.transportUpgrade(mockNewTransport)
 		assert.ErrorContains(t, err, "oops")
 		assert.Equal(t, mockNewTransport, client.transport)
+
+		// waitUpgrade must be closed so Send() callers don't hang forever.
+		select {
+		case <-client.waitUpgrade:
+			// closed — correct
+		default:
+			t.Fatal("waitUpgrade must be closed on Run() failure")
+		}
+	})
+
+	t.Run("probe send error unblocks waitUpgrade", func(t *testing.T) {
+		client.transport = mockOldTransport
+		mockOldTransport.EXPECT().Stop().Return(nil)
+		client.transportClosed = make(chan error, 1)
+		client.transportClosed <- nil
+		mockNewTransport.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		mockParser.EXPECT().Serialize(gomock.Any()).Return([]byte("probe"), nil)
+		mockNewTransport.EXPECT().SendMessage([]byte("probe")).Return(errors.New("send failed"))
+
+		err := client.transportUpgrade(mockNewTransport)
+		assert.ErrorContains(t, err, "send failed")
+
+		// waitUpgrade must be closed so Send() callers don't hang forever.
+		select {
+		case <-client.waitUpgrade:
+			// closed — correct
+		default:
+			t.Fatal("waitUpgrade must be closed on probe send failure")
+		}
 	})
 
 }
@@ -769,9 +813,13 @@ func TestClient_Close(t *testing.T) {
 
 		err := client.Close()
 		assert.NoError(t, err)
+		assert.Nil(t, client.transport, "transport must be nil after close")
 	})
 
 	t.Run("Failed close", func(t *testing.T) {
+		// Reset transport after previous Close() nil'd it out.
+		client.transport = mockTransport
+		client.transportClosed = make(chan error, 1)
 
 		mockTransport.EXPECT().Stop().Return(errors.New("oops"))
 		client.transportClosed <- nil
@@ -779,4 +827,29 @@ func TestClient_Close(t *testing.T) {
 		err := client.Close()
 		assert.ErrorContains(t, err, "oops")
 	})
+
+	t.Run("Close when already closed", func(t *testing.T) {
+		// transport is nil after a previous close — should return nil, not panic.
+		client.transport = nil
+		err := client.Close()
+		assert.NoError(t, err)
+	})
+}
+
+func TestClient_Send_after_close(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := mocks.NewMockLogger(ctrl)
+	mockParser := mocks.NewMockParser(ctrl)
+
+	client := &Client{
+		log:       mockLogger,
+		parser:    mockParser,
+		transport: nil, // simulate closed client
+	}
+
+	err := client.Send([]byte("test"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "client is closed")
 }

--- a/engine.io/v4/client/client_test.go
+++ b/engine.io/v4/client/client_test.go
@@ -172,7 +172,7 @@ func TestClient_messageLoop(t *testing.T) {
 	t.Run("Handle packet", func(t *testing.T) {
 		mockParser.EXPECT().Parse([]byte("test")).Return(&engineio_v4.Message{Type: engineio_v4.PacketMessage}, nil)
 
-		go client.messageLoop(client.messages)
+		go client.messageLoop(ctx, client.messages)
 		client.messages <- []byte("test")
 		time.Sleep(10 * time.Millisecond)
 	})
@@ -181,7 +181,7 @@ func TestClient_messageLoop(t *testing.T) {
 		mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).Times(2)
 		mockParser.EXPECT().Parse([]byte("error")).Return(nil, errors.New("parse error"))
 
-		go client.messageLoop(client.messages)
+		go client.messageLoop(ctx, client.messages)
 		client.messages <- []byte("error")
 		time.Sleep(10 * time.Millisecond)
 	})
@@ -189,14 +189,14 @@ func TestClient_messageLoop(t *testing.T) {
 	t.Run("Context done", func(t *testing.T) {
 		mockLogger.EXPECT().Warnf("context done, engine.io client stopped processing messages").AnyTimes()
 		messages := make(chan []byte, 1)
-		go client.messageLoop(messages)
+		go client.messageLoop(ctx, messages)
 		cancel()
 		time.Sleep(10 * time.Millisecond)
 	})
 
 	t.Run("NIL messages channel", func(t *testing.T) {
 		mockLogger.EXPECT().Errorf("messages channel is nil, can't read transport messages")
-		client.messageLoop(nil)
+		client.messageLoop(ctx, nil)
 	})
 }
 
@@ -366,6 +366,29 @@ func TestClient_handleHandshake(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, mockTransportWs, transportDuringCallback,
 			"afterConnect must be called after transport upgrade")
+	})
+
+	t.Run("Handshake with upgrade failure", func(t *testing.T) {
+		handshakeResp := &engineio_v4.HandshakeResponse{
+			Sid:          "test-sid",
+			PingInterval: 25000,
+			PingTimeout:  5000,
+			Upgrades:     []string{"websocket"},
+		}
+		data, _ := json.Marshal(handshakeResp)
+
+		client.transport = mockTransportPolling
+
+		mockTransportPolling.EXPECT().SetHandshake(handshakeResp)
+		mockTransportWs.EXPECT().SetHandshake(handshakeResp)
+		mockTransportPolling.EXPECT().Stop().Return(errors.New("stop failed"))
+		mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any())
+
+		client.hadHandshake = sync.Once{}
+		client.waitHandshake = make(chan struct{})
+		err := client.handleHandshake(data)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "stop failed")
 	})
 
 	t.Run("Successful handshake with wrong upgrade", func(t *testing.T) {

--- a/socket.io/v5/client/client.go
+++ b/socket.io/v5/client/client.go
@@ -28,7 +28,9 @@ type Client struct {
 type namespace struct {
 	client *Client
 
-	name        string
+	name string
+
+	mu          sync.RWMutex
 	handlers    map[string][]func([]interface{})
 	anyHandlers []func(string, []interface{})
 

--- a/socket.io/v5/client/handlers.go
+++ b/socket.io/v5/client/handlers.go
@@ -11,17 +11,17 @@ func (c *Client) OnAny(handler func(string, []interface{})) {
 }
 
 func (n *namespace) On(event string, handler interface{}) {
-	n.handlers[event] = append(
-		n.handlers[event],
-		n.client.parser.WrapCallback(handler),
-	)
+	wrapped := n.client.parser.WrapCallback(handler)
+
+	n.mu.Lock()
+	n.handlers[event] = append(n.handlers[event], wrapped)
+	n.mu.Unlock()
 }
 
 func (n *namespace) OnAny(handler func(string, []interface{})) {
-	n.anyHandlers = append(
-		n.anyHandlers,
-		handler,
-	)
+	n.mu.Lock()
+	n.anyHandlers = append(n.anyHandlers, handler)
+	n.mu.Unlock()
 }
 
 func (c *Client) onMessage(data []byte) {
@@ -53,7 +53,10 @@ func (c *Client) onMessage(data []byte) {
 func (c *Client) handleConnectError(ns *namespace, payload interface{}) {
 	c.logger.Infof("Connect error, namespace: %s", ns.name)
 
+	ns.mu.RLock()
 	handlers, ok := ns.handlers["error"]
+	ns.mu.RUnlock()
+
 	if !ok {
 		c.logger.Infof("No handlers for event: %s", "error")
 		return
@@ -67,7 +70,10 @@ func (c *Client) handleConnectError(ns *namespace, payload interface{}) {
 func (c *Client) handleDisconnect(ns *namespace, payload interface{}) {
 	c.logger.Infof("Disconnected from namespace: %s", ns.name)
 
+	ns.mu.RLock()
 	handlers, ok := ns.handlers["disconnect"]
+	ns.mu.RUnlock()
+
 	if !ok {
 		c.logger.Infof("No handlers for event: %s", "disconnect")
 		return
@@ -86,7 +92,10 @@ func (c *Client) handleConnect(ns *namespace, payload interface{}) {
 		}
 	})
 
+	ns.mu.RLock()
 	handlers, ok := ns.handlers["connect"]
+	ns.mu.RUnlock()
+
 	if !ok {
 		c.logger.Debugf("No handlers for event: %s", "connect")
 		return
@@ -98,17 +107,18 @@ func (c *Client) handleConnect(ns *namespace, payload interface{}) {
 }
 
 func (c *Client) handleEvent(ns *namespace, event *socketio_v5.Event) {
-
+	ns.mu.RLock()
 	handlers, ok := ns.handlers[event.Name]
-	if !ok && len(ns.anyHandlers) == 0 {
+	anyHandlers := ns.anyHandlers
+	ns.mu.RUnlock()
+
+	if !ok && len(anyHandlers) == 0 {
 		c.logger.Infof("No handlers for event: %s", event.Name)
 		return
 	}
 
-	if len(ns.anyHandlers) > 0 {
-		for _, handler := range ns.anyHandlers {
-			go handler(event.Name, event.Payloads)
-		}
+	for _, handler := range anyHandlers {
+		go handler(event.Name, event.Payloads)
 	}
 
 	for _, handler := range handlers {


### PR DESCRIPTION
Fix race conditions between Send() and transportUpgrade() in the engine.io client, and between handler registration and dispatch in the socket.io client.

Engine.IO:

- Add transportMu (sync.RWMutex) to serialize access to the transport field, waitUpgrade, and waitHandshake channels
- Send() now snapshots wait channels under the read lock and re-acquires it before calling sendPacket, preventing use of a stale or stopped transport
- transportUpgrade() holds the write lock while swapping transport and creating the new waitUpgrade channel
- Close() reads the transport under the lock
- Reorder handleHandshake() to perform the transport upgrade before calling the afterConnect hook, so that any Send() triggered by the callback will observe the new transport and properly wait for the upgrade probe to complete

Socket.IO:

- Add mu (sync.RWMutex) to namespace to protect concurrent access to the handlers and anyHandlers maps
- On() and OnAny() acquire write locks during registration
- All handler dispatch functions (handleEvent, handleConnect, handleDisconnect, handleConnectError) snapshot handlers under read locks before invoking them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved connection stability by resolving concurrency issues in transport upgrades and message handling
  * Enhanced event handler management for reliable behavior during concurrent operations

* **Tests**
  * Expanded test coverage for connection lifecycle and upgrade scenarios, including failure cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->