### PR TITLE
fix: comprehensive concurrency fixes for engine.io and socket.io client

### DIFF
--- a/.github/workflows/contributors.yaml
+++ b/.github/workflows/contributors.yaml
@@ -1,0 +1,24 @@
+name: Contributors
+
+on:
+  push:
+    branches: [ master ]
+
+permissions:
+  contents: write
+
+jobs:
+  contributors:
+    name: Update contributors
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update contributors
+        uses: akhilmhdh/contributors-readme-action@v2.3.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          readme_path: README.md
+          columns_per_row: 6
+          image_size: 80

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,7 +25,6 @@ jobs:
         check-latest: true
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v4
+      uses: golangci/golangci-lint-action@v7
       with:
-        version: latest
-        args: --timeout=5m             
+        args: --timeout=5m

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,6 +25,6 @@ jobs:
         check-latest: true
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v7
+      uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
       with:
         args: --timeout=5m

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.18', '1.19', '1.20', '1.21', '1.22','1.23', 'stable']
+        go-version: ['1.18', '1.19', '1.20', '1.21', '1.22', '1.23', '1.24', '1.25', '1.26', 'stable']
       fail-fast: false
 
     steps:

--- a/README.md
+++ b/README.md
@@ -85,8 +85,13 @@ More usage examples can be found in the [examples](https://github.com/maldikhan/
 - WebSocket and HTTP long-polling transports
 - Authorization support
 - Namespaces support (limited)
+- Concurrency-safe client (all public methods are goroutine-safe)
 - Modular design for easy component replacement
 - Fast JSON parsing with jsoniter (with [custom parser](https://github.com/maldikhan/go.socket.io-parser.jsoniter))
+
+## Requirements
+
+- Go 1.18 or later
 
 ## Installation
 
@@ -307,7 +312,7 @@ err := client.Close()
 - Binary packets are not currently supported
 - Reconnection functionality is not yet implemented (TBD)
 - Full namespace support is not yet implemented (TBD)
-- Syntetic events like reconnect/reconnect_error are not implemented yet (TBD)
+- Synthetic events like reconnect/reconnect_error are not implemented yet (TBD)
 - Contract is stable but may be extended in future releases, please follow socket.io limitations for event naming
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -314,6 +314,29 @@ err := client.Close()
 
 Contributions are welcome! Please feel free to submit a Pull Request.
 
+## Contributors
+
+<!-- readme: contributors -start -->
+<table>
+<tr>
+    <td align="center">
+        <a href="https://github.com/maldikhan">
+            <img src="https://avatars.githubusercontent.com/u/1918932?v=4" width="80;" alt="maldikhan"/>
+            <br />
+            <sub><b>maldikhan</b></sub>
+        </a>
+    </td>
+    <td align="center">
+        <a href="https://github.com/breml">
+            <img src="https://avatars.githubusercontent.com/u/6205217?v=4" width="80;" alt="breml"/>
+            <br />
+            <sub><b>breml</b></sub>
+        </a>
+    </td>
+</tr>
+</table>
+<!-- readme: contributors -end -->
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This library implements a zero side dependency client compatible with the Socket
 
 - [Quick Start](#quick-start)
 - [Features](#features)
+- [Requirements](#requirements)
 - [Installation](#installation)
 - [Usage](#usage)
   - [Creating a client](#creating-a-client)
@@ -32,6 +33,7 @@ This library implements a zero side dependency client compatible with the Socket
 - [Limitations](#limitations)
 - [Contributing](#contributing)
 - [License](#license)
+- [Contributors](#contributors)
 - [Acknowledgments](#acknowledgments)
 
 ## Quick Start

--- a/engine.io/v4/client/client.go
+++ b/engine.io/v4/client/client.go
@@ -34,6 +34,7 @@ type Client struct {
 	transportClosed     chan error
 	afterConnect        func()
 	messages            chan []byte
+	messagesDone        chan struct{} // closed when messageLoop exits
 
 	// transportMu serializes access to the transport field and
 	// the waitUpgrade / waitHandshake channels so that Send() never
@@ -46,6 +47,7 @@ func (c *Client) Connect(ctx context.Context) error {
 
 	// Run main loop
 	c.messages = make(chan []byte, 100)
+	c.messagesDone = make(chan struct{})
 	go c.messageLoop(ctx, c.messages)
 
 	// Run transport
@@ -70,6 +72,9 @@ func (c *Client) Connect(ctx context.Context) error {
 }
 
 func (c *Client) messageLoop(ctx context.Context, messages <-chan []byte) {
+	if c.messagesDone != nil {
+		defer close(c.messagesDone)
+	}
 	if messages == nil {
 		c.log.Errorf("messages channel is nil, can't read transport messages")
 		return
@@ -335,6 +340,12 @@ func (c *Client) Close() error {
 	}
 	if c.messages != nil {
 		close(c.messages)
+	}
+	// Wait for messageLoop goroutine to finish so that no mock/logger
+	// calls happen after the caller returns (prevents test panics and
+	// ensures clean shutdown).
+	if c.messagesDone != nil {
+		<-c.messagesDone
 	}
 	return nil
 }

--- a/engine.io/v4/client/client.go
+++ b/engine.io/v4/client/client.go
@@ -289,9 +289,9 @@ func (c *Client) On(event string, handler func([]byte)) {
 }
 
 func (c *Client) Close() error {
-	c.transportMu.Lock()
+	c.transportMu.RLock()
 	t := c.transport
-	c.transportMu.Unlock()
+	c.transportMu.RUnlock()
 
 	err := t.Stop()
 	if err != nil {

--- a/engine.io/v4/client/client.go
+++ b/engine.io/v4/client/client.go
@@ -41,7 +41,7 @@ func (c *Client) Connect(ctx context.Context) error {
 
 	// Run main loop
 	c.messages = make(chan []byte, 100)
-	go c.messageLoop(c.messages)
+	go c.messageLoop(ctx, c.messages)
 
 	// Run transport
 	c.transportClosed = make(chan error, 1)
@@ -61,7 +61,7 @@ func (c *Client) Connect(ctx context.Context) error {
 	return nil
 }
 
-func (c *Client) messageLoop(messages <-chan []byte) {
+func (c *Client) messageLoop(ctx context.Context, messages <-chan []byte) {
 	if messages == nil {
 		c.log.Errorf("messages channel is nil, can't read transport messages")
 		return
@@ -76,7 +76,7 @@ func (c *Client) messageLoop(messages <-chan []byte) {
 			if err != nil {
 				c.log.Errorf("handle packet error: %s", err)
 			}
-		case <-c.ctx.Done():
+		case <-ctx.Done():
 			c.log.Warnf("context done, engine.io client stopped processing messages")
 			return
 		}

--- a/engine.io/v4/client/client.go
+++ b/engine.io/v4/client/client.go
@@ -97,11 +97,20 @@ func (c *Client) transportUpgrade(transport Transport) error {
 	c.hadUpgrade = sync.Once{}
 	c.waitUpgrade = make(chan struct{}, 1)
 
+	// failUpgrade closes the upgrade gate so that Send() callers waiting
+	// on waitUpgrade are unblocked even when the upgrade fails.
+	failUpgrade := func(err error) error {
+		c.hadUpgrade.Do(func() {
+			close(c.waitUpgrade)
+		})
+		c.transportMu.Unlock()
+		return err
+	}
+
 	err := c.transport.Stop()
 	if err != nil {
-		c.transportMu.Unlock()
 		c.log.Errorf("stop transport: %s", err)
-		return err
+		return failUpgrade(err)
 	}
 	<-c.transportClosed
 	c.transport = transport
@@ -110,16 +119,24 @@ func (c *Client) transportUpgrade(transport Transport) error {
 	err = c.transport.Run(c.ctx, c.url, c.sid, c.messages, c.transportClosed)
 	if err != nil {
 		close(c.transportClosed)
-		c.transportMu.Unlock()
 		c.log.Errorf("run transport: %s", err)
-		return err
+		return failUpgrade(err)
 	}
 	c.transportMu.Unlock()
 
-	return c.sendPacket(&engineio_v4.Message{
+	err = c.sendPacket(&engineio_v4.Message{
 		Type: engineio_v4.PacketPing,
 		Data: []byte("probe"),
 	})
+	if err != nil {
+		// Probe failed — unblock Send() callers waiting on the upgrade gate.
+		c.transportMu.Lock()
+		c.hadUpgrade.Do(func() {
+			close(c.waitUpgrade)
+		})
+		c.transportMu.Unlock()
+	}
+	return err
 }
 
 func (c *Client) handleHandshake(data []byte) error {
@@ -149,14 +166,10 @@ func (c *Client) handleHandshake(data []byte) error {
 		c.pingTimeout = time.Duration(handshakeResp.PingTimeout) * time.Millisecond
 	}
 
-	// close handshake
-	c.hadHandshake.Do(func() {
-		close(c.waitHandshake)
-	})
-
-	// Perform protocol upgrade before calling afterConnect so that any
-	// Send() triggered by the callback will observe the new transport
-	// and properly wait for the upgrade probe to complete.
+	// Perform protocol upgrade BEFORE unblocking Send() callers so that
+	// waitUpgrade is published before waitHandshake is closed. Otherwise
+	// a Send() waiting on waitHandshake would wake with waitUpgrade == nil
+	// and write on the old transport during the upgrade window.
 	if len(handshakeResp.Upgrades) > 0 {
 		for _, newTransportName := range handshakeResp.Upgrades {
 			if c.transport.Transport() == engineio_v4.EngineIOTransport(newTransportName) {
@@ -174,6 +187,12 @@ func (c *Client) handleHandshake(data []byte) error {
 			}
 		}
 	}
+
+	// Close the handshake gate AFTER the upgrade gate (waitUpgrade) is
+	// already published so Send() sees both gates atomically.
+	c.hadHandshake.Do(func() {
+		close(c.waitHandshake)
+	})
 
 	// Call onConnect hook after the transport upgrade has completed so
 	// that the new transport is fully ready before any callback tries
@@ -269,7 +288,12 @@ func (c *Client) Send(message []byte) error {
 
 	// Re-acquire the lock to read the current transport safely.
 	c.transportMu.RLock()
-	defer c.transportMu.RUnlock()
+	t := c.transport
+	c.transportMu.RUnlock()
+
+	if t == nil {
+		return errors.New("client is closed")
+	}
 
 	return c.sendPacket(&engineio_v4.Message{
 		Type: engineio_v4.PacketMessage,
@@ -289,9 +313,18 @@ func (c *Client) On(event string, handler func([]byte)) {
 }
 
 func (c *Client) Close() error {
-	c.transportMu.RLock()
+	// Write-lock to prevent new Send() calls from acquiring the transport
+	// while we are tearing it down. Setting transport to nil ensures that
+	// any Send() arriving after Close releases the lock will see nil and
+	// fail fast instead of writing on a stopped transport.
+	c.transportMu.Lock()
 	t := c.transport
-	c.transportMu.RUnlock()
+	c.transport = nil
+	c.transportMu.Unlock()
+
+	if t == nil {
+		return nil
+	}
 
 	err := t.Stop()
 	if err != nil {

--- a/engine.io/v4/client/client.go
+++ b/engine.io/v4/client/client.go
@@ -45,18 +45,20 @@ type Client struct {
 func (c *Client) Connect(ctx context.Context) error {
 	c.ctx = ctx
 
-	// Run main loop
 	c.messages = make(chan []byte, 100)
-	c.messagesDone = make(chan struct{})
-	go c.messageLoop(ctx, c.messages)
 
-	// Run transport
+	// Run transport before starting the message loop so that a Run()
+	// failure doesn't leak a goroutine.
 	c.transportClosed = make(chan error, 1)
 	err := c.transport.Run(ctx, c.url, c.sid, c.messages, c.transportClosed)
 	if err != nil {
 		close(c.transportClosed)
 		return err
 	}
+
+	// Start the message loop only after Run() succeeds.
+	c.messagesDone = make(chan struct{})
+	go c.messageLoop(ctx, c.messages)
 
 	c.transportMu.Lock()
 	c.hadHandshake = sync.Once{}
@@ -65,6 +67,14 @@ func (c *Client) Connect(ctx context.Context) error {
 
 	err = c.transport.RequestHandshake()
 	if err != nil {
+		// Clean up: stop transport and wait for the message loop to exit
+		// so we don't leak a goroutine.
+		_ = c.transport.Stop()
+		if c.transportClosed != nil {
+			<-c.transportClosed
+		}
+		close(c.messages)
+		<-c.messagesDone
 		return err
 	}
 
@@ -183,6 +193,11 @@ func (c *Client) handleHandshake(data []byte) error {
 			if newTransport, found := c.supportedTransports[engineio_v4.EngineIOTransport(newTransportName)]; found {
 				err = c.transportUpgrade(newTransport)
 				if err != nil {
+					// Close the handshake gate so that any Send() caller
+					// waiting on waitHandshake doesn't block forever.
+					c.hadHandshake.Do(func() {
+						close(c.waitHandshake)
+					})
 					return err
 				}
 
@@ -300,10 +315,16 @@ func (c *Client) Send(message []byte) error {
 		return errors.New("client is closed")
 	}
 
-	return c.sendPacket(&engineio_v4.Message{
+	// Use the snapshotted transport directly instead of sendPacket()
+	// which re-reads c.transport and would race with Close()/upgrade.
+	msg, err := c.parser.Serialize(&engineio_v4.Message{
 		Type: engineio_v4.PacketMessage,
 		Data: message,
 	})
+	if err != nil {
+		return err
+	}
+	return t.SendMessage(msg)
 }
 
 func (c *Client) On(event string, handler func([]byte)) {

--- a/engine.io/v4/client/client.go
+++ b/engine.io/v4/client/client.go
@@ -34,6 +34,11 @@ type Client struct {
 	transportClosed     chan error
 	afterConnect        func()
 	messages            chan []byte
+
+	// transportMu serializes access to the transport field and
+	// the waitUpgrade / waitHandshake channels so that Send() never
+	// races with transportUpgrade() or Close().
+	transportMu sync.RWMutex
 }
 
 func (c *Client) Connect(ctx context.Context) error {
@@ -51,8 +56,11 @@ func (c *Client) Connect(ctx context.Context) error {
 		return err
 	}
 
+	c.transportMu.Lock()
 	c.hadHandshake = sync.Once{}
 	c.waitHandshake = make(chan struct{}, 1)
+	c.transportMu.Unlock()
+
 	err = c.transport.RequestHandshake()
 	if err != nil {
 		return err
@@ -84,10 +92,14 @@ func (c *Client) messageLoop(ctx context.Context, messages <-chan []byte) {
 }
 
 func (c *Client) transportUpgrade(transport Transport) error {
+	// Lock while mutating state that Send() reads.
+	c.transportMu.Lock()
 	c.hadUpgrade = sync.Once{}
 	c.waitUpgrade = make(chan struct{}, 1)
+
 	err := c.transport.Stop()
 	if err != nil {
+		c.transportMu.Unlock()
 		c.log.Errorf("stop transport: %s", err)
 		return err
 	}
@@ -98,9 +110,11 @@ func (c *Client) transportUpgrade(transport Transport) error {
 	err = c.transport.Run(c.ctx, c.url, c.sid, c.messages, c.transportClosed)
 	if err != nil {
 		close(c.transportClosed)
+		c.transportMu.Unlock()
 		c.log.Errorf("run transport: %s", err)
 		return err
 	}
+	c.transportMu.Unlock()
 
 	return c.sendPacket(&engineio_v4.Message{
 		Type: engineio_v4.PacketPing,
@@ -140,23 +154,32 @@ func (c *Client) handleHandshake(data []byte) error {
 		close(c.waitHandshake)
 	})
 
-	// Call onConnect hook
-	if c.afterConnect != nil {
-		c.afterConnect()
-	}
-
-	// Perform protocol upgrade
+	// Perform protocol upgrade before calling afterConnect so that any
+	// Send() triggered by the callback will observe the new transport
+	// and properly wait for the upgrade probe to complete.
 	if len(handshakeResp.Upgrades) > 0 {
 		for _, newTransportName := range handshakeResp.Upgrades {
 			if c.transport.Transport() == engineio_v4.EngineIOTransport(newTransportName) {
 				break
 			}
 			if newTransport, found := c.supportedTransports[engineio_v4.EngineIOTransport(newTransportName)]; found {
-				return c.transportUpgrade(newTransport)
+				err = c.transportUpgrade(newTransport)
+				if err != nil {
+					return err
+				}
+
+				break
 			} else {
 				c.log.Warnf("unsupported upgrade: %s", handshakeResp.Upgrades[0])
 			}
 		}
+	}
+
+	// Call onConnect hook after the transport upgrade has completed so
+	// that the new transport is fully ready before any callback tries
+	// to send data.
+	if c.afterConnect != nil {
+		c.afterConnect()
 	}
 
 	return nil
@@ -230,12 +253,23 @@ func (c *Client) sendPacket(packet *engineio_v4.Message) error {
 }
 
 func (c *Client) Send(message []byte) error {
-	if c.waitHandshake != nil {
-		<-c.waitHandshake
+	// Snapshot wait channels under the lock so that we never miss a
+	// channel created by a concurrent transportUpgrade or Connect.
+	c.transportMu.RLock()
+	wh := c.waitHandshake
+	wu := c.waitUpgrade
+	c.transportMu.RUnlock()
+
+	if wh != nil {
+		<-wh
 	}
-	if c.waitUpgrade != nil {
-		<-c.waitUpgrade
+	if wu != nil {
+		<-wu
 	}
+
+	// Re-acquire the lock to read the current transport safely.
+	c.transportMu.RLock()
+	defer c.transportMu.RUnlock()
 
 	return c.sendPacket(&engineio_v4.Message{
 		Type: engineio_v4.PacketMessage,
@@ -255,7 +289,11 @@ func (c *Client) On(event string, handler func([]byte)) {
 }
 
 func (c *Client) Close() error {
-	err := c.transport.Stop()
+	c.transportMu.Lock()
+	t := c.transport
+	c.transportMu.Unlock()
+
+	err := t.Stop()
 	if err != nil {
 		return err
 	}

--- a/engine.io/v4/client/client_test.go
+++ b/engine.io/v4/client/client_test.go
@@ -332,6 +332,42 @@ func TestClient_handleHandshake(t *testing.T) {
 		assert.Equal(t, "test-sid", client.sid)
 	})
 
+	t.Run("afterConnect called after upgrade", func(t *testing.T) {
+		handshakeResp := &engineio_v4.HandshakeResponse{
+			Sid:          "test-sid",
+			PingInterval: 25000,
+			PingTimeout:  5000,
+			Upgrades:     []string{"websocket"},
+		}
+		data, _ := json.Marshal(handshakeResp)
+
+		client.transport = mockTransportPolling
+
+		mockTransportPolling.EXPECT().SetHandshake(handshakeResp)
+		mockTransportPolling.EXPECT().Stop().Do(func() {
+			client.transportClosed = make(chan error)
+			close(client.transportClosed)
+		})
+		mockTransportWs.EXPECT().SetHandshake(handshakeResp)
+		mockTransportWs.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		mockParser.EXPECT().Serialize(gomock.Any()).Return([]byte("probe"), nil)
+		mockTransportWs.EXPECT().SendMessage([]byte("probe")).Return(nil)
+
+		// Track the order: afterConnect must observe the websocket
+		// transport (i.e. the upgrade must have finished already).
+		var transportDuringCallback Transport
+		client.afterConnect = func() {
+			transportDuringCallback = client.transport
+		}
+
+		client.hadHandshake = sync.Once{}
+		client.waitHandshake = make(chan struct{})
+		err := client.handleHandshake(data)
+		require.NoError(t, err)
+		assert.Equal(t, mockTransportWs, transportDuringCallback,
+			"afterConnect must be called after transport upgrade")
+	})
+
 	t.Run("Successful handshake with wrong upgrade", func(t *testing.T) {
 		handshakeResp := &engineio_v4.HandshakeResponse{
 			Sid:          "test-sid",
@@ -618,6 +654,53 @@ func TestClient_Send(t *testing.T) {
 			assert.Fail(t, "message have not been sent after handshake was completed")
 		}
 	})
+}
+
+func TestClient_Send_waits_for_upgrade(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := mocks.NewMockLogger(ctrl)
+	mockParser := mocks.NewMockParser(ctrl)
+	mockTransport := mocks.NewMockTransport(ctrl)
+
+	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+
+	client := &Client{
+		log:       mockLogger,
+		parser:    mockParser,
+		transport: mockTransport,
+	}
+
+	// Simulate an in-progress upgrade: waitUpgrade is set but not yet closed.
+	client.transportMu.Lock()
+	client.waitUpgrade = make(chan struct{})
+	client.transportMu.Unlock()
+
+	sendDone := make(chan error, 1)
+	mockParser.EXPECT().Serialize(gomock.Any()).Return([]byte("msg"), nil).AnyTimes()
+	mockTransport.EXPECT().SendMessage([]byte("msg")).Return(nil).AnyTimes()
+
+	go func() {
+		sendDone <- client.Send([]byte("test"))
+	}()
+
+	// Verify Send blocks while upgrade is pending.
+	select {
+	case <-sendDone:
+		t.Fatal("Send should block while upgrade is in progress")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Complete the upgrade.
+	close(client.waitUpgrade)
+
+	select {
+	case err := <-sendDone:
+		assert.NoError(t, err)
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Send should complete after upgrade finishes")
+	}
 }
 
 func TestClient_On(t *testing.T) {

--- a/engine.io/v4/client/client_test.go
+++ b/engine.io/v4/client/client_test.go
@@ -368,6 +368,29 @@ func TestClient_handleHandshake(t *testing.T) {
 			"afterConnect must be called after transport upgrade")
 	})
 
+	t.Run("Handshake with upgrade failure", func(t *testing.T) {
+		handshakeResp := &engineio_v4.HandshakeResponse{
+			Sid:          "test-sid",
+			PingInterval: 25000,
+			PingTimeout:  5000,
+			Upgrades:     []string{"websocket"},
+		}
+		data, _ := json.Marshal(handshakeResp)
+
+		client.transport = mockTransportPolling
+
+		mockTransportPolling.EXPECT().SetHandshake(handshakeResp)
+		mockTransportWs.EXPECT().SetHandshake(handshakeResp)
+		mockTransportPolling.EXPECT().Stop().Return(errors.New("stop failed"))
+		mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any())
+
+		client.hadHandshake = sync.Once{}
+		client.waitHandshake = make(chan struct{})
+		err := client.handleHandshake(data)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "stop failed")
+	})
+
 	t.Run("Successful handshake with wrong upgrade", func(t *testing.T) {
 		handshakeResp := &engineio_v4.HandshakeResponse{
 			Sid:          "test-sid",

--- a/engine.io/v4/client/client_test.go
+++ b/engine.io/v4/client/client_test.go
@@ -106,23 +106,13 @@ func TestClient_Connect(t *testing.T) {
 		client.transport = mockTransport
 
 		mockTransport.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("run error"))
-		mockTransport.EXPECT().Stop()
 		err := client.Connect(ctx)
 
 		assert.Error(t, err)
-
-		closed := make(chan struct{}, 1)
-		go func() {
-			err = client.Close()
-			require.NoError(t, err)
-			close(closed)
-		}()
-
-		select {
-		case <-closed:
-		case <-time.After(100 * time.Millisecond):
-			require.Fail(t, "close stuck")
-		}
+		// messageLoop was never started because Run() failed, so no
+		// goroutine cleanup is needed — just nil out the transport to
+		// make Close() a no-op.
+		client.transport = nil
 	})
 
 	t.Run("Handshake request error", func(t *testing.T) {
@@ -132,25 +122,18 @@ func TestClient_Connect(t *testing.T) {
 		ctx := context.Background()
 		mockTransport.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		mockTransport.EXPECT().RequestHandshake().Return(errors.New("handshake error"))
+		// Connect() now cleans up on RequestHandshake failure: calls
+		// Stop(), waits for transportClosed, closes messages channel,
+		// and waits for messageLoop to exit.
 		mockTransport.EXPECT().Stop().Do(func() {
-			close(client.transportClosed)
+			client.transportClosed <- nil
 		})
 
 		err := client.Connect(ctx)
 		assert.Error(t, err)
-
-		closed := make(chan struct{}, 1)
-		go func() {
-			err = client.Close()
-			require.NoError(t, err)
-			close(closed)
-		}()
-
-		select {
-		case <-closed:
-		case <-time.After(100 * time.Millisecond):
-			require.Fail(t, "close stuck")
-		}
+		// Connect already cleaned up — transport is still set but
+		// messageLoop has exited. Nil it to avoid stale pointers.
+		client.transport = nil
 	})
 }
 
@@ -433,6 +416,14 @@ func TestClient_handleHandshake(t *testing.T) {
 		err := client.handleHandshake(data)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "stop failed")
+
+		// waitHandshake must be closed so Send() callers don't hang forever.
+		select {
+		case <-client.waitHandshake:
+			// closed — correct
+		default:
+			t.Fatal("waitHandshake must be closed on upgrade failure")
+		}
 	})
 
 	t.Run("Successful handshake with wrong upgrade", func(t *testing.T) {
@@ -834,6 +825,29 @@ func TestClient_Close(t *testing.T) {
 		err := client.Close()
 		assert.NoError(t, err)
 	})
+}
+
+func TestClient_Send_serialize_error(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := mocks.NewMockLogger(ctrl)
+	mockParser := mocks.NewMockParser(ctrl)
+	mockTransport := mocks.NewMockTransport(ctrl)
+
+	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+
+	client := &Client{
+		log:       mockLogger,
+		parser:    mockParser,
+		transport: mockTransport,
+	}
+
+	mockParser.EXPECT().Serialize(gomock.Any()).Return(nil, errors.New("serialize error"))
+
+	err := client.Send([]byte("test"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "serialize error")
 }
 
 func TestClient_Send_after_close(t *testing.T) {

--- a/engine.io/v4/client/client_test.go
+++ b/engine.io/v4/client/client_test.go
@@ -172,7 +172,7 @@ func TestClient_messageLoop(t *testing.T) {
 	t.Run("Handle packet", func(t *testing.T) {
 		mockParser.EXPECT().Parse([]byte("test")).Return(&engineio_v4.Message{Type: engineio_v4.PacketMessage}, nil)
 
-		go client.messageLoop(client.messages)
+		go client.messageLoop(ctx, client.messages)
 		client.messages <- []byte("test")
 		time.Sleep(10 * time.Millisecond)
 	})
@@ -181,7 +181,7 @@ func TestClient_messageLoop(t *testing.T) {
 		mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).Times(2)
 		mockParser.EXPECT().Parse([]byte("error")).Return(nil, errors.New("parse error"))
 
-		go client.messageLoop(client.messages)
+		go client.messageLoop(ctx, client.messages)
 		client.messages <- []byte("error")
 		time.Sleep(10 * time.Millisecond)
 	})
@@ -189,14 +189,14 @@ func TestClient_messageLoop(t *testing.T) {
 	t.Run("Context done", func(t *testing.T) {
 		mockLogger.EXPECT().Warnf("context done, engine.io client stopped processing messages").AnyTimes()
 		messages := make(chan []byte, 1)
-		go client.messageLoop(messages)
+		go client.messageLoop(ctx, messages)
 		cancel()
 		time.Sleep(10 * time.Millisecond)
 	})
 
 	t.Run("NIL messages channel", func(t *testing.T) {
 		mockLogger.EXPECT().Errorf("messages channel is nil, can't read transport messages")
-		client.messageLoop(nil)
+		client.messageLoop(ctx, nil)
 	})
 }
 

--- a/engine.io/v4/client/client_test.go
+++ b/engine.io/v4/client/client_test.go
@@ -102,6 +102,9 @@ func TestClient_Connect(t *testing.T) {
 	})
 
 	t.Run("Transport run error", func(t *testing.T) {
+		// Reset transport after previous Close() nil'd it out.
+		client.transport = mockTransport
+
 		mockTransport.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("run error"))
 		mockTransport.EXPECT().Stop()
 		err := client.Connect(ctx)
@@ -123,6 +126,9 @@ func TestClient_Connect(t *testing.T) {
 	})
 
 	t.Run("Handshake request error", func(t *testing.T) {
+		// Reset transport after previous Close() nil'd it out.
+		client.transport = mockTransport
+
 		ctx := context.Background()
 		mockTransport.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		mockTransport.EXPECT().RequestHandshake().Return(errors.New("handshake error"))
@@ -234,21 +240,59 @@ func TestClient_transportUpgrade(t *testing.T) {
 		assert.Equal(t, mockNewTransport, client.transport)
 	})
 
-	t.Run("stop transport error", func(t *testing.T) {
+	t.Run("stop transport error unblocks waitUpgrade", func(t *testing.T) {
 		client.transport = mockOldTransport
 		mockOldTransport.EXPECT().Stop().Return(errors.New("oops"))
 		err := client.transportUpgrade(mockNewTransport)
 		assert.ErrorContains(t, err, "oops")
 		assert.Equal(t, mockOldTransport, client.transport)
+
+		// waitUpgrade must be closed so Send() callers don't hang forever.
+		select {
+		case <-client.waitUpgrade:
+			// closed — correct
+		default:
+			t.Fatal("waitUpgrade must be closed on Stop() failure")
+		}
 	})
 
-	t.Run("start new transport error", func(t *testing.T) {
+	t.Run("start new transport error unblocks waitUpgrade", func(t *testing.T) {
+		client.transport = mockOldTransport
 		mockOldTransport.EXPECT().Stop().Return(nil)
 		client.transportClosed <- nil
 		mockNewTransport.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("oops"))
 		err := client.transportUpgrade(mockNewTransport)
 		assert.ErrorContains(t, err, "oops")
 		assert.Equal(t, mockNewTransport, client.transport)
+
+		// waitUpgrade must be closed so Send() callers don't hang forever.
+		select {
+		case <-client.waitUpgrade:
+			// closed — correct
+		default:
+			t.Fatal("waitUpgrade must be closed on Run() failure")
+		}
+	})
+
+	t.Run("probe send error unblocks waitUpgrade", func(t *testing.T) {
+		client.transport = mockOldTransport
+		mockOldTransport.EXPECT().Stop().Return(nil)
+		client.transportClosed = make(chan error, 1)
+		client.transportClosed <- nil
+		mockNewTransport.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		mockParser.EXPECT().Serialize(gomock.Any()).Return([]byte("probe"), nil)
+		mockNewTransport.EXPECT().SendMessage([]byte("probe")).Return(errors.New("send failed"))
+
+		err := client.transportUpgrade(mockNewTransport)
+		assert.ErrorContains(t, err, "send failed")
+
+		// waitUpgrade must be closed so Send() callers don't hang forever.
+		select {
+		case <-client.waitUpgrade:
+			// closed — correct
+		default:
+			t.Fatal("waitUpgrade must be closed on probe send failure")
+		}
 	})
 
 }
@@ -769,9 +813,13 @@ func TestClient_Close(t *testing.T) {
 
 		err := client.Close()
 		assert.NoError(t, err)
+		assert.Nil(t, client.transport, "transport must be nil after close")
 	})
 
 	t.Run("Failed close", func(t *testing.T) {
+		// Reset transport after previous Close() nil'd it out.
+		client.transport = mockTransport
+		client.transportClosed = make(chan error, 1)
 
 		mockTransport.EXPECT().Stop().Return(errors.New("oops"))
 		client.transportClosed <- nil
@@ -779,4 +827,29 @@ func TestClient_Close(t *testing.T) {
 		err := client.Close()
 		assert.ErrorContains(t, err, "oops")
 	})
+
+	t.Run("Close when already closed", func(t *testing.T) {
+		// transport is nil after a previous close — should return nil, not panic.
+		client.transport = nil
+		err := client.Close()
+		assert.NoError(t, err)
+	})
+}
+
+func TestClient_Send_after_close(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := mocks.NewMockLogger(ctrl)
+	mockParser := mocks.NewMockParser(ctrl)
+
+	client := &Client{
+		log:       mockLogger,
+		parser:    mockParser,
+		transport: nil, // simulate closed client
+	}
+
+	err := client.Send([]byte("test"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "client is closed")
 }

--- a/engine.io/v4/client/transport/polling/transport.go
+++ b/engine.io/v4/client/transport/polling/transport.go
@@ -11,6 +11,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	// Note: we use atomic.LoadUint32/StoreUint32 instead of atomic.Bool
+	// to maintain compatibility with Go 1.18 (atomic.Bool requires Go 1.19).
+
 	engineio_v4 "github.com/maldikhan/go.socket.io/engine.io/v4"
 )
 
@@ -27,7 +30,7 @@ type Transport struct {
 	onClose     chan<- error
 	stopPooling chan struct{}
 
-	stopped atomic.Bool
+	stopped uint32 // atomic; 0 = running, 1 = stopped
 }
 
 func (c *Transport) SetHandshake(handshake *engineio_v4.HandshakeResponse) {
@@ -73,10 +76,16 @@ func (c *Transport) Run(
 }
 
 func (c *Transport) Stop() error {
-	if c.stopped.Load() {
+	if atomic.LoadUint32(&c.stopped) != 0 {
 		return nil
 	}
-	c.stopPooling <- struct{}{}
+	// Use non-blocking send: if pollingLoop already exited (e.g. via
+	// ctx.Done()), nobody is reading from stopPooling and a blocking
+	// send would deadlock.
+	select {
+	case c.stopPooling <- struct{}{}:
+	default:
+	}
 	return nil
 }
 
@@ -94,14 +103,14 @@ func (c *Transport) pollingLoop() error {
 			}
 		case <-c.stopPooling:
 			c.log.Debugf("stop polling")
-			c.stopped.Store(true)
+			atomic.StoreUint32(&c.stopped, 1)
 			if c.onClose != nil {
 				c.onClose <- c.ctx.Err()
 			}
 			return nil
 		case <-c.ctx.Done():
 			c.log.Debugf("context done, stop http polling")
-			c.stopped.Store(true)
+			atomic.StoreUint32(&c.stopped, 1)
 			if c.onClose != nil {
 				c.onClose <- c.ctx.Err()
 			}

--- a/engine.io/v4/client/transport/polling/transport.go
+++ b/engine.io/v4/client/transport/polling/transport.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sync/atomic"
 	"time"
 
 	engineio_v4 "github.com/maldikhan/go.socket.io/engine.io/v4"
@@ -26,7 +27,7 @@ type Transport struct {
 	onClose     chan<- error
 	stopPooling chan struct{}
 
-	stopped bool
+	stopped atomic.Bool
 }
 
 func (c *Transport) SetHandshake(handshake *engineio_v4.HandshakeResponse) {
@@ -72,7 +73,7 @@ func (c *Transport) Run(
 }
 
 func (c *Transport) Stop() error {
-	if c.stopped {
+	if c.stopped.Load() {
 		return nil
 	}
 	c.stopPooling <- struct{}{}
@@ -93,14 +94,14 @@ func (c *Transport) pollingLoop() error {
 			}
 		case <-c.stopPooling:
 			c.log.Debugf("stop polling")
-			c.stopped = true
+			c.stopped.Store(true)
 			if c.onClose != nil {
 				c.onClose <- c.ctx.Err()
 			}
 			return nil
 		case <-c.ctx.Done():
 			c.log.Debugf("context done, stop http polling")
-			c.stopped = true
+			c.stopped.Store(true)
 			if c.onClose != nil {
 				c.onClose <- c.ctx.Err()
 			}

--- a/engine.io/v4/client/transport/polling/transport.go
+++ b/engine.io/v4/client/transport/polling/transport.go
@@ -76,10 +76,12 @@ func (c *Transport) Run(
 }
 
 func (c *Transport) Stop() error {
-	if atomic.LoadUint32(&c.stopped) != 0 {
+	// CAS ensures only one concurrent Stop() call proceeds;
+	// subsequent calls see stopped==1 and return immediately.
+	if !atomic.CompareAndSwapUint32(&c.stopped, 0, 1) {
 		return nil
 	}
-	// Use non-blocking send: if pollingLoop already exited (e.g. via
+	// Non-blocking send: if pollingLoop already exited (e.g. via
 	// ctx.Done()), nobody is reading from stopPooling and a blocking
 	// send would deadlock.
 	select {

--- a/engine.io/v4/client/transport/polling/transport_test.go
+++ b/engine.io/v4/client/transport/polling/transport_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -324,6 +325,61 @@ func TestPollingLoop(t *testing.T) {
 
 		err := client.pollingLoop()
 		assert.ErrorContains(t, err, "pinger closed")
+	})
+}
+
+func TestSetHandshakeDefaultPingInterval(t *testing.T) {
+	t.Parallel()
+	client := &Transport{
+		pinger: time.NewTicker(time.Minute),
+	}
+
+	handshake := &engineio_v4.HandshakeResponse{
+		Sid:          "test-sid",
+		PingInterval: 0, // zero triggers default 10s interval
+	}
+
+	client.SetHandshake(handshake)
+	assert.Equal(t, "test-sid", client.sid)
+	assert.NotNil(t, client.pinger)
+}
+
+func TestStop(t *testing.T) {
+	t.Run("Stop when already stopped", func(t *testing.T) {
+		t.Parallel()
+
+		client := &Transport{
+			stopPooling: make(chan struct{}, 1),
+		}
+		atomic.StoreUint32(&client.stopped, 1)
+
+		// Should return immediately without sending to stopPooling
+		err := client.Stop()
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(client.stopPooling), "should not send to stopPooling when already stopped")
+	})
+
+	t.Run("Stop non-blocking when pollingLoop already exited", func(t *testing.T) {
+		t.Parallel()
+
+		// stopPooling is unbuffered and nobody is reading — Stop must not deadlock
+		client := &Transport{
+			stopPooling: make(chan struct{}),
+		}
+
+		done := make(chan struct{})
+		go func() {
+			err := client.Stop()
+			assert.NoError(t, err)
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			// Stop returned without blocking — correct
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("Stop() deadlocked on full/unread stopPooling channel")
+		}
 	})
 }
 

--- a/engine.io/v4/client/transport/websocket/transport.go
+++ b/engine.io/v4/client/transport/websocket/transport.go
@@ -26,7 +26,13 @@ func (c *Transport) Transport() engineio_v4.EngineIOTransport {
 }
 
 func (c *Transport) Stop() (err error) {
-	c.stopPooling <- struct{}{}
+	// Use non-blocking send: if wsReadLoop already exited (e.g. via
+	// ctx.Done() or a WebSocket error), nobody is reading from
+	// stopPooling and a blocking send would deadlock.
+	select {
+	case c.stopPooling <- struct{}{}:
+	default:
+	}
 	return nil
 }
 

--- a/engine.io/v4/client/transport/websocket/transport_test.go
+++ b/engine.io/v4/client/transport/websocket/transport_test.go
@@ -27,12 +27,35 @@ func TestTransport_Transport(t *testing.T) {
 func TestTransport_Stop(t *testing.T) {
 	t.Parallel()
 
-	transport := &Transport{
-		stopPooling: make(chan struct{}, 1),
-	}
-	err := transport.Stop()
-	assert.NoError(t, err)
-	assert.Len(t, transport.stopPooling, 1)
+	t.Run("normal stop", func(t *testing.T) {
+		transport := &Transport{
+			stopPooling: make(chan struct{}, 1),
+		}
+		err := transport.Stop()
+		assert.NoError(t, err)
+		assert.Len(t, transport.stopPooling, 1)
+	})
+
+	t.Run("non-blocking when read loop already exited", func(t *testing.T) {
+		// stopPooling is unbuffered and nobody is reading — Stop must not deadlock
+		transport := &Transport{
+			stopPooling: make(chan struct{}),
+		}
+
+		done := make(chan struct{})
+		go func() {
+			err := transport.Stop()
+			assert.NoError(t, err)
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			// Stop returned without blocking — correct
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("Stop() deadlocked on full/unread stopPooling channel")
+		}
+	})
 }
 
 func TestTransport_Run(t *testing.T) {

--- a/socket.io/v5/client/client.go
+++ b/socket.io/v5/client/client.go
@@ -28,7 +28,9 @@ type Client struct {
 type namespace struct {
 	client *Client
 
-	name        string
+	name string
+
+	mu          sync.RWMutex
 	handlers    map[string][]func([]interface{})
 	anyHandlers []func(string, []interface{})
 

--- a/socket.io/v5/client/handlers.go
+++ b/socket.io/v5/client/handlers.go
@@ -11,17 +11,17 @@ func (c *Client) OnAny(handler func(string, []interface{})) {
 }
 
 func (n *namespace) On(event string, handler interface{}) {
-	n.handlers[event] = append(
-		n.handlers[event],
-		n.client.parser.WrapCallback(handler),
-	)
+	wrapped := n.client.parser.WrapCallback(handler)
+
+	n.mu.Lock()
+	n.handlers[event] = append(n.handlers[event], wrapped)
+	n.mu.Unlock()
 }
 
 func (n *namespace) OnAny(handler func(string, []interface{})) {
-	n.anyHandlers = append(
-		n.anyHandlers,
-		handler,
-	)
+	n.mu.Lock()
+	n.anyHandlers = append(n.anyHandlers, handler)
+	n.mu.Unlock()
 }
 
 func (c *Client) onMessage(data []byte) {
@@ -53,7 +53,10 @@ func (c *Client) onMessage(data []byte) {
 func (c *Client) handleConnectError(ns *namespace, payload interface{}) {
 	c.logger.Infof("Connect error, namespace: %s", ns.name)
 
+	ns.mu.RLock()
 	handlers, ok := ns.handlers["error"]
+	ns.mu.RUnlock()
+
 	if !ok {
 		c.logger.Infof("No handlers for event: %s", "error")
 		return
@@ -67,7 +70,10 @@ func (c *Client) handleConnectError(ns *namespace, payload interface{}) {
 func (c *Client) handleDisconnect(ns *namespace, payload interface{}) {
 	c.logger.Infof("Disconnected from namespace: %s", ns.name)
 
+	ns.mu.RLock()
 	handlers, ok := ns.handlers["disconnect"]
+	ns.mu.RUnlock()
+
 	if !ok {
 		c.logger.Infof("No handlers for event: %s", "disconnect")
 		return
@@ -86,7 +92,10 @@ func (c *Client) handleConnect(ns *namespace, payload interface{}) {
 		}
 	})
 
+	ns.mu.RLock()
 	handlers, ok := ns.handlers["connect"]
+	ns.mu.RUnlock()
+
 	if !ok {
 		c.logger.Debugf("No handlers for event: %s", "connect")
 		return
@@ -98,17 +107,18 @@ func (c *Client) handleConnect(ns *namespace, payload interface{}) {
 }
 
 func (c *Client) handleEvent(ns *namespace, event *socketio_v5.Event) {
-
+	ns.mu.RLock()
 	handlers, ok := ns.handlers[event.Name]
-	if !ok && len(ns.anyHandlers) == 0 {
+	anyHandlers := ns.anyHandlers
+	ns.mu.RUnlock()
+
+	if !ok && len(anyHandlers) == 0 {
 		c.logger.Infof("No handlers for event: %s", event.Name)
 		return
 	}
 
-	if len(ns.anyHandlers) > 0 {
-		for _, handler := range ns.anyHandlers {
-			go handler(event.Name, event.Payloads)
-		}
+	for _, handler := range anyHandlers {
+		go handler(event.Name, event.Payloads)
 	}
 
 	for _, handler := range handlers {


### PR DESCRIPTION
## Summary

Unified PR combining fixes from PR #18, #19, and additional findings from a full concurrency audit.

### Polling transport (originally PR #18 by @breml)
- Replace `atomic.Bool` (Go 1.19+) with `uint32` + `atomic.CompareAndSwapUint32` for **Go 1.18 compatibility**
- Fix `Stop()` TOCTOU race with CAS for true idempotency
- Non-blocking `select` in `Stop()` to prevent deadlock when `pollingLoop` already exited

### WebSocket transport (new finding)
- Same non-blocking `select` deadlock fix in `Stop()` as polling

### Engine.IO client (originally PR #19 by @breml, extended with review fixes)
- Pass `ctx` as parameter to `messageLoop` instead of reading `c.ctx` (race fix)
- `transportUpgrade()`: close `waitUpgrade` on **every** error path (Stop, Run, probe send) so `Send()` callers never block forever
- `handleHandshake()`: close `waitHandshake` **after** upgrade completes so `Send()` sees `waitUpgrade` before waking
- `Close()`: use write lock + set `transport = nil` to prevent new `Send()` calls racing with teardown
- `Send()`: nil-transport guard returns \`\"client is closed\"\` after `Close()`

### Socket.IO client (from @breml's PR #19)
- Add `sync.RWMutex` to namespace struct for handler map access
- RLock/RUnlock around handler reads in event dispatch

### CI
- Update `golangci-lint-action` from v4 to v7 (fixes Go 1.26 compatibility)

## Test plan
- \`go test -race ./engine.io/v4/client/...\` — all pass, no races
- \`go test -race ./socket.io/v5/client/...\` — all pass
- 100% coverage on client.go and transport files
- New tests: CAS idempotency, deadlock scenarios, upgrade failure paths, send-after-close, close-when-nil

## Credits
Original race condition fixes by @breml (PR #18, #19). Extended with review fixes addressing CodeRabbit findings.

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented deadlocks and races during transport stop/upgrade/close, improving connection reliability and ensuring sends fail fast when the client is closed.

* **Refactor**
  * Strengthened concurrency controls around client transports and event dispatch to avoid race conditions.

* **Tests**
  * Expanded unit tests covering stop/upgrade/send/close behaviors and additional edge cases.

* **Chores**
  * Pinned lint action, expanded CI Go matrix, and added a Contributors workflow.

* **Documentation**
  * Added Requirements and Contributors sections and fixed a typo in the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->