### PR TITLE
Fix nil namespace panic and race condition in onMessage

### DIFF
--- a/socket.io/v5/client/handlers.go
+++ b/socket.io/v5/client/handlers.go
@@ -33,6 +33,12 @@ func (c *Client) onMessage(data []byte) {
 		return
 	}
 
+	// Handle ACK packets first — they don't depend on namespace
+	if msg.Type == socketio_v5.PacketAck {
+		c.handleAck(msg.Event, *msg.AckId)
+		return
+	}
+
 	// Safely read namespace under RLock to prevent race condition
 	c.mutex.RLock()
 	ns := c.namespaces[msg.NS]
@@ -57,8 +63,6 @@ func (c *Client) onMessage(data []byte) {
 		c.handleConnect(ns, msg.Payload)
 	case socketio_v5.PacketEvent:
 		c.handleEvent(ns, msg.Event)
-	case socketio_v5.PacketAck:
-		c.handleAck(msg.Event, *msg.AckId)
 	case socketio_v5.PacketConnectError:
 		c.handleConnectError(ns, msg.Payload)
 		c.logger.Errorf("Connect error: %v", *msg.ErrorMessage)

--- a/socket.io/v5/client/handlers.go
+++ b/socket.io/v5/client/handlers.go
@@ -33,7 +33,22 @@ func (c *Client) onMessage(data []byte) {
 		return
 	}
 
+	// Safely read namespace under RLock to prevent race condition
+	c.mutex.RLock()
 	ns := c.namespaces[msg.NS]
+	c.mutex.RUnlock()
+
+	// Handle nil namespace case
+	if ns == nil {
+		// For PacketConnect, auto-create the namespace
+		if msg.Type == socketio_v5.PacketConnect {
+			ns = c.namespace(msg.NS)
+		} else {
+			// For other packet types, log warning and return
+			c.logger.Warnf("Received %v for unknown namespace: %s", msg.Type, msg.NS)
+			return
+		}
+	}
 
 	switch msg.Type {
 	case socketio_v5.PacketDisconnect:

--- a/socket.io/v5/client/handlers_test.go
+++ b/socket.io/v5/client/handlers_test.go
@@ -189,6 +189,41 @@ func TestClientOnMessage(t *testing.T) {
 
 		client.onMessage([]byte("valid data"))
 	})
+
+	t.Run("Unknown namespace event should not crash", func(t *testing.T) {
+		// Clear namespaces to simulate unknown namespace
+		client.namespaces = make(map[string]*namespace)
+
+		msg := &socketio_v5.Message{
+			NS:    "unknown",
+			Type:  socketio_v5.PacketEvent,
+			Event: &socketio_v5.Event{Name: "test_event"},
+		}
+
+		mockParser.EXPECT().Parse(gomock.Any()).Return(msg, nil)
+		mockLogger.EXPECT().Warnf(gomock.Any(), gomock.Any())
+
+		// Should not panic and should log warning
+		client.onMessage([]byte("valid data"))
+	})
+
+	t.Run("PacketConnect for unknown namespace should auto-create", func(t *testing.T) {
+		// Clear namespaces to simulate unknown namespace
+		client.namespaces = make(map[string]*namespace)
+
+		msg := &socketio_v5.Message{
+			NS:   "custom",
+			Type: socketio_v5.PacketConnect,
+		}
+
+		mockParser.EXPECT().Parse(gomock.Any()).Return(msg, nil)
+
+		// Should not panic and should create namespace
+		client.onMessage([]byte("valid data"))
+
+		// Verify namespace was created
+		assert.NotNil(t, client.namespaces["custom"])
+	})
 }
 
 func TestClientHandleEvent(t *testing.T) {

--- a/socket.io/v5/client/handlers_test.go
+++ b/socket.io/v5/client/handlers_test.go
@@ -201,7 +201,7 @@ func TestClientOnMessage(t *testing.T) {
 		}
 
 		mockParser.EXPECT().Parse(gomock.Any()).Return(msg, nil)
-		mockLogger.EXPECT().Warnf(gomock.Any(), gomock.Any())
+		mockLogger.EXPECT().Warnf(gomock.Any(), gomock.Any(), gomock.Any())
 
 		// Should not panic and should log warning
 		client.onMessage([]byte("valid data"))


### PR DESCRIPTION
## Problem

The `onMessage()` function in `socket.io/v5/client/handlers.go` has two critical issues:

### 1. Race Condition on Namespace Map
Line 36 reads from `c.namespaces[msg.NS]` **without holding a lock**, while the `namespace()` method in `client.go` writes to the same map **under `c.mutex.Lock()`**. This creates a concurrent map read/write race condition that causes the Go runtime to panic.

### 2. Nil Namespace Panic
When `msg.NS` is not registered, the map lookup returns `nil`. Subsequent calls to `handleConnect()`, `handleDisconnect()`, etc. then try to access `ns.name` or `ns.mu` on a nil pointer, causing a panic.

## Solution

The fix implements three key changes to `onMessage()`:

1. **Acquire Read Lock Before Accessing Map**
   - Add `c.mutex.RLock()` before reading `c.namespaces[msg.NS]`
   - Release with `c.mutex.RUnlock()` immediately after
   - This prevents the race condition with the map writes

2. **Handle Nil Namespace for PacketConnect**
   - If `ns == nil` and type is `PacketConnect`, call `c.namespace(msg.NS)` to auto-create
   - This is safe because `c.namespace()` acquires its own `Lock()` internally
   - The `RUnlock()` is released before calling `c.namespace()` to avoid deadlock (RLock + Lock = deadlock)

3. **Log Warning and Return for Other Packet Types**
   - If `ns == nil` for any other packet type, log a warning and return
   - This prevents nil pointer dereference and allows graceful degradation

## Testing

Added comprehensive test cases:
- **Unknown namespace event**: Verifies that receiving an event for an unknown namespace logs a warning and does not crash
- **PacketConnect for unknown namespace**: Verifies that a connect packet for an unknown namespace automatically creates the namespace

All existing tests continue to pass, and the fix verified with the race detector:
```bash
go test ./socket.io/v5/client/... -race -count=1 -v
```

## Impact

- **Fixes**: Critical race condition and nil pointer panics
- **Safety**: All concurrent access to `c.namespaces` now properly synchronized
- **Behavior**: PacketConnect messages now auto-create missing namespaces, other messages to unknown namespaces are logged and ignored
- **Breaking Changes**: None - this is a bug fix that prevents crashes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a race in message handling that could cause dropped or misrouted messages when namespaces changed; unknown namespaces are now handled safely and logged.

* **Tests**
  * Added tests covering messages targeting unknown namespaces and auto-creation of namespaces on connect to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->