### PR TITLE
Fix nil AckId dereference panic

### DIFF
--- a/socket.io/v5/client/handlers.go
+++ b/socket.io/v5/client/handlers.go
@@ -49,6 +49,10 @@ func (c *Client) onMessage(data []byte) {
 		}
 		if msg.Event == nil {
 			c.logger.Errorf("received ACK packet without event data, dropping")
+			// Clean up the callback to prevent memory leak
+			c.mutex.Lock()
+			delete(c.ackCallbacks, *msg.AckId)
+			c.mutex.Unlock()
 			return
 		}
 		c.handleAck(msg.Event, *msg.AckId)

--- a/socket.io/v5/client/handlers.go
+++ b/socket.io/v5/client/handlers.go
@@ -43,6 +43,14 @@ func (c *Client) onMessage(data []byte) {
 	case socketio_v5.PacketEvent:
 		c.handleEvent(ns, msg.Event)
 	case socketio_v5.PacketAck:
+		if msg.AckId == nil {
+			c.logger.Errorf("received ACK packet without ack ID, dropping")
+			return
+		}
+		if msg.Event == nil {
+			c.logger.Errorf("received ACK packet without event data, dropping")
+			return
+		}
 		c.handleAck(msg.Event, *msg.AckId)
 	case socketio_v5.PacketConnectError:
 		c.handleConnectError(ns, msg.Payload)

--- a/socket.io/v5/client/handlers_test.go
+++ b/socket.io/v5/client/handlers_test.go
@@ -149,6 +149,32 @@ func TestClientOnMessage(t *testing.T) {
 		client.onMessage([]byte("valid data"))
 	})
 
+	t.Run("PacketAck with nil AckId", func(t *testing.T) {
+		msg := &socketio_v5.Message{
+			Type:  socketio_v5.PacketAck,
+			Event: &socketio_v5.Event{},
+			AckId: nil,
+		}
+
+		mockParser.EXPECT().Parse(gomock.Any()).Return(msg, nil)
+		mockLogger.EXPECT().Errorf("received ACK packet without ack ID, dropping").Times(1)
+
+		client.onMessage([]byte("valid data"))
+	})
+
+	t.Run("PacketAck with nil Event", func(t *testing.T) {
+		msg := &socketio_v5.Message{
+			Type:  socketio_v5.PacketAck,
+			Event: nil,
+			AckId: new(int),
+		}
+
+		mockParser.EXPECT().Parse(gomock.Any()).Return(msg, nil)
+		mockLogger.EXPECT().Errorf("received ACK packet without event data, dropping").Times(1)
+
+		client.onMessage([]byte("valid data"))
+	})
+
 	t.Run("PacketConnectError", func(t *testing.T) {
 		errorMsg := "connection error"
 		msg := &socketio_v5.Message{


### PR DESCRIPTION
## Problem
Malformed ACK packets from the server with nil AckId or nil Event can cause a remote-triggered crash when the client tries to dereference them.

## Solution
Add nil guards before dereferencing AckId and Event in the PacketAck case handler.

## Changes
- Added nil check for AckId before dereferencing — logs error and returns
- Added nil check for Event before processing — cleans up the registered ACK callback (`delete(c.ackCallbacks, *msg.AckId)`) to prevent memory leaks, then returns
- Added comprehensive test cases for both nil scenarios
- Prevents panic from malformed ACK packets

## Testing
- All existing tests pass
- New tests verify proper handling of nil AckId and nil Event
- Tested with race detector (-race flag)
- All packages pass full test suite