### PR TITLE
Fix nil pointer dereference and response body leak in polling transport SendMessage

### DIFF
--- a/engine.io/v4/client/transport/polling/transport.go
+++ b/engine.io/v4/client/transport/polling/transport.go
@@ -179,7 +179,9 @@ func (c *Transport) SendMessage(msg []byte) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	_, _ = io.Copy(io.Discard, resp.Body)
 	c.log.Debugf("receiveHttp: %s", resp.Status)
 	return nil

--- a/engine.io/v4/client/transport/polling/transport.go
+++ b/engine.io/v4/client/transport/polling/transport.go
@@ -176,6 +176,11 @@ func (c *Transport) SendMessage(msg []byte) error {
 		return fmt.Errorf("error creating request: %w", err)
 	}
 	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
 	c.log.Debugf("receiveHttp: %s", resp.Status)
-	return err
+	return nil
 }

--- a/engine.io/v4/client/transport/polling/transport_test.go
+++ b/engine.io/v4/client/transport/polling/transport_test.go
@@ -596,6 +596,81 @@ func TestSendMessage(t *testing.T) {
 		err := client.SendMessage([]byte("test message"))
 		assert.Error(t, err)
 	})
+
+	t.Run("HTTP client error - no nil pointer dereference", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockHTTPClient := mocks.NewMockHttpClient(ctrl)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		client := &Transport{
+			log:        mockLogger,
+			httpClient: mockHTTPClient,
+			url:        &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
+			sid:        "test-sid",
+			ctx:        ctx,
+		}
+
+		mockLogger.EXPECT().Debugf("sendHttp: %s", []byte("test message"))
+
+		expectedError := errors.New("network error")
+
+		mockHTTPClient.EXPECT().
+			Do(gomock.Any()).
+			Return(nil, expectedError)
+
+		// Should not panic even though resp is nil
+		err := client.SendMessage([]byte("test message"))
+		assert.Error(t, err)
+		assert.Equal(t, expectedError, err)
+	})
+
+	t.Run("Response body is closed and drained", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockHTTPClient := mocks.NewMockHttpClient(ctrl)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		client := &Transport{
+			log:        mockLogger,
+			httpClient: mockHTTPClient,
+			url:        &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
+			sid:        "test-sid",
+			ctx:        ctx,
+		}
+
+		mockLogger.EXPECT().Debugf("sendHttp: %s", []byte("test message"))
+		mockLogger.EXPECT().Debugf("receiveHttp: %s", "200 OK")
+
+		// Track if the body was closed
+		bodyClosed := false
+		mockBody := &closeTrackingBody{
+			reader:      strings.NewReader("response data"),
+			onCloseFn: func() { bodyClosed = true },
+		}
+
+		mockResp := &http.Response{
+			StatusCode: 200,
+			Status:     "200 OK",
+			Body:       mockBody,
+		}
+
+		mockHTTPClient.EXPECT().
+			Do(gomock.Any()).
+			Return(mockResp, nil)
+
+		err := client.SendMessage([]byte("test message"))
+		assert.NoError(t, err)
+		assert.True(t, bodyClosed, "response body should be closed")
+	})
 }
 
 // errorReader is a helper type that always returns an error when Read is called
@@ -605,4 +680,21 @@ type errorReader struct {
 
 func (e *errorReader) Read(p []byte) (n int, err error) {
 	return 0, e.err
+}
+
+// closeTrackingBody is a helper type for testing that tracks if Close was called
+type closeTrackingBody struct {
+	reader    io.Reader
+	onCloseFn func()
+}
+
+func (c *closeTrackingBody) Read(p []byte) (int, error) {
+	return c.reader.Read(p)
+}
+
+func (c *closeTrackingBody) Close() error {
+	if c.onCloseFn != nil {
+		c.onCloseFn()
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

This PR fixes two critical bugs in the polling transport's SendMessage method:

1. **Nil pointer dereference**: When httpClient.Do() returns an error, resp is nil. The original code tried to access resp.Status unconditionally, causing a panic.

2. **Response body leak**: Response bodies were never closed, leaving TCP connections open and causing resource exhaustion.

## Changes

- Added nil check after httpClient.Do() call
- Added defer resp.Body.Close() to ensure proper cleanup
- Added io.Copy(io.Discard, resp.Body) to drain response body before closing
- Added comprehensive tests covering error cases and body closure behavior

## Testing

All tests pass including new tests that verify:
- No panic when httpClient.Do() returns an error
- Response body is properly closed and drained in success case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced HTTP response handling and resource cleanup in network operations
  * Improved error reporting for request failures

* **Tests**
  * Added comprehensive test coverage for HTTP communication scenarios, including error cases and successful responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->