### PR TITLE
fix: synchronize handler access in engine.io Client to prevent data races

### DIFF
--- a/engine.io/v4/client/client.go
+++ b/engine.io/v4/client/client.go
@@ -40,6 +40,12 @@ type Client struct {
 	// the waitUpgrade / waitHandshake channels so that Send() never
 	// races with transportUpgrade() or Close().
 	transportMu sync.RWMutex
+
+	// handlerMu protects access to the handler fields
+	// (messageHandler, closeHandler, afterConnect).
+	// On() writes them from the user goroutine, while handlePacket()
+	// and handleHandshake() read them from the transport goroutine.
+	handlerMu sync.RWMutex
 }
 
 func (c *Client) Connect(ctx context.Context) error {
@@ -217,8 +223,11 @@ func (c *Client) handleHandshake(data []byte) error {
 	// Call onConnect hook after the transport upgrade has completed so
 	// that the new transport is fully ready before any callback tries
 	// to send data.
-	if c.afterConnect != nil {
-		c.afterConnect()
+	c.handlerMu.RLock()
+	handler := c.afterConnect
+	c.handlerMu.RUnlock()
+	if handler != nil {
+		handler()
 	}
 
 	return nil
@@ -244,8 +253,11 @@ func (c *Client) handlePacket(packetData []byte) error {
 			return err
 		}
 	case engineio_v4.PacketClose:
-		if c.closeHandler != nil {
-			c.closeHandler()
+		c.handlerMu.RLock()
+		handler := c.closeHandler
+		c.handlerMu.RUnlock()
+		if handler != nil {
+			handler()
 		}
 	case engineio_v4.PacketPing:
 		err := c.sendPacket(&engineio_v4.Message{
@@ -271,8 +283,11 @@ func (c *Client) handlePacket(packetData []byte) error {
 			}
 		}
 	case engineio_v4.PacketMessage:
-		if c.messageHandler != nil {
-			c.messageHandler(packet.Data)
+		c.handlerMu.RLock()
+		handler := c.messageHandler
+		c.handlerMu.RUnlock()
+		if handler != nil {
+			handler(packet.Data)
 		}
 	}
 	return nil
@@ -328,6 +343,9 @@ func (c *Client) Send(message []byte) error {
 }
 
 func (c *Client) On(event string, handler func([]byte)) {
+	c.handlerMu.Lock()
+	defer c.handlerMu.Unlock()
+
 	switch event {
 	case "connect":
 		c.afterConnect = func() { handler(nil) }

--- a/engine.io/v4/client/client_test.go
+++ b/engine.io/v4/client/client_test.go
@@ -867,3 +867,102 @@ func TestClient_Send_after_close(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "client is closed")
 }
+
+// TestClient_On_concurrent tests that concurrent On() calls and handler reads
+// do not cause data races. This test should be run with -race to detect issues.
+func TestClient_On_concurrent(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := mocks.NewMockLogger(ctrl)
+	mockParser := mocks.NewMockParser(ctrl)
+
+	testURL, _ := url.Parse("http://localhost")
+	client := &Client{
+		url:    testURL,
+		log:    mockLogger,
+		parser: mockParser,
+	}
+
+	// Track which handlers were called
+	var mu sync.Mutex
+	handlersSet := make(map[string]bool)
+
+	// Simulate concurrent On() calls from the user goroutine
+	numWriters := 10
+	numReaders := 10
+	numIterations := 100
+
+	done := make(chan struct{})
+
+	// Writer goroutines: continuously call On() to register handlers
+	for w := 0; w < numWriters; w++ {
+		go func(writerID int) {
+			for i := 0; i < numIterations; i++ {
+				client.On("message", func(b []byte) {
+					mu.Lock()
+					handlersSet["message"] = true
+					mu.Unlock()
+				})
+				client.On("connect", func(b []byte) {
+					mu.Lock()
+					handlersSet["connect"] = true
+					mu.Unlock()
+				})
+				client.On("close", func(b []byte) {
+					mu.Lock()
+					handlersSet["close"] = true
+					mu.Unlock()
+				})
+			}
+			done <- struct{}{}
+		}(w)
+	}
+
+	// Reader goroutines: continuously read and call handlers
+	// (simulating what happens in handlePacket and handleHandshake)
+	for r := 0; r < numReaders; r++ {
+		go func(readerID int) {
+			for i := 0; i < numIterations; i++ {
+				// Simulate reading messageHandler
+				client.handlerMu.RLock()
+				handler := client.messageHandler
+				client.handlerMu.RUnlock()
+				if handler != nil {
+					handler([]byte("test"))
+				}
+
+				// Simulate reading closeHandler
+				client.handlerMu.RLock()
+				closeH := client.closeHandler
+				client.handlerMu.RUnlock()
+				if closeH != nil {
+					closeH()
+				}
+
+				// Simulate reading afterConnect
+				client.handlerMu.RLock()
+				connectH := client.afterConnect
+				client.handlerMu.RUnlock()
+				if connectH != nil {
+					connectH()
+				}
+			}
+			done <- struct{}{}
+		}(r)
+	}
+
+	// Wait for all goroutines to finish
+	total := numWriters + numReaders
+	for i := 0; i < total; i++ {
+		<-done
+	}
+
+	// Verify that some handlers were indeed set and called
+	mu.Lock()
+	assert.True(t, handlersSet["message"] || handlersSet["connect"] || handlersSet["close"],
+		"At least some handlers should have been called")
+	mu.Unlock()
+}


### PR DESCRIPTION
## Problem
The `On()` method writes to `messageHandler`, `closeHandler`, and `afterConnect` fields from the user goroutine, while `handlePacket()` and `handleHandshake()` read from these fields from the transport goroutine. Without synchronization, this causes data races detected by Go's race detector.

## Solution
Add a dedicated `handlerMu sync.RWMutex` to the Client struct to protect access to handler fields:

- `On()` now acquires `handlerMu.Lock()` before writing to handler fields
- `handlePacket()` and `handleHandshake()` acquire `handlerMu.RLock()` before reading, copy the handler to a local variable, release the lock, then invoke the handler

This approach ensures proper synchronization while avoiding holding the lock during user callback execution, which could cause deadlocks or reduce concurrency.

## Changes
- Added `handlerMu sync.RWMutex` field to Client struct
- Protected `On()` method with mutex lock
- Protected three read sites in `handlePacket()` and `handleHandshake()` with mutex read lock
- Added comprehensive concurrent test that triggers data race if synchronization is missing

## Testing
- All existing tests pass with `go test ./... -count=1`
- All tests pass with race detector: `go test ./engine.io/v4/client/... -race -count=1 -v`
- New concurrent test validates the fix by exercising both writer and reader goroutines simultaneously

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved race conditions in event handler registration by adding thread-safe synchronization. Handler reads and writes are now protected to ensure consistent, reliable behavior during concurrent registration and invocation.

* **Tests**
  * Added concurrency-focused tests that simulate parallel handler registration and access to validate thread-safety and prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maldikhan/go.socket.io/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->