### PR TITLE
fix: prevent data race on c.ctx and c.handshakeData

### DIFF
--- a/socket.io/v5/client/client.go
+++ b/socket.io/v5/client/client.go
@@ -38,8 +38,12 @@ type namespace struct {
 	hadConnected  sync.Once
 }
 
+// SetHandshakeData stores a shallow copy of the provided map as the handshake
+// payload. Top-level keys are detached from the caller's map, but nested
+// maps/slices are still shared. Callers must not mutate nested values after
+// calling SetHandshakeData, or supply only flat/JSON-primitive values.
 func (c *Client) SetHandshakeData(data map[string]interface{}) {
-	// Make a copy to prevent external mutation after set
+	// Make a shallow copy to prevent external mutation of top-level keys
 	dataCopy := make(map[string]interface{})
 	for k, v := range data {
 		dataCopy[k] = v

--- a/socket.io/v5/client/client.go
+++ b/socket.io/v5/client/client.go
@@ -39,13 +39,24 @@ type namespace struct {
 }
 
 func (c *Client) SetHandshakeData(data map[string]interface{}) {
-	c.handshakeData = data
+	// Make a copy to prevent external mutation after set
+	dataCopy := make(map[string]interface{})
+	for k, v := range data {
+		dataCopy[k] = v
+	}
+	c.mutex.Lock()
+	c.handshakeData = dataCopy
+	c.mutex.Unlock()
 }
 
 func (c *Client) connectSocketIO(_ []byte) {
+	c.mutex.RLock()
+	handshakeData := c.handshakeData
+	c.mutex.RUnlock()
+
 	err := c.sendPacket(&socketio_v5.Message{
 		Type:    socketio_v5.PacketConnect,
-		Payload: c.handshakeData,
+		Payload: handshakeData,
 	})
 
 	if err != nil {
@@ -54,7 +65,9 @@ func (c *Client) connectSocketIO(_ []byte) {
 }
 
 func (c *Client) Connect(ctx context.Context, callbacks ...func(arg interface{})) error {
+	c.mutex.Lock()
 	c.ctx = ctx
+	c.mutex.Unlock()
 	for _, callback := range callbacks {
 		c.On("connect", callback)
 	}

--- a/socket.io/v5/client/client_test.go
+++ b/socket.io/v5/client/client_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -183,4 +184,131 @@ func TestClose(t *testing.T) {
 	if err != nil {
 		t.Errorf("Close() returned an error: %v", err)
 	}
+}
+
+func TestConcurrentConnectAndEmit(t *testing.T) {
+	// This test ensures no data race when Connect() writes c.ctx
+	// while Emit() reads it concurrently
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockEngineIO := mocks.NewMockEngineIOClient(ctrl)
+	mockParser := mocks.NewMockParser(ctrl)
+	mockLogger := mocks.NewMockLogger(ctrl)
+
+	ctx := context.Background()
+
+	client := &Client{
+		engineio:         mockEngineIO,
+		parser:           mockParser,
+		logger:           mockLogger,
+		ctx:              ctx, // Initialize ctx
+		namespaces:       make(map[string]*namespace),
+		ackCallbacks:     make(map[int]func([]interface{})),
+		handshakeData:    make(map[string]interface{}),
+	}
+
+	// Create default namespace without waitConnected (nil) so Emit skips the select
+	client.defaultNs = &namespace{
+		client:        client,
+		name:          "/",
+		handlers:      make(map[string][]func([]interface{})),
+		waitConnected: nil,
+	}
+
+	mockEngineIO.EXPECT().Connect(ctx).Return(nil).AnyTimes()
+	mockParser.EXPECT().Serialize(gomock.Any()).Return([]byte("packet"), nil).AnyTimes()
+	mockEngineIO.EXPECT().Send(gomock.Any()).Return(nil).AnyTimes()
+
+	// Simulate concurrent Connect and Emit operations
+	done := make(chan bool, 2)
+	go func() {
+		// Simulate Connect writing to c.ctx
+		for i := 0; i < 10; i++ {
+			_ = client.Connect(ctx)
+		}
+		done <- true
+	}()
+
+	go func() {
+		// Simulate Emit reading from c.ctx
+		for i := 0; i < 10; i++ {
+			_ = client.Emit("test_event")
+		}
+		done <- true
+	}()
+
+	<-done
+	<-done
+}
+
+func TestSetHandshakeDataMakesaCopy(t *testing.T) {
+	// This test ensures SetHandshakeData makes a copy to prevent mutation
+	client := &Client{
+		handshakeData: make(map[string]interface{}),
+		mutex:         sync.RWMutex{},
+	}
+
+	originalData := map[string]interface{}{
+		"key1": "value1",
+		"key2": 42,
+	}
+
+	client.SetHandshakeData(originalData)
+
+	// Mutate the original data
+	originalData["key1"] = "mutated"
+
+	// Verify that client.handshakeData is not affected
+	client.mutex.RLock()
+	if client.handshakeData["key1"] != "value1" {
+		t.Errorf("SetHandshakeData() did not make a copy. Got %v, want value1", client.handshakeData["key1"])
+	}
+	client.mutex.RUnlock()
+}
+
+func TestConcurrentSetHandshakeDataAndConnect(t *testing.T) {
+	// This test ensures no data race when SetHandshakeData writes c.handshakeData
+	// while connectSocketIO reads it concurrently
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockParser := mocks.NewMockParser(ctrl)
+	mockLogger := mocks.NewMockLogger(ctrl)
+	mockEngineIO := mocks.NewMockEngineIOClient(ctrl)
+
+	client := &Client{
+		parser:        mockParser,
+		logger:        mockLogger,
+		engineio:      mockEngineIO,
+		handshakeData: make(map[string]interface{}),
+		mutex:         sync.RWMutex{},
+	}
+
+	mockParser.EXPECT().Serialize(gomock.Any()).Return([]byte("packet"), nil).AnyTimes()
+	mockEngineIO.EXPECT().Send(gomock.Any()).Return(nil).AnyTimes()
+
+	done := make(chan bool, 2)
+	go func() {
+		// Simulate concurrent SetHandshakeData calls
+		for i := 0; i < 10; i++ {
+			data := map[string]interface{}{
+				"key":   "value",
+				"index": i,
+			}
+			client.SetHandshakeData(data)
+		}
+		done <- true
+	}()
+
+	go func() {
+		// Simulate concurrent connectSocketIO calls
+		for i := 0; i < 10; i++ {
+			client.connectSocketIO(nil)
+		}
+		done <- true
+	}()
+
+	<-done
+	<-done
 }

--- a/socket.io/v5/client/client_test.go
+++ b/socket.io/v5/client/client_test.go
@@ -208,12 +208,15 @@ func TestConcurrentConnectAndEmit(t *testing.T) {
 		handshakeData:    make(map[string]interface{}),
 	}
 
-	// Create default namespace without waitConnected (nil) so Emit skips the select
+	// Create default namespace with a pre-closed waitConnected channel
+	// so Emit exercises the ctx snapshot path without blocking
+	alreadyConnected := make(chan struct{})
+	close(alreadyConnected)
 	client.defaultNs = &namespace{
 		client:        client,
 		name:          "/",
 		handlers:      make(map[string][]func([]interface{})),
-		waitConnected: nil,
+		waitConnected: alreadyConnected,
 	}
 
 	mockEngineIO.EXPECT().Connect(ctx).Return(nil).AnyTimes()

--- a/socket.io/v5/client/constructor.go
+++ b/socket.io/v5/client/constructor.go
@@ -1,6 +1,7 @@
 package socketio_v5_client
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/url"
@@ -21,6 +22,7 @@ type InitClient struct {
 func NewClient(options ...ClientOption) (*Client, error) {
 	client := &InitClient{
 		Client: &Client{
+			ctx:           context.Background(), // safe default so Emit before Connect won't panic
 			handshakeData: make(map[string]interface{}),
 			namespaces:    make(map[string]*namespace),
 			ackCallbacks:  make(map[int]func([]interface{})),

--- a/socket.io/v5/client/emitters.go
+++ b/socket.io/v5/client/emitters.go
@@ -16,10 +16,15 @@ func (c *Client) Emit(event interface{}, args ...interface{}) error {
 func (n *namespace) Emit(event interface{}, args ...interface{}) error {
 
 	if n.waitConnected != nil {
+		// Snapshot ctx under lock to prevent data race
+		n.client.mutex.RLock()
+		ctx := n.client.ctx
+		n.client.mutex.RUnlock()
+
 		select {
 		case <-n.waitConnected:
-		case <-n.client.ctx.Done():
-			return n.client.ctx.Err()
+		case <-ctx.Done():
+			return ctx.Err()
 		}
 	}
 
@@ -113,6 +118,11 @@ func (c *Client) sendPacketWithAckTimeout(
 	c.mutex.Unlock()
 
 	if timeout != nil {
+		// Snapshot ctx under lock to prevent data race
+		c.mutex.RLock()
+		ctx := c.ctx
+		c.mutex.RUnlock()
+
 		go func(done chan []interface{}) {
 			select {
 			case <-c.timer.After(*timeout):
@@ -123,8 +133,8 @@ func (c *Client) sendPacketWithAckTimeout(
 				if timeoutCallback != nil {
 					timeoutCallback()
 				}
-			case <-c.ctx.Done():
-				c.logger.Warnf("context is done: %v", c.ctx.Err())
+			case <-ctx.Done():
+				c.logger.Warnf("context is done: %v", ctx.Err())
 			case param := <-done:
 				if wrappedCallback != nil {
 					wrappedCallback(param)


### PR DESCRIPTION
This PR fixes critical data race conditions in the socket.io client:

## Issues Fixed

1. **Data race on c.ctx**: The `Connect()` method was writing to `c.ctx` without synchronization, while `Emit()` and other methods read it concurrently from different goroutines.

2. **Data race on c.handshakeData**: The `SetHandshakeData()` method wrote to `c.handshakeData` without protection, while `connectSocketIO()` read it concurrently.

3. **Nil ctx panic before Connect**: If `Emit()` is called before `Connect()`, the `ctx` snapshot is nil and `ctx.Done()` panics.

## Changes

- Protected `c.ctx` writes in `Connect()` with `mutex.Lock/Unlock`
- Protected `c.handshakeData` writes in `SetHandshakeData()` with `mutex.Lock/Unlock` and made a defensive shallow copy (with doc comment noting nested values are still shared)
- Snapshot `c.ctx` under `RLock` in `Emit()` before using it in select statement
- Snapshot `c.ctx` under `RLock` in `sendPacketWithAckTimeout()` before launching goroutine
- Initialized `c.ctx = context.Background()` in `NewClient()` constructor so `Emit`/ack-timeout paths never see nil ctx before `Connect` is called
- Added comprehensive tests for concurrent scenarios (`TestConcurrentConnectAndEmit` with pre-closed `waitConnected` to exercise ctx snapshot path, `TestSetHandshakeDataMakesaCopy`, `TestConcurrentSetHandshakeDataAndConnect`)

## Testing

All tests pass with the -race flag:
```
go test ./socket.io/v5/client/... -race -count=1 -v
go test ./... -count=1
```