### PR TITLE
Add inbound payload size limit to prevent OOM

### DIFF
--- a/engine.io/v4/client/transport/polling/constructor.go
+++ b/engine.io/v4/client/transport/polling/constructor.go
@@ -13,10 +13,11 @@ type EngineTransportOption func(*Transport) error
 func NewTransport(options ...EngineTransportOption) (*Transport, error) {
 	// Create default client
 	client := &Transport{
-		log:         &utils.DefaultLogger{},
-		httpClient:  &http.Client{},
-		pinger:      time.NewTicker(10 * time.Second),
-		stopPooling: make(chan struct{}, 1),
+		log:             &utils.DefaultLogger{},
+		httpClient:      &http.Client{},
+		pinger:          time.NewTicker(10 * time.Second),
+		stopPooling:     make(chan struct{}, 1),
+		maxPayloadSize:  4 * 1024 * 1024, // 4MB default, matches socket.io JS maxHttpBufferSize
 	}
 
 	// Apply options
@@ -59,6 +60,16 @@ func WithDefaultPinger(pinger *time.Ticker) EngineTransportOption {
 	return func(c *Transport) error {
 		c.pinger.Stop()
 		c.pinger = pinger
+		return nil
+	}
+}
+
+func WithMaxPayloadSize(size int64) EngineTransportOption {
+	return func(c *Transport) error {
+		if size <= 0 {
+			return errors.New("maxPayloadSize must be positive")
+		}
+		c.maxPayloadSize = size
 		return nil
 	}
 }

--- a/engine.io/v4/client/transport/polling/constructor_test.go
+++ b/engine.io/v4/client/transport/polling/constructor_test.go
@@ -207,3 +207,51 @@ func TestWithDefaultPinger(t *testing.T) {
 		t.Errorf("WithDefaultPinger() did not set the pinger correctly")
 	}
 }
+
+func TestWithMaxPayloadSize(t *testing.T) {
+	t.Run("Valid size", func(t *testing.T) {
+		option := WithMaxPayloadSize(8 * 1024 * 1024) // 8MB
+		transport := &Transport{}
+		err := option(transport)
+
+		if err != nil {
+			t.Errorf("WithMaxPayloadSize() returned an error: %v", err)
+		}
+
+		if transport.maxPayloadSize != 8*1024*1024 {
+			t.Errorf("WithMaxPayloadSize() did not set the max payload size correctly, got %d", transport.maxPayloadSize)
+		}
+	})
+
+	t.Run("Zero size", func(t *testing.T) {
+		option := WithMaxPayloadSize(0)
+		transport := &Transport{}
+		err := option(transport)
+
+		if err == nil {
+			t.Errorf("WithMaxPayloadSize() should return an error for zero size")
+		}
+	})
+
+	t.Run("Negative size", func(t *testing.T) {
+		option := WithMaxPayloadSize(-1)
+		transport := &Transport{}
+		err := option(transport)
+
+		if err == nil {
+			t.Errorf("WithMaxPayloadSize() should return an error for negative size")
+		}
+	})
+}
+
+func TestDefaultMaxPayloadSize(t *testing.T) {
+	transport, err := NewTransport()
+	if err != nil {
+		t.Errorf("NewTransport() returned an error: %v", err)
+	}
+
+	expectedSize := int64(4 * 1024 * 1024) // 4MB
+	if transport.maxPayloadSize != expectedSize {
+		t.Errorf("Default maxPayloadSize = %d, want %d", transport.maxPayloadSize, expectedSize)
+	}
+}

--- a/engine.io/v4/client/transport/polling/transport.go
+++ b/engine.io/v4/client/transport/polling/transport.go
@@ -30,7 +30,8 @@ type Transport struct {
 	onClose     chan<- error
 	stopPooling chan struct{}
 
-	stopped uint32 // atomic; 0 = running, 1 = stopped
+	stopped         uint32 // atomic; 0 = running, 1 = stopped
+	maxPayloadSize  int64
 }
 
 func (c *Transport) SetHandshake(handshake *engineio_v4.HandshakeResponse) {
@@ -158,10 +159,17 @@ func (c *Transport) poll() error {
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
-	body, err := io.ReadAll(resp.Body)
+	// Limit payload size: read one byte more than the limit to detect oversized payloads
+	body, err := io.ReadAll(io.LimitReader(resp.Body, c.maxPayloadSize+1))
 	if err != nil {
 		return err
 	}
+
+	// Check if payload exceeds the maximum size
+	if int64(len(body)) > c.maxPayloadSize {
+		return fmt.Errorf("inbound payload size %d exceeds maximum allowed %d", len(body), c.maxPayloadSize)
+	}
+
 	c.log.Debugf("receiveHttp: %s", string(body))
 
 	c.messages <- body

--- a/engine.io/v4/client/transport/polling/transport.go
+++ b/engine.io/v4/client/transport/polling/transport.go
@@ -159,8 +159,13 @@ func (c *Transport) poll() error {
 	}
 	defer resp.Body.Close() //nolint:errcheck
 
-	// Limit payload size: read one byte more than the limit to detect oversized payloads
-	body, err := io.ReadAll(io.LimitReader(resp.Body, c.maxPayloadSize+1))
+	// Limit payload size: read one byte more than the limit to detect oversized payloads.
+	// Guard against int64 overflow when maxPayloadSize is near math.MaxInt64.
+	readLimit := c.maxPayloadSize + 1
+	if readLimit <= 0 {
+		readLimit = c.maxPayloadSize // overflow: clamp to maxPayloadSize
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, readLimit))
 	if err != nil {
 		return err
 	}

--- a/engine.io/v4/client/transport/polling/transport_test.go
+++ b/engine.io/v4/client/transport/polling/transport_test.go
@@ -710,4 +710,59 @@ func TestPollOversizedPayload(t *testing.T) {
 			t.Fatal("Timeout waiting for poll to complete")
 		}
 	})
+
+	t.Run("Payload limit overflow guard", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockHTTPClient := mocks.NewMockHttpClient(ctrl)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		messagesChan := make(chan []byte, 1)
+		// Set maxPayloadSize to a value that would overflow when incremented
+		maxPayloadSize := int64(9223372036854775807) // math.MaxInt64
+
+		client := &Transport{
+			log:            mockLogger,
+			httpClient:     mockHTTPClient,
+			url:            &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
+			sid:            "test-sid",
+			ctx:            ctx,
+			messages:       messagesChan,
+			maxPayloadSize: maxPayloadSize,
+		}
+
+		mockLogger.EXPECT().Debugf("run polling")
+		mockLogger.EXPECT().Debugf("receiveHttp: %s", "test")
+
+		mockResp := &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader("test")),
+		}
+
+		mockHTTPClient.EXPECT().
+			Do(gomock.Any()).
+			DoAndReturn(func(req *http.Request) (*http.Response, error) {
+				return mockResp, nil
+			})
+
+		done := make(chan struct{})
+		go func() {
+			err := client.poll()
+			// Should succeed because "test" (4 bytes) is within MaxInt64
+			assert.NoError(t, err)
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			assert.Equal(t, 1, len(messagesChan), "Expected one message to be sent")
+		case <-time.After(time.Second):
+			t.Fatal("Timeout waiting for poll to complete")
+		}
+	})
 }

--- a/engine.io/v4/client/transport/polling/transport_test.go
+++ b/engine.io/v4/client/transport/polling/transport_test.go
@@ -49,11 +49,12 @@ func TestRequestHandshake(t *testing.T) {
 
 	messages := make(chan []byte, 1)
 	client := &Transport{
-		log:        mockLogger,
-		httpClient: mockHttpClient,
-		url:        &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
-		ctx:        ctx,
-		messages:   messages,
+		log:            mockLogger,
+		httpClient:     mockHttpClient,
+		url:            &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
+		ctx:            ctx,
+		messages:       messages,
+		maxPayloadSize: 4 * 1024 * 1024, // 4MB default
 	}
 
 	mockLogger.EXPECT().Debugf("run polling")
@@ -400,12 +401,13 @@ func TestPoll(t *testing.T) {
 		messagesChan := make(chan []byte, 1)
 
 		client := &Transport{
-			log:        mockLogger,
-			httpClient: mockHTTPClient,
-			url:        &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
-			sid:        "test-sid",
-			ctx:        ctx,
-			messages:   messagesChan,
+			log:            mockLogger,
+			httpClient:     mockHTTPClient,
+			url:            &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
+			sid:            "test-sid",
+			ctx:            ctx,
+			messages:       messagesChan,
+			maxPayloadSize: 4 * 1024 * 1024, // 4MB default
 		}
 
 		mockLogger.EXPECT().Debugf("run polling")
@@ -605,4 +607,107 @@ type errorReader struct {
 
 func (e *errorReader) Read(p []byte) (n int, err error) {
 	return 0, e.err
+}
+
+func TestPollOversizedPayload(t *testing.T) {
+	t.Run("Payload exceeds max size", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockHTTPClient := mocks.NewMockHttpClient(ctrl)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		messagesChan := make(chan []byte, 1)
+		maxPayloadSize := int64(100)
+		oversizedBody := strings.Repeat("x", 101)
+
+		client := &Transport{
+			log:            mockLogger,
+			httpClient:     mockHTTPClient,
+			url:            &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
+			sid:            "test-sid",
+			ctx:            ctx,
+			messages:       messagesChan,
+			maxPayloadSize: maxPayloadSize,
+		}
+
+		mockLogger.EXPECT().Debugf("run polling")
+
+		mockResp := &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(oversizedBody)),
+		}
+
+		mockHTTPClient.EXPECT().
+			Do(gomock.Any()).
+			DoAndReturn(func(req *http.Request) (*http.Response, error) {
+				return mockResp, nil
+			})
+
+		err := client.poll()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "inbound payload size")
+		assert.Contains(t, err.Error(), "exceeds maximum allowed")
+
+		// Ensure no message was sent
+		assert.Equal(t, 0, len(messagesChan), "Expected no message to be sent for oversized payload")
+	})
+
+	t.Run("Payload within max size", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockHTTPClient := mocks.NewMockHttpClient(ctrl)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		messagesChan := make(chan []byte, 1)
+		maxPayloadSize := int64(100)
+		validBody := strings.Repeat("x", 50)
+
+		client := &Transport{
+			log:            mockLogger,
+			httpClient:     mockHTTPClient,
+			url:            &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
+			sid:            "test-sid",
+			ctx:            ctx,
+			messages:       messagesChan,
+			maxPayloadSize: maxPayloadSize,
+		}
+
+		mockLogger.EXPECT().Debugf("run polling")
+		mockLogger.EXPECT().Debugf("receiveHttp: %s", validBody)
+
+		mockResp := &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(validBody)),
+		}
+
+		mockHTTPClient.EXPECT().
+			Do(gomock.Any()).
+			DoAndReturn(func(req *http.Request) (*http.Response, error) {
+				return mockResp, nil
+			})
+
+		done := make(chan struct{})
+		go func() {
+			err := client.poll()
+			assert.NoError(t, err)
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			assert.Equal(t, 1, len(messagesChan), "Expected one message to be sent")
+		case <-time.After(time.Second):
+			t.Fatal("Timeout waiting for poll to complete")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Adds a configurable inbound payload size limit to the polling transport to prevent out-of-memory (OOM) attacks from malicious servers sending oversized responses.

## Problem

The polling transport's `poll()` function uses `io.ReadAll(resp.Body)` without any size limits. A malicious server can send gigabytes of data, causing the client to exhaust available memory and be killed by the OS.

## Solution

- Add `maxPayloadSize` field to Transport struct (default: 4MB)
- Use `io.LimitReader()` to enforce the limit: read one byte more than the limit to detect oversized payloads
- Guard against int64 overflow when `maxPayloadSize` is near `math.MaxInt64` (clamp `readLimit` if it wraps to negative)
- Return error if payload exceeds the configured size
- Add `WithMaxPayloadSize()` constructor option for customization

The 4MB default matches the socket.io JavaScript library's `maxHttpBufferSize` for consistency across implementations.

## Changes

- Modified `engine.io/v4/client/transport/polling/transport.go`:
  - Added `maxPayloadSize int64` field
  - Updated `poll()` to use `io.LimitReader()` with overflow-safe sentinel byte pattern and size validation

- Modified `engine.io/v4/client/transport/polling/constructor.go`:
  - Set default `maxPayloadSize` to 4MB
  - Added `WithMaxPayloadSize(size int64)` constructor option

- Added comprehensive tests:
  - Test payload exceeding max size returns error
  - Test payload within limits succeeds
  - Test constructor option validation
  - Test overflow guard for near-MaxInt64 limit values