### PR TITLE
Add mutex protection to WebSocket Send/Close for concurrent safety

### DIFF
--- a/websocket/native/ws.go
+++ b/websocket/native/ws.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"net/url"
+	"sync"
 
 	"golang.org/x/net/websocket"
 )
 
 type WebSocketConnection struct {
+	mu   sync.Mutex
 	conn *websocket.Conn
 }
 
@@ -28,6 +30,8 @@ func (ws *WebSocketConnection) Send(v []byte) error {
 	if ws.conn == nil {
 		return ErrNotConnected
 	}
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
 	return websocket.Message.Send(ws.conn, string(v))
 }
 
@@ -42,5 +46,7 @@ func (ws *WebSocketConnection) Close() error {
 	if ws.conn == nil {
 		return nil
 	}
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
 	return ws.conn.Close()
 }

--- a/websocket/native/ws_test.go
+++ b/websocket/native/ws_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http/httptest"
 	"net/url"
+	"sync"
 	"testing"
 	"time"
 
@@ -183,6 +184,66 @@ func TestWebSocketConnection_Close(t *testing.T) {
 		ws := &WebSocketConnection{}
 		err := ws.Close()
 		assert.NoError(t, err, "Close should return nil for uninitialized connection")
+	})
+}
+
+func TestWebSocketConnection_ConcurrentSend(t *testing.T) {
+
+	ctx := context.Background()
+
+	origin, err := url.Parse("http://localhost")
+	require.NoError(t, err, "Failed to parse server URL")
+
+	t.Run("Concurrent Send calls are safe", func(t *testing.T) {
+		t.Parallel()
+
+		receivedChan := make(chan string, 10)
+		server := createTestServer(t, receivedChan)
+		defer server.Close()
+
+		url, err := url.Parse(server.URL)
+		require.NoError(t, err, "Failed to parse server URL")
+		url.Scheme = "ws"
+
+		ws := &WebSocketConnection{}
+		err = ws.Dial(ctx, url, origin)
+		require.NoError(t, err, "Dial should not return an error")
+		defer ws.Close()
+
+		// Launch multiple goroutines sending messages concurrently
+		numGoroutines := 10
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+
+		for i := 0; i < numGoroutines; i++ {
+			go func(id int) {
+				defer wg.Done()
+				message := []byte("Message from goroutine")
+				err := ws.Send(message)
+				assert.NoError(t, err, "Send should not return an error in concurrent goroutine")
+			}(i)
+		}
+
+		wg.Wait()
+
+		// Give the server time to process all messages
+		time.Sleep(100 * time.Millisecond)
+
+		// Verify all messages were received (allowing for echo responses)
+		received := 0
+		for {
+			select {
+			case <-receivedChan:
+				received++
+			case <-time.After(50 * time.Millisecond):
+				break
+			}
+			if received >= numGoroutines {
+				break
+			}
+		}
+
+		assert.GreaterOrEqual(t, received, numGoroutines, "All messages should be received")
 	})
 }
 

--- a/websocket/native/ws_test.go
+++ b/websocket/native/ws_test.go
@@ -208,7 +208,9 @@ func TestWebSocketConnection_ConcurrentSend(t *testing.T) {
 		ws := &WebSocketConnection{}
 		err = ws.Dial(ctx, url, origin)
 		require.NoError(t, err, "Dial should not return an error")
-		defer ws.Close()
+		defer func() {
+			_ = ws.Close()
+		}()
 
 		// Launch multiple goroutines sending messages concurrently
 		numGoroutines := 10
@@ -231,12 +233,13 @@ func TestWebSocketConnection_ConcurrentSend(t *testing.T) {
 
 		// Verify all messages were received (allowing for echo responses)
 		received := 0
+	Loop:
 		for {
 			select {
 			case <-receivedChan:
 				received++
 			case <-time.After(50 * time.Millisecond):
-				break
+				break Loop
 			}
 			if received >= numGoroutines {
 				break


### PR DESCRIPTION
## Summary
- Add sync.Mutex field to WebSocketConnection struct
- Protect Send() method with mutex to prevent corrupted frames from concurrent writes
- Protect Close() method with mutex for thread-safe connection closure
- Receive() remains unprotected (single reader guaranteed)

## Problem
golang.org/x/net/websocket.Conn is not safe for concurrent writes. Send() is called from user/emit goroutines while Receive() runs in the read-loop goroutine. Concurrent Send() calls can produce corrupted WebSocket frames.

## Test plan
- All existing tests pass
- New concurrent Send test verifies thread safety with -race detector
- Full test suite passes with no race conditions detected

## Test results
```
go test ./websocket/native/... -race -count=1 -v
PASS: All tests including concurrent safety test
ok  	github.com/maldikhan/go.socket.io/websocket/native	1.182s

go test ./... -count=1
PASS: All packages
```