### PR TITLE
Fix data races on transport sid field with sync.RWMutex

### DIFF
--- a/engine.io/v4/client/transport/polling/transport.go
+++ b/engine.io/v4/client/transport/polling/transport.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -31,10 +32,13 @@ type Transport struct {
 	stopPooling chan struct{}
 
 	stopped uint32 // atomic; 0 = running, 1 = stopped
+	mu      sync.RWMutex
 }
 
 func (c *Transport) SetHandshake(handshake *engineio_v4.HandshakeResponse) {
+	c.mu.Lock()
 	c.sid = handshake.Sid
+	c.mu.Unlock()
 	pingInterval := 10 * time.Second
 	if handshake.PingInterval != 0 {
 		pingInterval = time.Duration(handshake.PingInterval) * time.Millisecond
@@ -122,6 +126,9 @@ func (c *Transport) pollingLoop() error {
 }
 
 func (c *Transport) buildHttpUrl() *url.URL {
+	c.mu.RLock()
+	sid := c.sid
+	c.mu.RUnlock()
 
 	reqURL := &url.URL{
 		Scheme: c.url.Scheme,
@@ -133,7 +140,7 @@ func (c *Transport) buildHttpUrl() *url.URL {
 
 	query.Set("transport", "polling")
 	query.Set("EIO", "4")
-	query.Set("sid", c.sid)
+	query.Set("sid", sid)
 
 	reqURL.RawQuery = query.Encode()
 	return reqURL

--- a/engine.io/v4/client/transport/polling/transport_test.go
+++ b/engine.io/v4/client/transport/polling/transport_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -605,4 +606,47 @@ type errorReader struct {
 
 func (e *errorReader) Read(p []byte) (n int, err error) {
 	return 0, e.err
+}
+
+func TestConcurrentSetHandshakeAndBuildUrl(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := mocks.NewMockLogger(ctrl)
+	mockLogger.EXPECT().Debugf(gomock.Any()).AnyTimes()
+	mockLogger.EXPECT().Errorf(gomock.Any()).AnyTimes()
+
+	client := &Transport{
+		log:    mockLogger,
+		pinger: time.NewTicker(time.Minute),
+		url:    &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
+	}
+
+	var wg sync.WaitGroup
+
+	// Run SetHandshake and buildHttpUrl concurrently
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(iter int) {
+			defer wg.Done()
+			handshake := &engineio_v4.HandshakeResponse{
+				Sid:          "sid-" + string(rune(iter)),
+				PingInterval: 5000,
+			}
+			client.SetHandshake(handshake)
+		}(i)
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			url := client.buildHttpUrl()
+			assert.NotNil(t, url)
+		}()
+	}
+
+	wg.Wait()
+
+	// If there was a race condition, the race detector would catch it
 }

--- a/engine.io/v4/client/transport/websocket/transport.go
+++ b/engine.io/v4/client/transport/websocket/transport.go
@@ -3,6 +3,7 @@ package engineio_v4_client_transport
 import (
 	"context"
 	"net/url"
+	"sync"
 
 	engineio_v4 "github.com/maldikhan/go.socket.io/engine.io/v4"
 )
@@ -19,6 +20,7 @@ type Transport struct {
 	messages    chan<- []byte
 	onClose     chan<- error
 	stopPooling chan struct{}
+	mu          sync.RWMutex
 }
 
 func (c *Transport) Transport() engineio_v4.EngineIOTransport {
@@ -56,10 +58,16 @@ func (c *Transport) RequestHandshake() error {
 }
 
 func (c *Transport) SetHandshake(handshake *engineio_v4.HandshakeResponse) {
+	c.mu.Lock()
 	c.sid = handshake.Sid
+	c.mu.Unlock()
 }
 
 func (c *Transport) buildWsUrl() *url.URL {
+	c.mu.RLock()
+	sid := c.sid
+	c.mu.RUnlock()
+
 	wsURL := &url.URL{
 		Scheme: "ws",
 		Host:   c.url.Host,
@@ -82,7 +90,7 @@ func (c *Transport) buildWsUrl() *url.URL {
 
 	query.Set("transport", "websocket")
 	query.Set("EIO", "4")
-	query.Set("sid", c.sid)
+	query.Set("sid", sid)
 
 	wsURL.RawQuery = query.Encode()
 	return wsURL

--- a/engine.io/v4/client/transport/websocket/transport_test.go
+++ b/engine.io/v4/client/transport/websocket/transport_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"sync"
 	"testing"
 	"time"
 
@@ -495,4 +496,44 @@ func TestTransport_SendMessage_Error(t *testing.T) {
 	err := transport.SendMessage([]byte("test message"))
 	assert.Error(t, err)
 	assert.Equal(t, "send error", err.Error())
+}
+
+func TestConcurrentSetHandshakeAndBuildUrl(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := mock_engineio_v4_client_transport.NewMockLogger(ctrl)
+	mockLogger.EXPECT().Errorf(gomock.Any()).AnyTimes()
+
+	transport := &Transport{
+		log: mockLogger,
+		url: &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
+	}
+
+	var wg sync.WaitGroup
+
+	// Run SetHandshake and buildWsUrl concurrently
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(iter int) {
+			defer wg.Done()
+			handshake := &engineio_v4.HandshakeResponse{
+				Sid: "sid-" + string(rune(iter)),
+			}
+			transport.SetHandshake(handshake)
+		}(i)
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			url := transport.buildWsUrl()
+			assert.NotNil(t, url)
+		}()
+	}
+
+	wg.Wait()
+
+	// If there was a race condition, the race detector would catch it
 }


### PR DESCRIPTION
## Summary
Add sync.RWMutex to protect concurrent access to the 'sid' field in both polling and websocket transports.

## Problem
- In polling transport: SetHandshake() writes c.sid from messageLoop goroutine. buildHttpUrl() reads c.sid from polling goroutine without synchronization.
- In websocket transport: SetHandshake() writes c.sid. buildWsUrl() reads c.sid without synchronization.

## Solution
Added sync.RWMutex to both Transport structs:
- SetHandshake() protected with write lock (mu.Lock/Unlock)
- buildHttpUrl()/buildWsUrl() protected with read lock (mu.RLock/RUnlock)
- SendMessage() calls buildHttpUrl()/buildWsUrl() which already hold the read lock

## Testing
- Added concurrent test cases that run SetHandshake and buildUrl 10 times each concurrently
- Verified with `go test ./engine.io/v4/client/transport/... -race -count=1` - all tests pass
- All existing tests pass with `go test ./... -count=1`

## Files Changed
- engine.io/v4/client/transport/polling/transport.go: Add RWMutex, protect sid access
- engine.io/v4/client/transport/websocket/transport.go: Add RWMutex, protect sid access
- Transport test files: Add concurrent access tests
