### PR TITLE
Fix blocking channel sends in transports

### DIFF
--- a/engine.io/v4/client/transport/polling/transport.go
+++ b/engine.io/v4/client/transport/polling/transport.go
@@ -107,14 +107,20 @@ func (c *Transport) pollingLoop() error {
 			c.log.Debugf("stop polling")
 			atomic.StoreUint32(&c.stopped, 1)
 			if c.onClose != nil {
-				c.onClose <- c.ctx.Err()
+				select {
+				case c.onClose <- c.ctx.Err():
+				default:
+				}
 			}
 			return nil
 		case <-c.ctx.Done():
 			c.log.Debugf("context done, stop http polling")
 			atomic.StoreUint32(&c.stopped, 1)
 			if c.onClose != nil {
-				c.onClose <- c.ctx.Err()
+				select {
+				case c.onClose <- c.ctx.Err():
+				default:
+				}
 			}
 			return c.ctx.Err()
 		}
@@ -164,7 +170,11 @@ func (c *Transport) poll() error {
 	}
 	c.log.Debugf("receiveHttp: %s", string(body))
 
-	c.messages <- body
+	select {
+	case c.messages <- body:
+	case <-c.ctx.Done():
+		return c.ctx.Err()
+	}
 	return nil
 }
 

--- a/engine.io/v4/client/transport/polling/transport_test.go
+++ b/engine.io/v4/client/transport/polling/transport_test.go
@@ -383,6 +383,115 @@ func TestStop(t *testing.T) {
 	})
 }
 
+func TestPollingLoop_onClose_full_on_stop(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	mockLogger := mocks.NewMockLogger(ctrl)
+	mockLogger.EXPECT().Debugf("stop polling")
+
+	// onClose is buffered with 1 slot, but we fill it to test the default: branch
+	onClose := make(chan error, 1)
+	onClose <- errors.New("pre-filled error")
+
+	// Use a very long-interval ticker so it never fires during test
+	longTicker := time.NewTicker(10 * time.Minute)
+	defer longTicker.Stop()
+
+	stopPoolingCh := make(chan struct{})
+
+	client := &Transport{
+		log:         mockLogger,
+		pinger:      longTicker,
+		stopPooling: stopPoolingCh,
+		ctx:         ctx,
+		onClose:     onClose,
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- client.pollingLoop()
+	}()
+
+	// Send stop signal
+	close(stopPoolingCh)
+
+	// Wait for pollingLoop to return
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("pollingLoop did not return")
+	}
+
+	// Verify pre-filled error is still there (not replaced by onClose send)
+	select {
+	case e := <-onClose:
+		assert.Equal(t, "pre-filled error", e.Error())
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Pre-filled error should still be in channel")
+	}
+}
+
+func TestPollingLoop_onClose_full_on_context_cancel(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := mocks.NewMockLogger(ctrl)
+	mockLogger.EXPECT().Debugf("context done, stop http polling")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	onClose := make(chan error, 1)
+	onClose <- errors.New("pre-filled error")
+
+	// Use a very long-interval ticker so it never fires during test
+	longTicker := time.NewTicker(10 * time.Minute)
+	defer longTicker.Stop()
+
+	client := &Transport{
+		log:         mockLogger,
+		pinger:      longTicker,
+		stopPooling: make(chan struct{}),
+		ctx:         ctx,
+		onClose:     onClose,
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- client.pollingLoop()
+	}()
+
+	// Cancel context after a short delay to let pollingLoop start waiting on select
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	// Wait for pollingLoop to return
+	select {
+	case err := <-done:
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, context.Canceled))
+	case <-time.After(time.Second):
+		t.Fatal("pollingLoop did not return")
+	}
+
+	// Verify pre-filled error is still there (not replaced by onClose send)
+	select {
+	case e := <-onClose:
+		assert.Equal(t, "pre-filled error", e.Error())
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Pre-filled error should still be in channel")
+	}
+}
+
 func TestPoll(t *testing.T) {
 
 	t.Run("Successful poll", func(t *testing.T) {

--- a/engine.io/v4/client/transport/polling/transport_test.go
+++ b/engine.io/v4/client/transport/polling/transport_test.go
@@ -772,3 +772,27 @@ type errorReader struct {
 func (e *errorReader) Read(p []byte) (n int, err error) {
 	return 0, e.err
 }
+
+func TestStop_non_blocking_default_branch(t *testing.T) {
+	t.Parallel()
+
+	// Create unbuffered stopPooling channel with nobody reading
+	client := &Transport{
+		stopPooling: make(chan struct{}),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		// This must complete without deadlock even though stopPooling is full
+		err := client.Stop()
+		assert.NoError(t, err)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success: Stop returned without blocking via default: branch
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Stop() deadlocked - failed to execute default: branch")
+	}
+}

--- a/engine.io/v4/client/transport/polling/transport_test.go
+++ b/engine.io/v4/client/transport/polling/transport_test.go
@@ -654,6 +654,63 @@ func TestPoll(t *testing.T) {
 		err := client.poll()
 		assert.Error(t, err)
 	})
+
+	t.Run("Poll with context canceled during message send", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockHTTPClient := mocks.NewMockHttpClient(ctrl)
+
+		// Create a context that will be canceled
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Create an unbuffered channel to block the send
+		messagesChan := make(chan []byte)
+
+		client := &Transport{
+			log:        mockLogger,
+			httpClient: mockHTTPClient,
+			url:        &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
+			sid:        "test-sid",
+			ctx:        ctx,
+			messages:   messagesChan,
+		}
+
+		mockLogger.EXPECT().Debugf("run polling")
+		mockLogger.EXPECT().Debugf("receiveHttp: %s", "test response")
+
+		mockResp := &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader("test response")),
+		}
+
+		mockHTTPClient.EXPECT().
+			Do(gomock.Any()).
+			Return(mockResp, nil)
+
+		// Run poll in a goroutine and cancel the context while it's trying to send
+		done := make(chan error, 1)
+		go func() {
+			done <- client.poll()
+		}()
+
+		// Give poll time to get the response and try to send the message
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+
+		// Wait for poll to return with context.Canceled error
+		select {
+		case err := <-done:
+			assert.Error(t, err)
+			assert.True(t, errors.Is(err, context.Canceled))
+		case <-time.After(time.Second):
+			t.Fatal("Timeout waiting for poll to return with context canceled")
+		}
+	})
 }
 
 func TestSendMessage(t *testing.T) {

--- a/engine.io/v4/client/transport/websocket/transport.go
+++ b/engine.io/v4/client/transport/websocket/transport.go
@@ -137,24 +137,37 @@ func (c *Transport) wsReadLoop() error {
 		select {
 		case <-c.stopPooling:
 			c.log.Debugf("Context cancelled, exiting ws read loop")
-			c.onClose <- nil
+			select {
+			case c.onClose <- nil:
+			default:
+			}
 			return nil
 
 		case <-c.ctx.Done():
 			// Context cancelled
 			c.log.Debugf("Context cancelled, exiting ws read loop")
-			c.onClose <- c.ctx.Err()
+			select {
+			case c.onClose <- c.ctx.Err():
+			default:
+			}
 			return c.ctx.Err()
 
 		case message := <-messageCh:
 			// New message received
 			c.log.Debugf("receiveWs: %s", message)
-			c.messages <- message
+			select {
+			case c.messages <- message:
+			case <-c.ctx.Done():
+				return c.ctx.Err()
+			}
 
 		case err := <-errorCh:
 			// WebSocket error
 			c.log.Errorf("receiveWsError: %v", err)
-			c.onClose <- err
+			select {
+			case c.onClose <- err:
+			default:
+			}
 			return err
 		}
 	}

--- a/engine.io/v4/client/transport/websocket/transport_test.go
+++ b/engine.io/v4/client/transport/websocket/transport_test.go
@@ -655,3 +655,56 @@ func TestTransport_wsReadLoop_onClose_full_on_context_cancel(t *testing.T) {
 	cancel()
 	time.Sleep(50 * time.Millisecond)
 }
+
+func TestTransport_wsReadLoop_message_context_cancel(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockWS := mock_engineio_v4_client_transport.NewMockWebSocket(ctrl)
+	mockLogger := mock_engineio_v4_client_transport.NewMockLogger(ctrl)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create an unbuffered messages channel to block the send
+	messages := make(chan []byte)
+	onClose := make(chan error, 1)
+
+	transport := &Transport{
+		log:         mockLogger,
+		ws:          mockWS,
+		ctx:         ctx,
+		messages:    messages,
+		onClose:     onClose,
+		stopPooling: make(chan struct{}, 1),
+	}
+
+	mockLogger.EXPECT().Debugf(gomock.Any()).AnyTimes()
+	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+
+	// Test message context canceled branch (line 160-161)
+	// Return a message that will cause wsReadLoop to block trying to send to unbuffered messages channel
+	mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(message *[]byte) error {
+		*message = []byte("test message")
+		return nil
+	}).Times(1)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- transport.wsReadLoop()
+	}()
+
+	// Give wsReadLoop time to receive the message and attempt to send it to the unbuffered channel
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	// Wait for wsReadLoop to return with context.Canceled
+	select {
+	case err := <-done:
+		assert.Equal(t, context.Canceled, err)
+	case <-time.After(time.Second):
+		t.Fatal("Timeout waiting for wsReadLoop to return with context canceled")
+	}
+}

--- a/engine.io/v4/client/transport/websocket/transport_test.go
+++ b/engine.io/v4/client/transport/websocket/transport_test.go
@@ -526,41 +526,47 @@ func TestTransport_wsReadLoop_onClose_already_full(t *testing.T) {
 	mockLogger.EXPECT().Debugf(gomock.Any()).AnyTimes()
 	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
 
-	// Test stopPooling default: branch (line 142-143)
+	// Test stopPooling default: branch - send stopPooling signal BEFORE first Receive completes
+	// so wsReadLoop sees stopPooling in the select
+	stopPoolingCalled := make(chan struct{})
 	mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(message *[]byte) error {
-		*message = []byte("test")
-		return nil
-	}).Times(1)
-	mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(message *[]byte) error {
+		// Signal that we're about to wait for either stopPooling or more data
+		close(stopPoolingCalled)
+		// Block until context is canceled
 		<-transport.ctx.Done()
 		return nil
 	}).Times(1)
 
+	done := make(chan error, 1)
 	go func() {
-		err := transport.wsReadLoop()
-		assert.NoError(t, err)
+		done <- transport.wsReadLoop()
 	}()
 
-	// Check message is received
+	// Wait for Receive to be called and ready to process stopPooling
+	<-stopPoolingCalled
+	time.Sleep(10 * time.Millisecond)
+
+	// Now send stopPooling - wsReadLoop will try to send to onClose but it's full,
+	// so it hits the default: branch and returns nil
+	close(transport.stopPooling)
+
+	// Wait for wsReadLoop to exit
 	select {
-	case msg := <-messages:
-		assert.Equal(t, []byte("test"), msg)
+	case err := <-done:
+		assert.NoError(t, err)
 	case <-time.After(time.Second):
-		t.Fatal("Timeout waiting for message")
+		t.Fatal("Timeout waiting for wsReadLoop to exit")
 	}
 
-	// Trigger stopPooling with onClose buffer already full
-	transport.stopPooling <- struct{}{}
+	// Verify pre-filled error is still in onClose (not replaced)
 	select {
 	case err := <-onClose:
 		assert.Equal(t, "pre-filled error", err.Error())
-	case <-time.After(time.Second):
-		t.Fatal("Timeout waiting for initial onClose")
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Expected pre-filled error to still be in onClose")
 	}
 
-	// wsReadLoop should exit without deadlock
 	cancel()
-	time.Sleep(50 * time.Millisecond)
 }
 
 func TestTransport_wsReadLoop_onClose_full_on_error(t *testing.T) {
@@ -706,5 +712,29 @@ func TestTransport_wsReadLoop_message_context_cancel(t *testing.T) {
 		assert.Equal(t, context.Canceled, err)
 	case <-time.After(time.Second):
 		t.Fatal("Timeout waiting for wsReadLoop to return with context canceled")
+	}
+}
+
+func TestTransport_Stop_non_blocking_default_branch(t *testing.T) {
+	t.Parallel()
+
+	// Create unbuffered stopPooling channel with nobody reading
+	transport := &Transport{
+		stopPooling: make(chan struct{}),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		// This must complete without deadlock even though stopPooling is full
+		err := transport.Stop()
+		assert.NoError(t, err)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success: Stop returned without blocking via default: branch
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Stop() deadlocked - failed to execute default: branch")
 	}
 }

--- a/engine.io/v4/client/transport/websocket/transport_test.go
+++ b/engine.io/v4/client/transport/websocket/transport_test.go
@@ -496,3 +496,162 @@ func TestTransport_SendMessage_Error(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "send error", err.Error())
 }
+
+func TestTransport_wsReadLoop_onClose_already_full(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockWS := mock_engineio_v4_client_transport.NewMockWebSocket(ctrl)
+	mockLogger := mock_engineio_v4_client_transport.NewMockLogger(ctrl)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	messages := make(chan []byte, 1)
+	// onClose is buffered with 1 slot, but we fill it to test the default: branch
+	onClose := make(chan error, 1)
+	onClose <- errors.New("pre-filled error")
+
+	transport := &Transport{
+		log:         mockLogger,
+		ws:          mockWS,
+		ctx:         ctx,
+		messages:    messages,
+		onClose:     onClose,
+		stopPooling: make(chan struct{}, 1),
+	}
+
+	mockLogger.EXPECT().Debugf(gomock.Any()).AnyTimes()
+	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+
+	// Test stopPooling default: branch (line 142-143)
+	mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(message *[]byte) error {
+		*message = []byte("test")
+		return nil
+	}).Times(1)
+	mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(message *[]byte) error {
+		<-transport.ctx.Done()
+		return nil
+	}).Times(1)
+
+	go func() {
+		err := transport.wsReadLoop()
+		assert.NoError(t, err)
+	}()
+
+	// Check message is received
+	select {
+	case msg := <-messages:
+		assert.Equal(t, []byte("test"), msg)
+	case <-time.After(time.Second):
+		t.Fatal("Timeout waiting for message")
+	}
+
+	// Trigger stopPooling with onClose buffer already full
+	transport.stopPooling <- struct{}{}
+	select {
+	case err := <-onClose:
+		assert.Equal(t, "pre-filled error", err.Error())
+	case <-time.After(time.Second):
+		t.Fatal("Timeout waiting for initial onClose")
+	}
+
+	// wsReadLoop should exit without deadlock
+	cancel()
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestTransport_wsReadLoop_onClose_full_on_error(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockWS := mock_engineio_v4_client_transport.NewMockWebSocket(ctrl)
+	mockLogger := mock_engineio_v4_client_transport.NewMockLogger(ctrl)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	messages := make(chan []byte, 1)
+	onClose := make(chan error, 1)
+	onClose <- errors.New("pre-filled error")
+
+	transport := &Transport{
+		log:         mockLogger,
+		ws:          mockWS,
+		ctx:         ctx,
+		messages:    messages,
+		onClose:     onClose,
+		stopPooling: make(chan struct{}, 1),
+	}
+
+	mockLogger.EXPECT().Debugf(gomock.Any()).AnyTimes()
+	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
+
+	// Test error default: branch (line 168-169)
+	wsErr := errors.New("websocket error")
+	mockWS.EXPECT().Receive(gomock.Any()).Return(wsErr)
+
+	go func() {
+		err := transport.wsReadLoop()
+		assert.Equal(t, wsErr, err)
+	}()
+
+	select {
+	case err := <-onClose:
+		assert.Equal(t, "pre-filled error", err.Error())
+	case <-time.After(time.Second):
+		t.Fatal("Timeout waiting for initial onClose")
+	}
+
+	// Give time for wsReadLoop to try sending error to full onClose channel
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestTransport_wsReadLoop_onClose_full_on_context_cancel(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockWS := mock_engineio_v4_client_transport.NewMockWebSocket(ctrl)
+	mockLogger := mock_engineio_v4_client_transport.NewMockLogger(ctrl)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	messages := make(chan []byte, 1)
+	onClose := make(chan error, 1)
+	onClose <- errors.New("pre-filled error")
+
+	transport := &Transport{
+		log:         mockLogger,
+		ws:          mockWS,
+		ctx:         ctx,
+		messages:    messages,
+		onClose:     onClose,
+		stopPooling: make(chan struct{}, 1),
+	}
+
+	mockLogger.EXPECT().Debugf(gomock.Any()).AnyTimes()
+	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+
+	// Test context canceled default: branch (line 150-151)
+	mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(message *[]byte) error {
+		<-transport.ctx.Done()
+		return nil
+	})
+
+	go func() {
+		err := transport.wsReadLoop()
+		assert.Equal(t, context.Canceled, err)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	time.Sleep(50 * time.Millisecond)
+}

--- a/engine.io/v4/client/transport/websocket/transport_test.go
+++ b/engine.io/v4/client/transport/websocket/transport_test.go
@@ -715,6 +715,60 @@ func TestTransport_wsReadLoop_message_context_cancel(t *testing.T) {
 	}
 }
 
+func TestTransport_wsReadLoop_error_default_onClose_branch(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockWS := mock_engineio_v4_client_transport.NewMockWebSocket(ctrl)
+	mockLogger := mock_engineio_v4_client_transport.NewMockLogger(ctrl)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	messages := make(chan []byte, 1)
+	// Pre-fill onClose so the error-path default branch (line 169) is taken
+	onClose := make(chan error, 1)
+	onClose <- errors.New("pre-filled")
+
+	transport := &Transport{
+		log:         mockLogger,
+		ws:          mockWS,
+		ctx:         ctx,
+		messages:    messages,
+		onClose:     onClose,
+		stopPooling: make(chan struct{}, 1),
+	}
+
+	mockLogger.EXPECT().Debugf(gomock.Any()).AnyTimes()
+	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
+
+	wsErr := errors.New("ws read error")
+	mockWS.EXPECT().Receive(gomock.Any()).Return(wsErr)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- transport.wsReadLoop()
+	}()
+
+	select {
+	case err := <-done:
+		assert.Equal(t, wsErr, err)
+	case <-time.After(time.Second):
+		t.Fatal("Timeout waiting for wsReadLoop to exit")
+	}
+
+	// Verify pre-filled error is still in onClose (ws error was dropped via default)
+	select {
+	case err := <-onClose:
+		assert.Equal(t, "pre-filled", err.Error())
+	default:
+		t.Fatal("Expected pre-filled error to still be in onClose")
+	}
+}
+
 func TestTransport_Stop_non_blocking_default_branch(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem
In both polling and websocket transports, channel sends to `c.messages` and `c.onClose` were blocking. If the consumer is stopped or the channel buffer is full, the transport goroutine hangs forever, preventing graceful shutdown.

## Solution
Replace blocking channel sends with `select` statements that respect context cancellation:

### Polling Transport
- `poll()`: Wrap `c.messages <- body` in select with `c.ctx.Done()`
- `pollingLoop()`: Use non-blocking send for `c.onClose` in exit paths

### WebSocket Transport  
- `wsReadLoop()`: Wrap `c.messages <- message` in select with `c.ctx.Done()`
- `wsReadLoop()`: Use non-blocking send for `c.onClose` in all exit paths

## Testing
- All existing unit tests pass
- Tests run with race detector enabled: `go test ./... -race`
- No new deadlocks or blocking issues observed

## Affected Files
- `engine.io/v4/client/transport/polling/transport.go`
- `engine.io/v4/client/transport/websocket/transport.go`