### PR TITLE
Add panic recovery to handler goroutines

### DIFF
--- a/socket.io/v5/client/client.go
+++ b/socket.io/v5/client/client.go
@@ -80,6 +80,17 @@ func (c *Client) namespace(name string) *namespace {
 	return ns
 }
 
+func (c *Client) safeGo(fn func()) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				c.logger.Errorf("panic in event handler: %v", r)
+			}
+		}()
+		fn()
+	}()
+}
+
 func (c *Client) Close() error {
 	return c.engineio.Close()
 }

--- a/socket.io/v5/client/handlers.go
+++ b/socket.io/v5/client/handlers.go
@@ -63,7 +63,8 @@ func (c *Client) handleConnectError(ns *namespace, payload interface{}) {
 	}
 
 	for _, handler := range handlers {
-		go handler([]interface{}{payload})
+		h := handler
+		c.safeGo(func() { h([]interface{}{payload}) })
 	}
 }
 
@@ -80,7 +81,8 @@ func (c *Client) handleDisconnect(ns *namespace, payload interface{}) {
 	}
 
 	for _, handler := range handlers {
-		go handler([]interface{}{payload})
+		h := handler
+		c.safeGo(func() { h([]interface{}{payload}) })
 	}
 }
 
@@ -102,7 +104,8 @@ func (c *Client) handleConnect(ns *namespace, payload interface{}) {
 	}
 
 	for _, handler := range handlers {
-		go handler([]interface{}{payload})
+		h := handler
+		c.safeGo(func() { h([]interface{}{payload}) })
 	}
 }
 
@@ -118,11 +121,13 @@ func (c *Client) handleEvent(ns *namespace, event *socketio_v5.Event) {
 	}
 
 	for _, handler := range anyHandlers {
-		go handler(event.Name, event.Payloads)
+		h := handler
+		c.safeGo(func() { h(event.Name, event.Payloads) })
 	}
 
 	for _, handler := range handlers {
-		go handler(event.Payloads)
+		h := handler
+		c.safeGo(func() { h(event.Payloads) })
 	}
 }
 
@@ -137,5 +142,5 @@ func (c *Client) handleAck(event *socketio_v5.Event, ackId int) {
 		return
 	}
 
-	go callback(event.Payloads)
+	c.safeGo(func() { callback(event.Payloads) })
 }

--- a/socket.io/v5/client/handlers_test.go
+++ b/socket.io/v5/client/handlers_test.go
@@ -408,3 +408,88 @@ func TestClientHandleAck(t *testing.T) {
 		assert.Len(t, client.ackCallbacks, 0)
 	})
 }
+
+func TestSafeGoPanicRecovery(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := mocks.NewMockLogger(ctrl)
+
+	client := &Client{
+		logger: mockLogger,
+	}
+
+	t.Run("Handler that panics is recovered", func(t *testing.T) {
+		panicMsg := "test panic"
+		handlerExecuted := make(chan bool)
+
+		mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).Do(func(format string, args ...interface{}) {
+			assert.Contains(t, format, "panic in event handler")
+			assert.Contains(t, args[0], panicMsg)
+			handlerExecuted <- true
+		})
+
+		client.safeGo(func() {
+			panic(panicMsg)
+		})
+
+		select {
+		case <-handlerExecuted:
+		case <-time.After(100 * time.Millisecond):
+			t.Error("panic recovery should have logged error")
+		}
+	})
+
+	t.Run("Handler that completes normally works fine", func(t *testing.T) {
+		handlerExecuted := make(chan bool)
+
+		client.safeGo(func() {
+			handlerExecuted <- true
+		})
+
+		select {
+		case <-handlerExecuted:
+		case <-time.After(100 * time.Millisecond):
+			t.Error("handler should have executed")
+		}
+	})
+
+	t.Run("handleEvent with panicking handler recovers gracefully", func(t *testing.T) {
+		panicMsg := "event handler panic"
+		handlerExecuted := make(chan bool, 1)
+		normalHandlerExecuted := make(chan bool, 1)
+
+		mockLogger.EXPECT().Infof(gomock.Any(), gomock.Any()).AnyTimes()
+		mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).Do(func(format string, args ...interface{}) {
+			assert.Contains(t, format, "panic in event handler")
+			handlerExecuted <- true
+		})
+
+		ns := &namespace{
+			handlers: make(map[string][]func([]interface{})),
+		}
+
+		ns.handlers["test_event"] = []func([]interface{}){
+			func(args []interface{}) {
+				panic(panicMsg)
+			},
+			func(args []interface{}) {
+				normalHandlerExecuted <- true
+			},
+		}
+
+		client.handleEvent(ns, &socketio_v5.Event{Name: "test_event"})
+
+		select {
+		case <-handlerExecuted:
+		case <-time.After(100 * time.Millisecond):
+			t.Error("panicking handler should have been recovered")
+		}
+
+		select {
+		case <-normalHandlerExecuted:
+		case <-time.After(100 * time.Millisecond):
+			t.Error("second handler should have executed despite first panicking")
+		}
+	})
+}


### PR DESCRIPTION
This change wraps all event handler goroutines with panic recovery to prevent silent crashes when user callbacks panic.

## Problem
Event handlers are spawned as goroutines without panic recovery. If a user's callback panics, the goroutine dies silently with no logging or recovery, potentially leaving the client in an inconsistent state.

## Solution
Added a `safeGo()` helper method on the Client that wraps function execution with defer/recover logic. All bare `go handler(...)` calls in handlers.go are now wrapped with panic recovery.

## Changes
- Added `safeGo()` helper method to Client that catches and logs panics
- Replaced all bare 'go handler(...)' calls with 'c.safeGo(func() { ... })' in:
  - handleConnectError (line 66)
  - handleDisconnect (line 83)
  - handleConnect (line 105)
  - handleEvent (lines 121, 125)
  - handleAck (line 140)
- Added proper variable capture in loop closures to prevent race conditions
- Added comprehensive tests for panic recovery behavior

## Testing
- All existing tests pass
- New tests verify panic recovery and logging
- Race detector passes with -race flag