### PR TITLE
Fix copy-paste error message in constructor validation

### DIFF
--- a/engine.io/v4/client/constructor.go
+++ b/engine.io/v4/client/constructor.go
@@ -42,7 +42,7 @@ func NewClient(options ...EngineClientOption) (*Client, error) {
 	}
 
 	if client.parser == nil {
-		return nil, errors.New("logger is nil")
+		return nil, errors.New("parser is nil")
 	}
 
 	if len(client.supportedTransports) == 0 {

--- a/engine.io/v4/client/constructor_test.go
+++ b/engine.io/v4/client/constructor_test.go
@@ -32,6 +32,7 @@ func TestNewClientEdges(t *testing.T) {
 	t.Run("Empty parser", func(t *testing.T) {
 		_, err := NewClient(WithRawURL("http://example.com"), WithParser(nil))
 		assert.Error(t, err)
+		assert.Equal(t, "parser is nil", err.Error())
 	})
 
 	t.Run("Transport fallback", func(t *testing.T) {


### PR DESCRIPTION
When checking if client.parser is nil, the error message incorrectly says 'logger is nil'. This is a copy-paste error from the previous check.

**Problem:**
The validation logic checks for parser being nil, but the error message says 'logger is nil', which is confusing and incorrect.

**Solution:**
Changed the error message from 'logger is nil' to 'parser is nil' to accurately reflect what is being validated.

**Testing:**
- Added test case to verify the error message is correct when parser is nil
- All existing tests pass