### PR TITLE
Fix polling stopped flag not reset on Run()

### DIFF
--- a/engine.io/v4/client/transport/polling/transport.go
+++ b/engine.io/v4/client/transport/polling/transport.go
@@ -62,6 +62,10 @@ func (c *Transport) Run(
 	c.url = url
 	c.messages = messagesChan
 	c.onClose = onClose
+	// Reset the stopped flag to allow transport reuse
+	atomic.StoreUint32(&c.stopped, 0)
+	// Reinitialize stopPooling channel to ensure fresh channel for new run
+	c.stopPooling = make(chan struct{}, 1)
 
 	go func() {
 		c.pinger.Stop()

--- a/engine.io/v4/client/transport/polling/transport_test.go
+++ b/engine.io/v4/client/transport/polling/transport_test.go
@@ -606,3 +606,95 @@ type errorReader struct {
 func (e *errorReader) Read(p []byte) (n int, err error) {
 	return 0, e.err
 }
+
+func TestRun_stopped_flag_reset(t *testing.T) {
+	// Test that Run() resets the stopped flag and reinitializes stopPooling
+	// to allow the transport to be reused after Stop()
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := mocks.NewMockLogger(ctrl)
+	mockHttpClient := mocks.NewMockHttpClient(ctrl)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	url, _ := url.Parse("http://example.com")
+	messagesChan := make(chan []byte, 1)
+	onCloseChan := make(chan error, 1)
+
+	client := &Transport{
+		log:         mockLogger,
+		httpClient:  mockHttpClient,
+		pinger:      time.NewTicker(time.Millisecond),
+		url:         url,
+		stopPooling: make(chan struct{}, 1),
+	}
+
+	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
+
+	// Mock the poll method to avoid actual HTTP requests
+	mockHttpClient.EXPECT().
+		Do(gomock.Any()).
+		Return(&http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader("test response")),
+		}, nil).
+		AnyTimes()
+
+	t.Run("Run -> Stop -> Run -> Stop", func(t *testing.T) {
+		// First Run
+		err := client.Run(ctx, url, "test-sid-1", messagesChan, onCloseChan)
+		assert.NoError(t, err)
+		time.Sleep(10 * time.Millisecond)
+
+		// First Stop
+		assert.NoError(t, client.Stop())
+		select {
+		case <-onCloseChan:
+		case <-time.After(200 * time.Millisecond):
+			t.Fatal("Timeout waiting for first onClose signal")
+		}
+
+		// Verify stopped flag is set
+		stoppedBefore := atomic.LoadUint32(&client.stopped)
+		assert.Equal(t, uint32(1), stoppedBefore, "stopped flag should be 1 after Stop()")
+
+		// Reset channels for second run
+		onCloseChan = make(chan error, 1)
+		client.pinger = time.NewTicker(time.Millisecond)
+
+		// Second Run - this should reset the stopped flag and reinitialize stopPooling
+		err = client.Run(ctx, url, "test-sid-2", messagesChan, onCloseChan)
+		assert.NoError(t, err)
+
+		// Verify stopped flag is reset
+		stoppedAfter := atomic.LoadUint32(&client.stopped)
+		assert.Equal(t, uint32(0), stoppedAfter, "stopped flag should be 0 after second Run()")
+
+		time.Sleep(10 * time.Millisecond)
+
+		// Second Stop should work without hanging
+		done := make(chan struct{})
+		go func() {
+			assert.NoError(t, client.Stop())
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			// Stop succeeded
+		case <-time.After(200 * time.Millisecond):
+			t.Fatal("Second Stop() should not hang - stopped flag was not reset properly")
+		}
+
+		select {
+		case <-onCloseChan:
+		case <-time.After(200 * time.Millisecond):
+			t.Fatal("Timeout waiting for second onClose signal")
+		}
+	})
+}


### PR DESCRIPTION
When a polling transport is stopped and then reused, the 'stopped' atomic flag is never reset. This causes Stop() to become a no-op on subsequent runs since the CAS (compare-and-swap) check sees stopped==1 and returns early without actually stopping anything.

Additionally, the stopPooling channel is not reinitialized, which can cause hangs, panics, or undefined behavior when the transport is reused.

**Problem:**
1. Transport.stopped flag set to 1 by Stop() is never reset in Run()
2. Second call to Stop() checks if stopped==0, sees 1, and returns immediately
3. stopPooling channel is not reinitialized, causing potential send-on-closed-channel panics

**Solution:**
1. In Run(): Reset the stopped flag to 0 with atomic.StoreUint32(&c.stopped, 0)
2. In Run(): Reinitialize stopPooling with a fresh buffered channel: c.stopPooling = make(chan struct{}, 1)

This allows transports to be safely reused after being stopped.

**Testing:**
- Added comprehensive test case: Run → Stop → Run → Stop sequence
- Verifies stopped flag is properly reset between runs
- Confirms second Run() works without hanging or panicking
- All existing tests pass