### PR TITLE
fix(engine.io/client): run afterConnect asynchronously to avoid handshake deadlock

### DIFF
--- a/engine.io/v4/client/client.go
+++ b/engine.io/v4/client/client.go
@@ -214,11 +214,16 @@ func (c *Client) handleHandshake(data []byte) error {
 		close(c.waitHandshake)
 	})
 
-	// Call onConnect hook after the transport upgrade has completed so
-	// that the new transport is fully ready before any callback tries
-	// to send data.
+	// Call onConnect hook in a separate goroutine. The callback typically
+	// issues a Send() (e.g. the socket.io CONNECT "40" packet), which
+	// blocks in Send() on waitUpgrade until the transport upgrade probe
+	// completes. The probe response ("3probe") is delivered via
+	// c.messages and processed by messageLoop — the same goroutine that
+	// is currently executing this handler. Running afterConnect inline
+	// would deadlock: messageLoop cannot advance to process "3probe"
+	// (and close waitUpgrade) while it is blocked inside afterConnect.
 	if c.afterConnect != nil {
-		c.afterConnect()
+		go c.afterConnect()
 	}
 
 	return nil

--- a/engine.io/v4/client/client_test.go
+++ b/engine.io/v4/client/client_test.go
@@ -381,16 +381,27 @@ func TestClient_handleHandshake(t *testing.T) {
 		mockTransportWs.EXPECT().SendMessage([]byte("probe")).Return(nil)
 
 		// Track the order: afterConnect must observe the websocket
-		// transport (i.e. the upgrade must have finished already).
+		// transport (i.e. the upgrade probe must already have been
+		// initiated and c.transport swapped to ws). afterConnect runs
+		// in its own goroutine to avoid deadlocking messageLoop on
+		// waitUpgrade, so synchronize via a channel before asserting.
 		var transportDuringCallback Transport
+		done := make(chan struct{})
 		client.afterConnect = func() {
 			transportDuringCallback = client.transport
+			close(done)
 		}
+		defer func() { client.afterConnect = nil }()
 
 		client.hadHandshake = sync.Once{}
 		client.waitHandshake = make(chan struct{})
 		err := client.handleHandshake(data)
 		require.NoError(t, err)
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			require.Fail(t, "afterConnect not called")
+		}
 		assert.Equal(t, mockTransportWs, transportDuringCallback,
 			"afterConnect must be called after transport upgrade")
 	})


### PR DESCRIPTION
Hi @MobDev-Hobby 

I tried the updated version (from `master`) with https://github.com/breml/go-uptime-kuma-client and then my tests started to fail. The analysis showed, that the issue is a deadlock.

With this change included, the test suite for https://github.com/breml/go-uptime-kuma-client does pass (see https://github.com/breml/go-uptime-kuma-client/pull/229).

Description of the change:

handleHandshake runs synchronously from messageLoop. It initiates the transport upgrade (which only sends "2probe" and returns) and then calls afterConnect. Common afterConnect callbacks — e.g. the socket.io v5 client's connectSocketIO sending the "40" CONNECT packet — invoke Send(), which blocks on waitUpgrade until the upgrade probe completes.

waitUpgrade is closed when messageLoop processes the "3probe" pong — but messageLoop is the very goroutine blocked inside afterConnect, so the pong is never processed and the connection deadlocks until the server closes it at pingTimeout.

Run afterConnect in its own goroutine so messageLoop stays free to process "3probe" and close waitUpgrade, unblocking the callback's Send.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified callback execution during the handshake process to prevent blocking.

* **Tests**
  * Updated handshake callback tests to accommodate asynchronous behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->