### PR TITLE
Fix blocking channel sends and unguarded namespace map read

### DIFF
--- a/engine.io/v4/client/client.go
+++ b/engine.io/v4/client/client.go
@@ -214,11 +214,13 @@ func (c *Client) handleHandshake(data []byte) error {
 		close(c.waitHandshake)
 	})
 
-	// Call onConnect hook after the transport upgrade has completed so
-	// that the new transport is fully ready before any callback tries
-	// to send data.
+	// Call onConnect hook in a goroutine so that messageLoop can continue
+	// processing engine.io packets (e.g. the WebSocket upgrade probe response
+	// "3probe") while the hook is running. If afterConnect calls Send(),
+	// Send() waits on waitUpgrade, which is only closed after messageLoop
+	// processes "3probe" — calling afterConnect inline would deadlock.
 	if c.afterConnect != nil {
-		c.afterConnect()
+		go c.afterConnect()
 	}
 
 	return nil

--- a/engine.io/v4/client/client_test.go
+++ b/engine.io/v4/client/client_test.go
@@ -382,17 +382,27 @@ func TestClient_handleHandshake(t *testing.T) {
 
 		// Track the order: afterConnect must observe the websocket
 		// transport (i.e. the upgrade must have finished already).
+		// afterConnect runs in a goroutine, so we synchronize with a channel.
 		var transportDuringCallback Transport
+		afterConnectDone := make(chan struct{})
 		client.afterConnect = func() {
 			transportDuringCallback = client.transport
+			close(afterConnectDone)
 		}
 
 		client.hadHandshake = sync.Once{}
 		client.waitHandshake = make(chan struct{})
 		err := client.handleHandshake(data)
 		require.NoError(t, err)
+
+		select {
+		case <-afterConnectDone:
+		case <-time.After(100 * time.Millisecond):
+			require.Fail(t, "afterConnect goroutine did not complete in time")
+		}
 		assert.Equal(t, mockTransportWs, transportDuringCallback,
 			"afterConnect must be called after transport upgrade")
+		client.afterConnect = nil
 	})
 
 	t.Run("Handshake with upgrade failure", func(t *testing.T) {

--- a/engine.io/v4/client/transport/polling/constructor.go
+++ b/engine.io/v4/client/transport/polling/constructor.go
@@ -17,6 +17,7 @@ func NewTransport(options ...EngineTransportOption) (*Transport, error) {
 		httpClient:  &http.Client{},
 		pinger:      time.NewTicker(10 * time.Second),
 		stopPooling: make(chan struct{}, 1),
+		stopCh:      make(chan struct{}),
 	}
 
 	// Apply options

--- a/engine.io/v4/client/transport/polling/transport.go
+++ b/engine.io/v4/client/transport/polling/transport.go
@@ -17,6 +17,12 @@ import (
 	engineio_v4 "github.com/maldikhan/go.socket.io/engine.io/v4"
 )
 
+// errTransportStopped is returned by poll() when it observes the stop
+// signal from stopPooling while blocked sending to c.messages. pollingLoop
+// interprets this as a clean shutdown request (the signal was consumed by
+// poll() so pollingLoop's own stopPooling case will never fire).
+var errTransportStopped = errors.New("transport stopped")
+
 type Transport struct {
 	log        Logger
 	httpClient HttpClient
@@ -100,6 +106,14 @@ func (c *Transport) pollingLoop() error {
 				return errors.New("pinger closed")
 			}
 			err := c.poll()
+			if errors.Is(err, errTransportStopped) {
+				c.log.Debugf("stop polling")
+				atomic.StoreUint32(&c.stopped, 1)
+				if c.onClose != nil {
+					c.onClose <- c.ctx.Err()
+				}
+				return nil
+			}
 			if err != nil {
 				c.log.Errorf("poll error: %s", err)
 			}
@@ -168,6 +182,11 @@ func (c *Transport) poll() error {
 	case c.messages <- body:
 	case <-c.ctx.Done():
 		return c.ctx.Err()
+	case <-c.stopPooling:
+		// Stop was signalled while we were blocked sending. Return the
+		// sentinel so pollingLoop performs the proper shutdown handshake
+		// (the stop signal has been consumed here).
+		return errTransportStopped
 	}
 	return nil
 }

--- a/engine.io/v4/client/transport/polling/transport.go
+++ b/engine.io/v4/client/transport/polling/transport.go
@@ -164,7 +164,11 @@ func (c *Transport) poll() error {
 	}
 	c.log.Debugf("receiveHttp: %s", string(body))
 
-	c.messages <- body
+	select {
+	case c.messages <- body:
+	case <-c.ctx.Done():
+		return c.ctx.Err()
+	}
 	return nil
 }
 

--- a/engine.io/v4/client/transport/polling/transport.go
+++ b/engine.io/v4/client/transport/polling/transport.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -17,10 +18,10 @@ import (
 	engineio_v4 "github.com/maldikhan/go.socket.io/engine.io/v4"
 )
 
-// errTransportStopped is returned by poll() when it observes the stop
-// signal from stopPooling while blocked sending to c.messages. pollingLoop
-// interprets this as a clean shutdown request (the signal was consumed by
-// poll() so pollingLoop's own stopPooling case will never fire).
+// errTransportStopped is an internal sentinel returned by poll() when it
+// observes stopCh while blocked sending to c.messages. It stays inside the
+// package: pollingLoop handles it directly, and RequestHandshake maps it to
+// context.Canceled before it can reach public API callers.
 var errTransportStopped = errors.New("transport stopped")
 
 type Transport struct {
@@ -36,6 +37,13 @@ type Transport struct {
 	onClose     chan<- error
 	stopPooling chan struct{}
 
+	// stopCh is closed by Stop() to broadcast the stop signal to any goroutine
+	// currently blocked inside poll(). Using a closed channel (instead of a
+	// buffered send) means both poll() and pollingLoop can observe the stop
+	// independently without competing to consume a single value.
+	stopCh   chan struct{}
+	stopOnce sync.Once
+
 	stopped uint32 // atomic; 0 = running, 1 = stopped
 }
 
@@ -49,7 +57,17 @@ func (c *Transport) SetHandshake(handshake *engineio_v4.HandshakeResponse) {
 }
 
 func (c *Transport) RequestHandshake() error {
-	return c.poll()
+	err := c.poll()
+	if errors.Is(err, errTransportStopped) {
+		// Transport was stopped while waiting to deliver the handshake response.
+		// Map the internal sentinel to a public cancellation error so callers
+		// never observe an unexported implementation detail.
+		if ctxErr := c.ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return context.Canceled
+	}
+	return err
 }
 
 func (c *Transport) Transport() engineio_v4.EngineIOTransport {
@@ -87,6 +105,12 @@ func (c *Transport) Stop() error {
 	if !atomic.CompareAndSwapUint32(&c.stopped, 0, 1) {
 		return nil
 	}
+	// Close stopCh to broadcast the stop signal to any poll() call that is
+	// currently blocked sending to c.messages. sync.Once guarantees we only
+	// close once even if Stop() is called from multiple goroutines.
+	c.stopOnce.Do(func() {
+		close(c.stopCh)
+	})
 	// Non-blocking send: if pollingLoop already exited (e.g. via
 	// ctx.Done()), nobody is reading from stopPooling and a blocking
 	// send would deadlock.
@@ -182,10 +206,10 @@ func (c *Transport) poll() error {
 	case c.messages <- body:
 	case <-c.ctx.Done():
 		return c.ctx.Err()
-	case <-c.stopPooling:
-		// Stop was signalled while we were blocked sending. Return the
-		// sentinel so pollingLoop performs the proper shutdown handshake
-		// (the stop signal has been consumed here).
+	case <-c.stopCh:
+		// Stop() was called while we were blocked sending. stopCh is a closed
+		// channel (broadcast), so pollingLoop's own stopPooling case remains
+		// intact — it will still exit cleanly via the value Stop() enqueued.
 		return errTransportStopped
 	}
 	return nil

--- a/engine.io/v4/client/transport/polling/transport_test.go
+++ b/engine.io/v4/client/transport/polling/transport_test.go
@@ -91,6 +91,57 @@ func TestTransport(t *testing.T) {
 	assert.Equal(t, engineio_v4.TransportPolling, client.Transport())
 }
 
+func TestRequestHandshake_StopDuringHandshake(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := mocks.NewMockLogger(ctrl)
+	mockHTTPClient := mocks.NewMockHttpClient(ctrl)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stopCh := make(chan struct{})
+
+	client := &Transport{
+		log:         mockLogger,
+		httpClient:  mockHTTPClient,
+		url:         &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
+		ctx:         ctx,
+		messages:    make(chan []byte), // unbuffered: send will block
+		stopPooling: make(chan struct{}, 1),
+		stopCh:      stopCh,
+	}
+
+	mockLogger.EXPECT().Debugf("run polling")
+	mockLogger.EXPECT().Debugf("receiveHttp: %s", "data")
+
+	mockHTTPClient.EXPECT().Do(gomock.Any()).Return(&http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader("data")),
+	}, nil)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- client.RequestHandshake()
+	}()
+
+	// Close stopCh to simulate Stop() while the handshake response is pending.
+	close(stopCh)
+
+	select {
+	case err := <-done:
+		// errTransportStopped must not escape: RequestHandshake maps it to
+		// context.Canceled so API callers never see the internal sentinel.
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.NotErrorIs(t, err, errTransportStopped)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("RequestHandshake blocked indefinitely when stop was signalled")
+	}
+}
+
 func TestRun(t *testing.T) {
 	t.Parallel()
 
@@ -113,6 +164,7 @@ func TestRun(t *testing.T) {
 		pinger:      time.NewTicker(time.Millisecond),
 		url:         url,
 		stopPooling: make(chan struct{}, 1),
+		stopCh:      make(chan struct{}),
 	}
 
 	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
@@ -261,6 +313,7 @@ func TestPollingLoop(t *testing.T) {
 			log:         mockLogger,
 			pinger:      time.NewTicker(10 * time.Millisecond),
 			stopPooling: make(chan struct{}, 1),
+			stopCh:      make(chan struct{}),
 			ctx:         ctx,
 			onClose:     onClose,
 			messages:    make(chan []byte, 1),
@@ -362,9 +415,11 @@ func TestStop(t *testing.T) {
 	t.Run("Stop non-blocking when pollingLoop already exited", func(t *testing.T) {
 		t.Parallel()
 
-		// stopPooling is unbuffered and nobody is reading — Stop must not deadlock
+		// stopPooling is unbuffered and nobody is reading — Stop must not deadlock.
+		// stopCh must be initialised so Stop() can close it without panicking.
 		client := &Transport{
 			stopPooling: make(chan struct{}),
+			stopCh:      make(chan struct{}),
 		}
 
 		done := make(chan struct{})
@@ -568,6 +623,7 @@ func TestPoll(t *testing.T) {
 			ctx:         ctx,
 			messages:    messagesChan,
 			stopPooling: make(chan struct{}, 1),
+			stopCh:      make(chan struct{}),
 		}
 
 		mockLogger.EXPECT().Debugf("run polling")
@@ -604,7 +660,9 @@ func TestPoll(t *testing.T) {
 		mockLogger := mocks.NewMockLogger(ctrl)
 		mockHTTPClient := mocks.NewMockHttpClient(ctrl)
 
-		stopPooling := make(chan struct{}, 1)
+		// poll() selects on stopCh (a closed channel), not stopPooling.
+		// Close stopCh to simulate Stop() being called while poll() is blocked.
+		stopCh := make(chan struct{})
 
 		client := &Transport{
 			log:         mockLogger,
@@ -613,7 +671,8 @@ func TestPoll(t *testing.T) {
 			sid:         "test-sid",
 			ctx:         context.Background(),
 			messages:    make(chan []byte), // unbuffered: send will block
-			stopPooling: stopPooling,
+			stopPooling: make(chan struct{}, 1),
+			stopCh:      stopCh,
 		}
 
 		mockLogger.EXPECT().Debugf("run polling")
@@ -630,8 +689,9 @@ func TestPoll(t *testing.T) {
 			done <- client.poll()
 		}()
 
-		// Signal stop while poll() is blocked on the full channel
-		stopPooling <- struct{}{}
+		// Close stopCh while poll() is blocked on the full channel.
+		// This simulates Stop() broadcasting the stop signal.
+		close(stopCh)
 
 		select {
 		case err := <-done:

--- a/engine.io/v4/client/transport/polling/transport_test.go
+++ b/engine.io/v4/client/transport/polling/transport_test.go
@@ -545,6 +545,54 @@ func TestPoll(t *testing.T) {
 		err := client.poll()
 		assert.Error(t, err)
 	})
+
+	t.Run("Context cancelled while sending to full messages channel", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockHTTPClient := mocks.NewMockHttpClient(ctrl)
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		// Full channel: poll() must not block forever
+		messagesChan := make(chan []byte)
+
+		client := &Transport{
+			log:        mockLogger,
+			httpClient: mockHTTPClient,
+			url:        &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
+			sid:        "test-sid",
+			ctx:        ctx,
+			messages:   messagesChan,
+		}
+
+		mockLogger.EXPECT().Debugf("run polling")
+		mockLogger.EXPECT().Debugf("receiveHttp: %s", "data")
+
+		mockResp := &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader("data")),
+		}
+		mockHTTPClient.EXPECT().Do(gomock.Any()).Return(mockResp, nil)
+
+		done := make(chan error, 1)
+		go func() {
+			done <- client.poll()
+		}()
+
+		// Cancel context while poll() is blocked on the full channel
+		cancel()
+
+		select {
+		case err := <-done:
+			assert.ErrorIs(t, err, context.Canceled)
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("poll() blocked indefinitely when messages channel was full and context was cancelled")
+		}
+	})
 }
 
 func TestSendMessage(t *testing.T) {

--- a/engine.io/v4/client/transport/polling/transport_test.go
+++ b/engine.io/v4/client/transport/polling/transport_test.go
@@ -557,16 +557,17 @@ func TestPoll(t *testing.T) {
 
 		ctx, cancel := context.WithCancel(context.Background())
 
-		// Full channel: poll() must not block forever
+		// Unbuffered channel: poll() must not block forever
 		messagesChan := make(chan []byte)
 
 		client := &Transport{
-			log:        mockLogger,
-			httpClient: mockHTTPClient,
-			url:        &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
-			sid:        "test-sid",
-			ctx:        ctx,
-			messages:   messagesChan,
+			log:         mockLogger,
+			httpClient:  mockHTTPClient,
+			url:         &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
+			sid:         "test-sid",
+			ctx:         ctx,
+			messages:    messagesChan,
+			stopPooling: make(chan struct{}, 1),
 		}
 
 		mockLogger.EXPECT().Debugf("run polling")
@@ -591,6 +592,52 @@ func TestPoll(t *testing.T) {
 			assert.ErrorIs(t, err, context.Canceled)
 		case <-time.After(500 * time.Millisecond):
 			t.Fatal("poll() blocked indefinitely when messages channel was full and context was cancelled")
+		}
+	})
+
+	t.Run("Stop signalled while sending to full messages channel", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockHTTPClient := mocks.NewMockHttpClient(ctrl)
+
+		stopPooling := make(chan struct{}, 1)
+
+		client := &Transport{
+			log:         mockLogger,
+			httpClient:  mockHTTPClient,
+			url:         &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
+			sid:         "test-sid",
+			ctx:         context.Background(),
+			messages:    make(chan []byte), // unbuffered: send will block
+			stopPooling: stopPooling,
+		}
+
+		mockLogger.EXPECT().Debugf("run polling")
+		mockLogger.EXPECT().Debugf("receiveHttp: %s", "data")
+
+		mockResp := &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader("data")),
+		}
+		mockHTTPClient.EXPECT().Do(gomock.Any()).Return(mockResp, nil)
+
+		done := make(chan error, 1)
+		go func() {
+			done <- client.poll()
+		}()
+
+		// Signal stop while poll() is blocked on the full channel
+		stopPooling <- struct{}{}
+
+		select {
+		case err := <-done:
+			assert.ErrorIs(t, err, errTransportStopped)
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("poll() blocked indefinitely when messages channel was full and stop was signalled")
 		}
 	})
 }

--- a/engine.io/v4/client/transport/websocket/transport.go
+++ b/engine.io/v4/client/transport/websocket/transport.go
@@ -149,7 +149,17 @@ func (c *Transport) wsReadLoop() error {
 		case message := <-messageCh:
 			// New message received
 			c.log.Debugf("receiveWs: %s", message)
-			c.messages <- message
+			select {
+			case c.messages <- message:
+			case <-c.stopPooling:
+				c.log.Debugf("Context cancelled, exiting ws read loop")
+				c.onClose <- nil
+				return nil
+			case <-c.ctx.Done():
+				c.log.Debugf("Context cancelled, exiting ws read loop")
+				c.onClose <- c.ctx.Err()
+				return c.ctx.Err()
+			}
 
 		case err := <-errorCh:
 			// WebSocket error

--- a/engine.io/v4/client/transport/websocket/transport.go
+++ b/engine.io/v4/client/transport/websocket/transport.go
@@ -152,7 +152,7 @@ func (c *Transport) wsReadLoop() error {
 			select {
 			case c.messages <- message:
 			case <-c.stopPooling:
-				c.log.Debugf("Context cancelled, exiting ws read loop")
+				c.log.Debugf("Stop requested, exiting ws read loop")
 				c.onClose <- nil
 				return nil
 			case <-c.ctx.Done():

--- a/engine.io/v4/client/transport/websocket/transport_test.go
+++ b/engine.io/v4/client/transport/websocket/transport_test.go
@@ -455,6 +455,12 @@ func TestTransport_wsReadLoop(t *testing.T) {
 // TestTransport_wsReadLoop_FullChannel verifies that wsReadLoop does not block
 // forever when the messages channel is full. When ctx is cancelled or a stop
 // signal arrives, the loop must exit via the inner select, not spin forever.
+//
+// The barrier used here is the "receiveWs: %s" log message, which is emitted
+// inside case C of the outer select, immediately before the inner select.
+// Because it is the only 2-argument Debugf call in wsReadLoop, it can be
+// intercepted without ordering ambiguity. Cancelling/stopping only after this
+// barrier guarantees the test actually exercises the inner select's exit path.
 func TestTransport_wsReadLoop_FullChannel(t *testing.T) {
 	t.Parallel()
 
@@ -470,9 +476,11 @@ func TestTransport_wsReadLoop_FullChannel(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		// Use a barrier so we know exactly when Receive has returned and the
-		// goroutine is about to block on the inner select.
-		receiveCalled := make(chan struct{})
+		// receiveWsLogged fires when "receiveWs: %s" is logged — the exact point
+		// between the outer select's case C and the inner select. Only then is
+		// the goroutine guaranteed to be blocked on c.messages <- message inside
+		// the inner select.
+		receiveWsLogged := make(chan struct{})
 
 		// Unbuffered messages channel ensures the inner select blocks.
 		messages := make(chan []byte)
@@ -486,16 +494,18 @@ func TestTransport_wsReadLoop_FullChannel(t *testing.T) {
 			stopPooling: make(chan struct{}, 1),
 		}
 
+		// "receiveWs: %s" is the only 2-arg Debugf in wsReadLoop; intercept it
+		// specifically to avoid any ordering ambiguity with AnyTimes().
+		mockLogger.EXPECT().Debugf("receiveWs: %s", gomock.Any()).DoAndReturn(
+			func(format string, v ...any) { close(receiveWsLogged) },
+		).Times(1)
 		mockLogger.EXPECT().Debugf(gomock.Any()).AnyTimes()
-		mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
 
-		// First Receive closes receiveCalled so the test knows a message is ready.
 		mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(msg *[]byte) error {
 			*msg = []byte("msg")
-			close(receiveCalled)
 			return nil
 		}).Times(1)
-		// After the loop exits via ctx.Done, a second goroutine may still be in Receive.
+		// A background goroutine may still be in Receive after the loop exits.
 		mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(msg *[]byte) error {
 			<-ctx.Done()
 			return ctx.Err()
@@ -506,8 +516,8 @@ func TestTransport_wsReadLoop_FullChannel(t *testing.T) {
 			_ = transport.wsReadLoop()
 		}()
 
-		// Wait until the first Receive has been called (message is ready), then cancel.
-		<-receiveCalled
+		// Wait until we are inside case C, right before the inner select.
+		<-receiveWsLogged
 		cancel()
 
 		select {
@@ -529,7 +539,7 @@ func TestTransport_wsReadLoop_FullChannel(t *testing.T) {
 
 		ctx := context.Background()
 
-		receiveCalled := make(chan struct{})
+		receiveWsLogged := make(chan struct{})
 
 		messages := make(chan []byte)
 		onClose := make(chan error, 1)
@@ -543,27 +553,23 @@ func TestTransport_wsReadLoop_FullChannel(t *testing.T) {
 			stopPooling: stopPooling,
 		}
 
+		mockLogger.EXPECT().Debugf("receiveWs: %s", gomock.Any()).DoAndReturn(
+			func(format string, v ...any) { close(receiveWsLogged) },
+		).Times(1)
 		mockLogger.EXPECT().Debugf(gomock.Any()).AnyTimes()
-		mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
 
 		mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(msg *[]byte) error {
 			*msg = []byte("msg")
-			close(receiveCalled)
 			return nil
 		}).Times(1)
-		// After stop, a second goroutine may still be in Receive — let it block forever
-		// (it gets collected when the test process exits).
-		mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(msg *[]byte) error {
-			<-stopPooling
-			return errors.New("stopped")
-		}).AnyTimes()
 		mockWS.EXPECT().Close().Return(nil).AnyTimes()
 
 		go func() {
 			_ = transport.wsReadLoop()
 		}()
 
-		<-receiveCalled
+		// Wait until we are inside case C, right before the inner select.
+		<-receiveWsLogged
 		stopPooling <- struct{}{}
 
 		select {

--- a/engine.io/v4/client/transport/websocket/transport_test.go
+++ b/engine.io/v4/client/transport/websocket/transport_test.go
@@ -452,6 +452,129 @@ func TestTransport_wsReadLoop(t *testing.T) {
 	})
 }
 
+// TestTransport_wsReadLoop_FullChannel verifies that wsReadLoop does not block
+// forever when the messages channel is full. When ctx is cancelled or a stop
+// signal arrives, the loop must exit via the inner select, not spin forever.
+func TestTransport_wsReadLoop_FullChannel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("context cancelled while messages channel is full", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockWS := mock_engineio_v4_client_transport.NewMockWebSocket(ctrl)
+		mockLogger := mock_engineio_v4_client_transport.NewMockLogger(ctrl)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Use a barrier so we know exactly when Receive has returned and the
+		// goroutine is about to block on the inner select.
+		receiveCalled := make(chan struct{})
+
+		// Unbuffered messages channel ensures the inner select blocks.
+		messages := make(chan []byte)
+		onClose := make(chan error, 1)
+		transport := &Transport{
+			log:         mockLogger,
+			ws:          mockWS,
+			ctx:         ctx,
+			messages:    messages,
+			onClose:     onClose,
+			stopPooling: make(chan struct{}, 1),
+		}
+
+		mockLogger.EXPECT().Debugf(gomock.Any()).AnyTimes()
+		mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+
+		// First Receive closes receiveCalled so the test knows a message is ready.
+		mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(msg *[]byte) error {
+			*msg = []byte("msg")
+			close(receiveCalled)
+			return nil
+		}).Times(1)
+		// After the loop exits via ctx.Done, a second goroutine may still be in Receive.
+		mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(msg *[]byte) error {
+			<-ctx.Done()
+			return ctx.Err()
+		}).AnyTimes()
+		mockWS.EXPECT().Close().Return(nil).AnyTimes()
+
+		go func() {
+			_ = transport.wsReadLoop()
+		}()
+
+		// Wait until the first Receive has been called (message is ready), then cancel.
+		<-receiveCalled
+		cancel()
+
+		select {
+		case err := <-onClose:
+			assert.ErrorIs(t, err, context.Canceled)
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("wsReadLoop blocked indefinitely when messages channel was full and context was cancelled")
+		}
+	})
+
+	t.Run("stop signal while messages channel is full", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockWS := mock_engineio_v4_client_transport.NewMockWebSocket(ctrl)
+		mockLogger := mock_engineio_v4_client_transport.NewMockLogger(ctrl)
+
+		ctx := context.Background()
+
+		receiveCalled := make(chan struct{})
+
+		messages := make(chan []byte)
+		onClose := make(chan error, 1)
+		stopPooling := make(chan struct{}, 1)
+		transport := &Transport{
+			log:         mockLogger,
+			ws:          mockWS,
+			ctx:         ctx,
+			messages:    messages,
+			onClose:     onClose,
+			stopPooling: stopPooling,
+		}
+
+		mockLogger.EXPECT().Debugf(gomock.Any()).AnyTimes()
+		mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+
+		mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(msg *[]byte) error {
+			*msg = []byte("msg")
+			close(receiveCalled)
+			return nil
+		}).Times(1)
+		// After stop, a second goroutine may still be in Receive — let it block forever
+		// (it gets collected when the test process exits).
+		mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(msg *[]byte) error {
+			<-stopPooling
+			return errors.New("stopped")
+		}).AnyTimes()
+		mockWS.EXPECT().Close().Return(nil).AnyTimes()
+
+		go func() {
+			_ = transport.wsReadLoop()
+		}()
+
+		<-receiveCalled
+		stopPooling <- struct{}{}
+
+		select {
+		case err := <-onClose:
+			assert.NoError(t, err)
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("wsReadLoop blocked indefinitely when messages channel was full and stop was signalled")
+		}
+	})
+}
+
 func TestTransport_SendMessage(t *testing.T) {
 	t.Parallel()
 

--- a/socket.io/v5/client/handlers.go
+++ b/socket.io/v5/client/handlers.go
@@ -33,7 +33,9 @@ func (c *Client) onMessage(data []byte) {
 		return
 	}
 
+	c.mutex.RLock()
 	ns := c.namespaces[msg.NS]
+	c.mutex.RUnlock()
 
 	switch msg.Type {
 	case socketio_v5.PacketDisconnect:

--- a/socket.io/v5/client/handlers_test.go
+++ b/socket.io/v5/client/handlers_test.go
@@ -191,6 +191,70 @@ func TestClientOnMessage(t *testing.T) {
 	})
 }
 
+// TestOnMessage_NamespaceLock verifies that onMessage holds c.mutex while reading
+// c.namespaces, preventing a data race with concurrent namespace() calls.
+// Run with -race to detect any violation.
+func TestOnMessage_NamespaceLock(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockParser := mocks.NewMockParser(ctrl)
+	mockLogger := mocks.NewMockLogger(ctrl)
+
+	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+	mockLogger.EXPECT().Infof(gomock.Any(), gomock.Any()).AnyTimes()
+
+	ns := &namespace{handlers: make(map[string][]func([]interface{}))}
+
+	client := &Client{
+		parser:     mockParser,
+		logger:     mockLogger,
+		namespaces: map[string]*namespace{"/": ns},
+	}
+
+	// onMessage reads c.namespaces under c.mutex.RLock (the fix).
+	// namespace() writes c.namespaces under c.mutex.Lock.
+	// Running them concurrently must not trigger the race detector.
+
+	msg := &socketio_v5.Message{
+		NS:    "/",
+		Type:  socketio_v5.PacketEvent,
+		Event: &socketio_v5.Event{Name: "evt"},
+	}
+	mockParser.EXPECT().Parse(gomock.Any()).Return(msg, nil).AnyTimes()
+
+	var wg sync.WaitGroup
+	const iterations = 50
+
+	wg.Add(iterations)
+	for i := 0; i < iterations; i++ {
+		go func() {
+			defer wg.Done()
+			client.onMessage([]byte("data"))
+		}()
+	}
+
+	wg.Add(iterations)
+	for i := 0; i < iterations; i++ {
+		go func() {
+			defer wg.Done()
+			client.namespace("/extra")
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("concurrent onMessage + namespace() timed out")
+	}
+}
+
 func TestClientHandleEvent(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
## Summary

- Fix data race in `socketio_v5_client.Client.onMessage`: the map read
  `c.namespaces[msg.NS]` is now guarded by `c.mutex.RLock/RUnlock`,
  matching the write lock held by `namespace()`. Addresses upstream
  maldikhan/go.socket.io#34.

- Replace the blocking `c.messages <- body` send in the polling
  transport's `poll()` with a `select` that also watches `c.ctx.Done()`.
  If `messageLoop` is temporarily busy (e.g. inside `transportUpgrade`),
  the buffer can fill and the goroutine blocks forever, unable to receive
  a `stopPooling` signal. The non-blocking send lets the goroutine exit
  cleanly.

- Apply the same fix to the websocket transport's `wsReadLoop`: the
  plain `c.messages <- message` send inside the `messageCh` case is
  replaced by a `select` that also watches `c.stopPooling` and
  `c.ctx.Done()`. Addresses upstream maldikhan/go.socket.io#42.

These bugs cause the provider to hang indefinitely waiting for socket.io
events (e.g. `maintenanceList`) that were received at the transport layer
but never dispatched because the transport goroutine was stuck on the
channel send.

Closes breml/terraform-provider-uptimekuma#325

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown so transports exit promptly without deadlocks; shutdown vs. context cancellation are distinguished and callers observe cancellation.
  * WebSocket receive/send paths now abort cleanly on shutdown or context cancellation.
  * Handshake post-connect hook now runs asynchronously to avoid blocking message processing.

* **Chores**
  * Transport initialization now prepares shutdown signaling to support clean stops.

* **Tests**
  * Added tests for stop/cancellation during blocked sends and for concurrent namespace access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maldikhan/go.socket.io/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->