### PR TITLE
test(polling): restore 100% coverage after the bugfix merge wave

### DIFF
--- a/engine.io/v4/client/transport/polling/transport_test.go
+++ b/engine.io/v4/client/transport/polling/transport_test.go
@@ -1147,3 +1147,112 @@ func TestConcurrentSetHandshakeAndBuildUrl(t *testing.T) {
 
 	// If there was a race condition, the race detector would catch it
 }
+
+// ctxCanceledDoneNever is a context whose Done() channel never fires (nil
+// channel) but whose Err() reports a non-nil error. It lets a test drive
+// poll() deterministically to the stopCh branch (since ctx.Done() is never
+// selected) while still making RequestHandshake observe a cancelled context.
+type ctxCanceledDoneNever struct {
+	context.Context
+	err error
+}
+
+func (c ctxCanceledDoneNever) Done() <-chan struct{} { return nil }
+func (c ctxCanceledDoneNever) Err() error            { return c.err }
+
+// TestRequestHandshake_StopWithCancelledContext covers the branch in
+// RequestHandshake where poll() returns errTransportStopped AND the context
+// already carries an error: the public cancellation error from ctx.Err() must
+// be returned (not the context.Canceled fallback).
+func TestRequestHandshake_StopWithCancelledContext(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := mocks.NewMockLogger(ctrl)
+	mockHTTPClient := mocks.NewMockHttpClient(ctrl)
+
+	stopCh := make(chan struct{})
+	close(stopCh) // Stop() already signalled
+
+	client := &Transport{
+		log:         mockLogger,
+		httpClient:  mockHTTPClient,
+		url:         &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
+		ctx:         ctxCanceledDoneNever{Context: context.Background(), err: context.DeadlineExceeded},
+		messages:    make(chan []byte), // unbuffered: the send blocks
+		stopPooling: make(chan struct{}, 1),
+		stopCh:      stopCh,
+	}
+
+	mockLogger.EXPECT().Debugf("run polling")
+	mockLogger.EXPECT().Debugf("receiveHttp: %s", "data")
+
+	mockHTTPClient.EXPECT().Do(gomock.Any()).Return(&http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader("data")),
+	}, nil)
+
+	err := client.RequestHandshake()
+	// The error must come from ctx.Err() (DeadlineExceeded), proving the
+	// ctxErr branch ran rather than the context.Canceled fallback.
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.NotErrorIs(t, err, errTransportStopped)
+}
+
+// TestPollingLoop_StopDuringPoll covers the branch in pollingLoop where the
+// inner poll() returns errTransportStopped (Stop() was signalled while poll was
+// blocked delivering a message): the loop must stop cleanly and notify onClose.
+func TestPollingLoop_StopDuringPoll(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := mocks.NewMockLogger(ctrl)
+	mockHTTPClient := mocks.NewMockHttpClient(ctrl)
+
+	stopCh := make(chan struct{})
+	close(stopCh) // Stop() already signalled
+
+	onClose := make(chan error, 1)
+	client := &Transport{
+		log:         mockLogger,
+		httpClient:  mockHTTPClient,
+		pinger:      time.NewTicker(time.Millisecond),
+		url:         &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
+		ctx:         context.Background(),
+		messages:    make(chan []byte), // unbuffered: poll's send blocks
+		stopPooling: make(chan struct{}, 1),
+		stopCh:      stopCh,
+		onClose:     onClose,
+	}
+
+	mockLogger.EXPECT().Debugf("run polling").AnyTimes()
+	mockLogger.EXPECT().Debugf("receiveHttp: %s", "data").AnyTimes()
+	mockLogger.EXPECT().Debugf("stop polling")
+
+	mockHTTPClient.EXPECT().Do(gomock.Any()).Return(&http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader("data")),
+	}, nil).AnyTimes()
+
+	done := make(chan error, 1)
+	go func() { done <- client.pollingLoop() }()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err) // errTransportStopped is handled internally -> nil
+	case <-time.After(time.Second):
+		t.Fatal("pollingLoop did not stop when poll() was interrupted by Stop()")
+	}
+
+	// onClose is notified with ctx.Err() (nil for a live background context).
+	select {
+	case err := <-onClose:
+		assert.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("pollingLoop did not notify onClose on stop")
+	}
+}

--- a/socket.io/v5/client/client_test.go
+++ b/socket.io/v5/client/client_test.go
@@ -199,13 +199,13 @@ func TestConcurrentConnectAndEmit(t *testing.T) {
 	ctx := context.Background()
 
 	client := &Client{
-		engineio:         mockEngineIO,
-		parser:           mockParser,
-		logger:           mockLogger,
-		ctx:              ctx, // Initialize ctx
-		namespaces:       make(map[string]*namespace),
-		ackCallbacks:     make(map[int]func([]interface{})),
-		handshakeData:    make(map[string]interface{}),
+		engineio:      mockEngineIO,
+		parser:        mockParser,
+		logger:        mockLogger,
+		ctx:           ctx, // Initialize ctx
+		namespaces:    make(map[string]*namespace),
+		ackCallbacks:  make(map[int]func([]interface{})),
+		handshakeData: make(map[string]interface{}),
 	}
 
 	// Create default namespace with a pre-closed waitConnected channel


### PR DESCRIPTION
## Summary

Follow-up to the bug-fix merge wave (#33–#48). The merge of #48 (breml's real-world fix) landed two new branches in `polling/transport.go` that weren't fully exercised, dropping total statement coverage to **99.3%** (`codecov/patch` was red on #48). This PR restores **100%** and cleans up one formatting nit.

## Changes

**`engine.io/v4/client/transport/polling/transport_test.go`** — two deterministic tests for the previously-uncovered branches:

1. `TestRequestHandshake_StopWithCancelledContext` — covers `RequestHandshake` mapping the internal `errTransportStopped` sentinel to `ctx.Err()` when the context is already cancelled (the `return ctxErr` branch, distinct from the `context.Canceled` fallback). Uses a small context shim whose `Done()` never fires but whose `Err()` is non-nil, so `poll()` is driven deterministically to the `stopCh` branch.
2. `TestPollingLoop_StopDuringPoll` — covers `pollingLoop` handling `poll()` returning `errTransportStopped` (Stop() signalled while `poll()` was blocked delivering a message): the loop stops cleanly and notifies `onClose`.

**`socket.io/v5/client/client_test.go`** — `gofmt` alignment of the `TestConcurrentConnectAndEmit` struct literal introduced in #38 (cosmetic; not enforced by CI lint but kept clean).

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test ./... -count=1` — pass; `-race` clean on the polling package
- `go test $(go list ./...|grep -v mocks) -coverprofile=...` → **total: 100.0% (statements)**, no function below 100%
- Zero dependency changes (`go.mod`/`go.sum` untouched); Go 1.18-compatible

## Known follow-ups (not in this PR)
- Strengthen the `afterConnect` deadlock regression test so it actually drives a `Send()` through the gated upgrade path (the current test from #47/#48 verifies the callback runs but does not reproduce the original deadlock).
- Synchronize access to `Client.pingInterval` (written in `handleHandshake`, read/`Stop()`-ed in `Close()`) — a latent `-race`-only issue surfaced while reviewing #45.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gkv7LscaX5vY63HQFudXTi)_