### PR TITLE
[3.4] Validate engine.io packet type range in parser

### DIFF
--- a/engine.io/v4/parser/parser.go
+++ b/engine.io/v4/parser/parser.go
@@ -2,6 +2,7 @@ package engineio_v4_parser
 
 import (
 	"errors"
+	"fmt"
 
 	engineio_v4 "github.com/maldikhan/go.socket.io/engine.io/v4"
 )
@@ -12,8 +13,17 @@ func (p *EngineIOV4Parser) Parse(data []byte) (*engineio_v4.Message, error) {
 	if len(data) == 0 {
 		return nil, errors.New("empty message")
 	}
+	// data[0] is an ASCII digit '0'..'6' (0x30..0x36). Subtracting 0x30 maps it
+	// to the packet type. Any other byte yields a value greater than PacketNoop
+	// (bytes below '0' wrap around in the unsigned subtraction), so a single
+	// upper-bound check rejects every malformed type without a separate
+	// lower-bound test.
+	packetType := engineio_v4.EngineIOPacket(data[0] - 0x30)
+	if packetType > engineio_v4.PacketNoop {
+		return nil, fmt.Errorf("unknown engine.io packet type: 0x%02x", data[0])
+	}
 	return &engineio_v4.Message{
-		Type: engineio_v4.EngineIOPacket(data[0] - 0x30),
+		Type: packetType,
 		Data: data[1:],
 	}, nil
 }

--- a/engine.io/v4/parser/parser_test.go
+++ b/engine.io/v4/parser/parser_test.go
@@ -41,6 +41,18 @@ func TestEngineIOV4Parser_Parse(t *testing.T) {
 			},
 			wantErr: nil,
 		},
+		{
+			name:    "Unknown packet type (above range)",
+			input:   []byte("9data"),
+			want:    nil,
+			wantErr: errors.New("unknown engine.io packet type: 0x39"),
+		},
+		{
+			name:    "Unknown packet type (below range)",
+			input:   []byte(" data"),
+			want:    nil,
+			wantErr: errors.New("unknown engine.io packet type: 0x20"),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Context
`Parse()` in `engine.io/v4/parser/parser.go` converted `data[0]` to an `EngineIOPacket` without validating the resulting value. Unknown packet types silently fell through the `switch` in `handlePacket` with no error.

## Change
After mapping `data[0] - 0x30` to the packet type, reject anything outside the valid range (`0x00` Open … `0x06` Noop) with a clear error:

```
unknown engine.io packet type: 0x39
```

A single upper-bound check (`> PacketNoop`) is sufficient: bytes below `'0'` wrap around in the unsigned `byte` subtraction and land well above `PacketNoop`, so both too-high and too-low inputs are caught.

## Tests
- Added `Parse` cases for an above-range type (`'9'`) and a below-range byte (`0x20`), both expecting the new error.
- Full suite green; `Parse`/`Serialize` at 100% statement coverage.

Closes #24

https://claude.ai/code/session_01Gkv7LscaX5vY63HQFudXTi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gkv7LscaX5vY63HQFudXTi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Engine.IO packet type parsing with stricter validation to reject malformed packet types
  * Enhanced error reporting for unknown packet types, now displaying the offending byte in hexadecimal format for better debugging

* **Tests**
  * Added test cases for unknown packet type handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maldikhan/go.socket.io/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->