### PR TITLE
[3.3] Add default timeout to polling HTTP client

### DIFF
--- a/engine.io/v4/client/transport/polling/constructor.go
+++ b/engine.io/v4/client/transport/polling/constructor.go
@@ -10,11 +10,17 @@ import (
 
 type EngineTransportOption func(*Transport) error
 
+// defaultHTTPTimeout bounds the full lifecycle (dial + TLS + headers + body)
+// of a polling request. Without it, the default http.Client has no timeout and
+// a poll can hang indefinitely on an unstable network, stalling the transport
+// goroutine. Override with WithHTTPClient for custom needs.
+const defaultHTTPTimeout = 30 * time.Second
+
 func NewTransport(options ...EngineTransportOption) (*Transport, error) {
 	// Create default client
 	client := &Transport{
 		log:            &utils.DefaultLogger{},
-		httpClient:     &http.Client{},
+		httpClient:     &http.Client{Timeout: defaultHTTPTimeout},
 		pinger:         time.NewTicker(10 * time.Second),
 		stopPooling:    make(chan struct{}, 1),
 		stopCh:         make(chan struct{}),

--- a/engine.io/v4/client/transport/polling/constructor_test.go
+++ b/engine.io/v4/client/transport/polling/constructor_test.go
@@ -152,6 +152,20 @@ func TestNewTransport(t *testing.T) {
 	}
 }
 
+func TestNewTransport_DefaultHTTPTimeout(t *testing.T) {
+	got, err := NewTransport()
+	if err != nil {
+		t.Fatalf("NewTransport() returned an error: %v", err)
+	}
+	httpClient, ok := got.httpClient.(*http.Client)
+	if !ok {
+		t.Fatalf("NewTransport() httpClient is not *http.Client")
+	}
+	if httpClient.Timeout != defaultHTTPTimeout {
+		t.Errorf("NewTransport() default httpClient.Timeout = %v, want %v", httpClient.Timeout, defaultHTTPTimeout)
+	}
+}
+
 func TestWithLogger(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
## Context
The default `http.Client{}` in `polling/constructor.go` had no timeout. On an unstable network a polling request can hang indefinitely, blocking the transport goroutine.

## Change
Default to `&http.Client{Timeout: 30 * time.Second}` (named `defaultHTTPTimeout`). The timeout covers the full request lifecycle (dial + TLS + headers + body). `WithHTTPClient(...)` continues to allow custom clients/overrides.

30s comfortably exceeds the engine.io long-poll cycle (pingInterval 25s / pingTimeout 20s), so it bounds hangs without cutting healthy long-polls.

## Tests
- Added `TestNewTransport_DefaultHTTPTimeout` asserting the default client's `Timeout`.
- `NewTransport` at 100% coverage; full suite green.

Closes #23

https://claude.ai/code/session_01Gkv7LscaX5vY63HQFudXTi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gkv7LscaX5vY63HQFudXTi)_