### PR TITLE
[5.2] Make engine.io serialize payload limit configurable

### DIFF
--- a/engine.io/v4/parser/parser.go
+++ b/engine.io/v4/parser/parser.go
@@ -6,7 +6,44 @@ import (
 	engineio_v4 "github.com/maldikhan/go.socket.io/engine.io/v4"
 )
 
-type EngineIOV4Parser struct{}
+// defaultMaxSerializeSize is the outbound payload limit applied when none is
+// configured. It mirrors the inbound default and guards against accidentally
+// serializing pathologically large frames.
+const defaultMaxSerializeSize = 64 * 1024 * 1024 // 64 MB
+
+type EngineIOV4Parser struct {
+	// maxSerializeSize caps the size of msg.Data accepted by Serialize().
+	// A value <= 0 means "use defaultMaxSerializeSize", which keeps the
+	// zero value (&EngineIOV4Parser{}) behaving exactly as before.
+	maxSerializeSize int64
+}
+
+// ParserOption configures an EngineIOV4Parser built with NewEngineIOV4Parser.
+type ParserOption func(*EngineIOV4Parser) error
+
+// NewEngineIOV4Parser builds a parser with the given options. With no options
+// it is equivalent to &EngineIOV4Parser{} and uses the default limits.
+func NewEngineIOV4Parser(options ...ParserOption) (*EngineIOV4Parser, error) {
+	p := &EngineIOV4Parser{maxSerializeSize: defaultMaxSerializeSize}
+	for _, opt := range options {
+		if err := opt(p); err != nil {
+			return nil, err
+		}
+	}
+	return p, nil
+}
+
+// WithMaxSerializeSize sets the maximum outbound payload size (in bytes)
+// accepted by Serialize(). The size must be positive.
+func WithMaxSerializeSize(size int64) ParserOption {
+	return func(p *EngineIOV4Parser) error {
+		if size <= 0 {
+			return errors.New("maxSerializeSize must be positive")
+		}
+		p.maxSerializeSize = size
+		return nil
+	}
+}
 
 func (p *EngineIOV4Parser) Parse(data []byte) (*engineio_v4.Message, error) {
 	if len(data) == 0 {
@@ -19,7 +56,11 @@ func (p *EngineIOV4Parser) Parse(data []byte) (*engineio_v4.Message, error) {
 }
 
 func (p *EngineIOV4Parser) Serialize(msg *engineio_v4.Message) ([]byte, error) {
-	if len(msg.Data) > 64*1024*1024 { // 64 MB limit
+	limit := p.maxSerializeSize
+	if limit <= 0 {
+		limit = defaultMaxSerializeSize
+	}
+	if int64(len(msg.Data)) > limit {
 		return nil, errors.New("message data too large")
 	}
 	packet := make([]byte, 1, len(msg.Data)+1)

--- a/engine.io/v4/parser/parser_test.go
+++ b/engine.io/v4/parser/parser_test.go
@@ -122,3 +122,60 @@ func TestEngineIOV4Parser_Serialize(t *testing.T) {
 		})
 	}
 }
+
+func TestNewEngineIOV4Parser(t *testing.T) {
+	t.Run("Default limit", func(t *testing.T) {
+		p, err := NewEngineIOV4Parser()
+		assert.NoError(t, err)
+		assert.Equal(t, int64(defaultMaxSerializeSize), p.maxSerializeSize)
+	})
+
+	t.Run("Custom limit", func(t *testing.T) {
+		p, err := NewEngineIOV4Parser(WithMaxSerializeSize(1024))
+		assert.NoError(t, err)
+		assert.Equal(t, int64(1024), p.maxSerializeSize)
+	})
+
+	t.Run("Invalid limit propagates error", func(t *testing.T) {
+		p, err := NewEngineIOV4Parser(WithMaxSerializeSize(0))
+		assert.Error(t, err)
+		assert.Nil(t, p)
+	})
+}
+
+func TestWithMaxSerializeSize(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		p := &EngineIOV4Parser{}
+		assert.NoError(t, WithMaxSerializeSize(2048)(p))
+		assert.Equal(t, int64(2048), p.maxSerializeSize)
+	})
+
+	t.Run("Zero", func(t *testing.T) {
+		assert.Error(t, WithMaxSerializeSize(0)(&EngineIOV4Parser{}))
+	})
+
+	t.Run("Negative", func(t *testing.T) {
+		assert.Error(t, WithMaxSerializeSize(-1)(&EngineIOV4Parser{}))
+	})
+}
+
+func TestEngineIOV4Parser_Serialize_CustomLimit(t *testing.T) {
+	p, err := NewEngineIOV4Parser(WithMaxSerializeSize(4))
+	assert.NoError(t, err)
+
+	// Within the custom limit.
+	got, err := p.Serialize(&engineio_v4.Message{
+		Type: engineio_v4.EngineIOPacket(4),
+		Data: []byte("ok"),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("4ok"), got)
+
+	// Exceeds the custom limit.
+	_, err = p.Serialize(&engineio_v4.Message{
+		Type: engineio_v4.EngineIOPacket(4),
+		Data: []byte("toolong"),
+	})
+	assert.Error(t, err)
+	assert.Equal(t, "message data too large", err.Error())
+}


### PR DESCRIPTION
## Context
The 64MB outbound payload limit in `EngineIOV4Parser.Serialize()` was hardcoded, while the inbound limit (item 1.7 / #39) is configurable. This adds symmetry.

## Change
- Add `maxSerializeSize int64` field, a `NewEngineIOV4Parser(...)` constructor, and a `WithMaxSerializeSize(size int64)` option (rejects non-positive sizes).
- `Serialize()` uses the configured limit, falling back to the 64MB default when `maxSerializeSize <= 0`. This keeps the bare `&EngineIOV4Parser{}` (used internally and in tests) behaving exactly as before — no breaking change.

## Tests
- `NewEngineIOV4Parser` (default / custom / option-error), `WithMaxSerializeSize` (valid / zero / negative), and `Serialize` under and over a custom limit.
- All four functions at 100% coverage; full suite green.

Closes #30

https://claude.ai/code/session_01Gkv7LscaX5vY63HQFudXTi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gkv7LscaX5vY63HQFudXTi)_