### PR TITLE
[5.1] Add payload redaction mode for production logging

### DIFF
--- a/engine.io/v4/client/client.go
+++ b/engine.io/v4/client/client.go
@@ -46,6 +46,22 @@ type Client struct {
 	// On() writes them from the user goroutine, while handlePacket()
 	// and handleHandshake() read them from the transport goroutine.
 	handlerMu sync.RWMutex
+
+	// redactPayload, when true, replaces raw packet payloads in debug logs
+	// with a size marker so production logs never leak message contents
+	// (tokens, PII). The zero value is "don't redact" (verbose); NewClient
+	// sets the production-safe default and WithDebugPayload(true) disables it.
+	redactPayload bool
+}
+
+// payload returns a size marker for debug logging when payload redaction is
+// enabled, or the raw data otherwise. The packet type/prefix stays visible
+// either way.
+func (c *Client) payload(data []byte) string {
+	if c.redactPayload {
+		return fmt.Sprintf("[redacted %d bytes]", len(data))
+	}
+	return string(data)
 }
 
 func (c *Client) Connect(ctx context.Context) error {
@@ -161,7 +177,7 @@ func (c *Client) transportUpgrade(transport Transport) error {
 }
 
 func (c *Client) handleHandshake(data []byte) error {
-	c.log.Debugf("apply handshake: %s", string(data))
+	c.log.Debugf("apply handshake: %s", c.payload(data))
 
 	handshakeResp := &engineio_v4.HandshakeResponse{}
 	err := json.Unmarshal(data, handshakeResp)
@@ -244,14 +260,14 @@ func (c *Client) handleHandshake(data []byte) error {
 }
 
 func (c *Client) handlePacket(packetData []byte) error {
-	c.log.Debugf("handle packet: %s", string(packetData))
+	c.log.Debugf("handle packet: %s", c.payload(packetData))
 	packet, err := c.parser.Parse(packetData)
 	if err != nil {
 		c.log.Errorf("Can't parse packet: %s %v", string(packetData), err)
 		return err
 	}
 
-	c.log.Debugf("handle: %d %s", packet.Type, packet.Data)
+	c.log.Debugf("handle: %d %s", packet.Type, c.payload(packet.Data))
 
 	switch packet.Type {
 	case engineio_v4.PacketOpen:

--- a/engine.io/v4/client/client_test.go
+++ b/engine.io/v4/client/client_test.go
@@ -1067,3 +1067,18 @@ func TestClient_On_concurrent(t *testing.T) {
 		"At least some handlers should have been called")
 	mu.Unlock()
 }
+
+func TestClient_payloadRedaction(t *testing.T) {
+	c := &Client{redactPayload: true}
+	assert.Equal(t, "[redacted 5 bytes]", c.payload([]byte("hello")))
+	c.redactPayload = false
+	assert.Equal(t, "hello", c.payload([]byte("hello")))
+}
+
+func TestClient_WithDebugPayload(t *testing.T) {
+	c := &Client{}
+	assert.NoError(t, WithDebugPayload(true)(c))
+	assert.False(t, c.redactPayload)
+	assert.NoError(t, WithDebugPayload(false)(c))
+	assert.True(t, c.redactPayload)
+}

--- a/engine.io/v4/client/constructor.go
+++ b/engine.io/v4/client/constructor.go
@@ -25,6 +25,7 @@ func NewClient(options ...EngineClientOption) (*Client, error) {
 		pingInterval:      time.NewTicker(10 * time.Second),
 		stopPooling:       make(chan struct{}, 1),
 		transportClosed:   make(chan error, 1),
+		redactPayload:     true, // production-safe default; WithDebugPayload(true) opts out
 	}
 
 	for _, opt := range options {
@@ -48,10 +49,12 @@ func NewClient(options ...EngineClientOption) (*Client, error) {
 	if len(client.supportedTransports) == 0 {
 		wsTransport, _ := engineio_v4_client_transport_ws.NewTransport(
 			engineio_v4_client_transport_ws.WithLogger(client.log),
+			engineio_v4_client_transport_ws.WithDebugPayload(!client.redactPayload),
 		)
 		pollingTransport, _ := engineio_v4_client_transport_polling.NewTransport(
 			engineio_v4_client_transport_polling.WithDefaultPinger(client.pingInterval),
 			engineio_v4_client_transport_polling.WithLogger(client.log),
+			engineio_v4_client_transport_polling.WithDebugPayload(!client.redactPayload),
 		)
 		if client.supportedTransports == nil {
 			client.supportedTransports = make(map[engineio_v4.EngineIOTransport]Transport)
@@ -148,6 +151,15 @@ func WithReconnectAttempts(attempts int) EngineClientOption {
 func WithReconnectWait(wait time.Duration) EngineClientOption {
 	return func(c *Client) error {
 		c.reconnectWait = wait
+		return nil
+	}
+}
+
+// WithDebugPayload enables logging of raw packet payloads at debug level.
+// It is disabled by default so production logs do not leak message contents.
+func WithDebugPayload(enabled bool) EngineClientOption {
+	return func(c *Client) error {
+		c.redactPayload = !enabled
 		return nil
 	}
 }

--- a/engine.io/v4/client/transport/polling/constructor.go
+++ b/engine.io/v4/client/transport/polling/constructor.go
@@ -25,6 +25,7 @@ func NewTransport(options ...EngineTransportOption) (*Transport, error) {
 		stopPooling:    make(chan struct{}, 1),
 		stopCh:         make(chan struct{}),
 		maxPayloadSize: 4 * 1024 * 1024, // 4MB default, matches socket.io JS maxHttpBufferSize
+		redactPayload:  true,            // production-safe default; WithDebugPayload(true) opts out
 	}
 
 	// Apply options
@@ -77,6 +78,15 @@ func WithMaxPayloadSize(size int64) EngineTransportOption {
 			return errors.New("maxPayloadSize must be positive")
 		}
 		c.maxPayloadSize = size
+		return nil
+	}
+}
+
+// WithDebugPayload enables logging of raw payloads at debug level.
+// Disabled by default so production logs don't leak message contents.
+func WithDebugPayload(enabled bool) EngineTransportOption {
+	return func(c *Transport) error {
+		c.redactPayload = !enabled
 		return nil
 	}
 }

--- a/engine.io/v4/client/transport/polling/transport.go
+++ b/engine.io/v4/client/transport/polling/transport.go
@@ -50,6 +50,18 @@ type Transport struct {
 	// mu guards the sid field, which is written by SetHandshake()/Run() and
 	// read by buildHttpUrl() from the polling goroutine.
 	mu sync.RWMutex
+
+	// redactPayload, when true, replaces raw payloads in debug logs with a
+	// size marker. Zero value is verbose; NewTransport sets the safe default.
+	redactPayload bool
+}
+
+// payload returns a size marker when redaction is enabled, or the raw data.
+func (c *Transport) payload(data []byte) string {
+	if c.redactPayload {
+		return fmt.Sprintf("[redacted %d bytes]", len(data))
+	}
+	return string(data)
 }
 
 func (c *Transport) SetHandshake(handshake *engineio_v4.HandshakeResponse) {
@@ -240,7 +252,7 @@ func (c *Transport) poll() error {
 		return fmt.Errorf("inbound payload size %d exceeds maximum allowed %d", len(body), c.maxPayloadSize)
 	}
 
-	c.log.Debugf("receiveHttp: %s", string(body))
+	c.log.Debugf("receiveHttp: %s", c.payload(body))
 
 	select {
 	case c.messages <- body:
@@ -257,7 +269,7 @@ func (c *Transport) poll() error {
 
 func (c *Transport) SendMessage(msg []byte) error {
 
-	c.log.Debugf("sendHttp: %s", msg)
+	c.log.Debugf("sendHttp: %s", c.payload(msg))
 	req, err := http.NewRequestWithContext(c.ctx, "POST", c.buildHttpUrl().String(), bytes.NewReader(msg))
 	if err != nil {
 		return fmt.Errorf("error creating request: %w", err)

--- a/engine.io/v4/client/transport/polling/transport_test.go
+++ b/engine.io/v4/client/transport/polling/transport_test.go
@@ -723,7 +723,7 @@ func TestSendMessage(t *testing.T) {
 		ctx:        ctx,
 	}
 
-	mockLogger.EXPECT().Debugf("sendHttp: %s", []byte("test message")).Times(2)
+	mockLogger.EXPECT().Debugf("sendHttp: %s", "test message").Times(2)
 	mockLogger.EXPECT().Debugf("receiveHttp: %s", "200 OK")
 
 	mockResp := &http.Response{
@@ -771,7 +771,7 @@ func TestSendMessage(t *testing.T) {
 			ctx:        ctx,
 		}
 
-		mockLogger.EXPECT().Debugf("sendHttp: %s", []byte("test message"))
+		mockLogger.EXPECT().Debugf("sendHttp: %s", "test message")
 
 		expectedError := errors.New("network error")
 
@@ -803,7 +803,7 @@ func TestSendMessage(t *testing.T) {
 			ctx:        ctx,
 		}
 
-		mockLogger.EXPECT().Debugf("sendHttp: %s", []byte("test message"))
+		mockLogger.EXPECT().Debugf("sendHttp: %s", "test message")
 		mockLogger.EXPECT().Debugf("receiveHttp: %s", "200 OK")
 
 		// Track if the body was closed
@@ -1255,4 +1255,19 @@ func TestPollingLoop_StopDuringPoll(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("pollingLoop did not notify onClose on stop")
 	}
+}
+
+func TestTransport_payloadRedaction(t *testing.T) {
+	c := &Transport{redactPayload: true}
+	assert.Equal(t, "[redacted 5 bytes]", c.payload([]byte("hello")))
+	c.redactPayload = false
+	assert.Equal(t, "hello", c.payload([]byte("hello")))
+}
+
+func TestTransport_WithDebugPayload(t *testing.T) {
+	c := &Transport{}
+	assert.NoError(t, WithDebugPayload(true)(c))
+	assert.False(t, c.redactPayload)
+	assert.NoError(t, WithDebugPayload(false)(c))
+	assert.True(t, c.redactPayload)
 }

--- a/engine.io/v4/client/transport/websocket/constructor.go
+++ b/engine.io/v4/client/transport/websocket/constructor.go
@@ -13,9 +13,10 @@ type EngineTransportOption func(*Transport) error
 func NewTransport(options ...EngineTransportOption) (*Transport, error) {
 	// Создаем клиент с настройками по умолчанию
 	client := &Transport{
-		log:         &utils.DefaultLogger{},
-		ws:          &ws_native.WebSocketConnection{},
-		stopPooling: make(chan struct{}, 1),
+		log:           &utils.DefaultLogger{},
+		ws:            &ws_native.WebSocketConnection{},
+		stopPooling:   make(chan struct{}, 1),
+		redactPayload: true, // production-safe default; WithDebugPayload(true) opts out
 	}
 
 	// Применяем пользовательские настройки
@@ -53,6 +54,15 @@ func WithWebSocket(ws WebSocket) EngineTransportOption {
 func WithOrigin(origin *url.URL) EngineTransportOption {
 	return func(c *Transport) error {
 		c.origin = origin
+		return nil
+	}
+}
+
+// WithDebugPayload enables logging of raw payloads at debug level.
+// Disabled by default so production logs don't leak message contents.
+func WithDebugPayload(enabled bool) EngineTransportOption {
+	return func(c *Transport) error {
+		c.redactPayload = !enabled
 		return nil
 	}
 }

--- a/engine.io/v4/client/transport/websocket/transport.go
+++ b/engine.io/v4/client/transport/websocket/transport.go
@@ -2,6 +2,7 @@ package engineio_v4_client_transport
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"sync"
 
@@ -21,6 +22,18 @@ type Transport struct {
 	onClose     chan<- error
 	stopPooling chan struct{}
 	mu          sync.RWMutex
+
+	// redactPayload, when true, replaces raw payloads in debug logs with a
+	// size marker. Zero value is verbose; NewTransport sets the safe default.
+	redactPayload bool
+}
+
+// payload returns a size marker when redaction is enabled, or the raw data.
+func (c *Transport) payload(data []byte) string {
+	if c.redactPayload {
+		return fmt.Sprintf("[redacted %d bytes]", len(data))
+	}
+	return string(data)
 }
 
 func (c *Transport) Transport() engineio_v4.EngineIOTransport {
@@ -170,7 +183,7 @@ func (c *Transport) wsReadLoop() error {
 
 		case message := <-messageCh:
 			// New message received
-			c.log.Debugf("receiveWs: %s", message)
+			c.log.Debugf("receiveWs: %s", c.payload(message))
 			select {
 			case c.messages <- message:
 			case <-c.stopPooling:
@@ -202,6 +215,6 @@ func (c *Transport) wsReadLoop() error {
 }
 
 func (c *Transport) SendMessage(msg []byte) error {
-	c.log.Debugf("sendWs: %s", string(msg))
+	c.log.Debugf("sendWs: %s", c.payload(msg))
 	return c.ws.Send(msg)
 }

--- a/engine.io/v4/client/transport/websocket/transport_test.go
+++ b/engine.io/v4/client/transport/websocket/transport_test.go
@@ -1276,3 +1276,18 @@ func TestConcurrentSetHandshakeAndBuildUrl(t *testing.T) {
 
 	// If there was a race condition, the race detector would catch it
 }
+
+func TestTransport_payloadRedaction(t *testing.T) {
+	c := &Transport{redactPayload: true}
+	assert.Equal(t, "[redacted 5 bytes]", c.payload([]byte("hello")))
+	c.redactPayload = false
+	assert.Equal(t, "hello", c.payload([]byte("hello")))
+}
+
+func TestTransport_WithDebugPayload(t *testing.T) {
+	c := &Transport{}
+	assert.NoError(t, WithDebugPayload(true)(c))
+	assert.False(t, c.redactPayload)
+	assert.NoError(t, WithDebugPayload(false)(c))
+	assert.True(t, c.redactPayload)
+}

--- a/socket.io/v5/client/client.go
+++ b/socket.io/v5/client/client.go
@@ -2,6 +2,7 @@ package socketio_v5_client
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	socketio_v5 "github.com/maldikhan/go.socket.io/socket.io/v5"
@@ -23,6 +24,18 @@ type Client struct {
 
 	ackCallbacks map[int]func([]interface{})
 	ackCounter   int
+
+	// redactPayload, when true, replaces raw payloads in debug logs with a
+	// size marker. Zero value is verbose; NewClient sets the safe default.
+	redactPayload bool
+}
+
+// payload returns a size marker when redaction is enabled, or the raw data.
+func (c *Client) payload(data []byte) string {
+	if c.redactPayload {
+		return fmt.Sprintf("[redacted %d bytes]", len(data))
+	}
+	return string(data)
 }
 
 type namespace struct {

--- a/socket.io/v5/client/client_test.go
+++ b/socket.io/v5/client/client_test.go
@@ -315,3 +315,18 @@ func TestConcurrentSetHandshakeDataAndConnect(t *testing.T) {
 	<-done
 	<-done
 }
+
+func TestClient_payloadRedaction(t *testing.T) {
+	c := &Client{redactPayload: true}
+	assert.Equal(t, "[redacted 5 bytes]", c.payload([]byte("hello")))
+	c.redactPayload = false
+	assert.Equal(t, "hello", c.payload([]byte("hello")))
+}
+
+func TestClient_WithDebugPayload(t *testing.T) {
+	c := &InitClient{Client: &Client{}}
+	assert.NoError(t, WithDebugPayload(true)(c))
+	assert.False(t, c.redactPayload)
+	assert.NoError(t, WithDebugPayload(false)(c))
+	assert.True(t, c.redactPayload)
+}

--- a/socket.io/v5/client/constructor.go
+++ b/socket.io/v5/client/constructor.go
@@ -27,8 +27,9 @@ func NewClient(options ...ClientOption) (*Client, error) {
 			namespaces:    make(map[string]*namespace),
 			ackCallbacks:  make(map[int]func([]interface{})),
 
-			logger: &utils.DefaultLogger{},
-			timer:  &utils.DefaultTimer{},
+			logger:        &utils.DefaultLogger{},
+			timer:         &utils.DefaultTimer{},
+			redactPayload: true, // production-safe default; WithDebugPayload(true) opts out
 		},
 	}
 
@@ -60,6 +61,7 @@ func NewClient(options ...ClientOption) (*Client, error) {
 		engineioClient, err := engineio_v4_client.NewClient(
 			engineio_v4_client.WithURL(client.url),
 			engineio_v4_client.WithLogger(client.logger),
+			engineio_v4_client.WithDebugPayload(!client.redactPayload),
 		)
 		if err != nil {
 			return nil, err
@@ -134,6 +136,16 @@ func WithTimer(timer Timer) ClientOption {
 func WithParser(parser Parser) ClientOption {
 	return func(c *InitClient) error {
 		c.parser = parser
+		return nil
+	}
+}
+
+// WithDebugPayload enables logging of raw payloads at debug level across the
+// client and the default transports it builds. Disabled by default so
+// production logs do not leak message contents (tokens, PII).
+func WithDebugPayload(enabled bool) ClientOption {
+	return func(c *InitClient) error {
+		c.redactPayload = !enabled
 		return nil
 	}
 }

--- a/socket.io/v5/client/handlers.go
+++ b/socket.io/v5/client/handlers.go
@@ -25,7 +25,7 @@ func (n *namespace) OnAny(handler func(string, []interface{})) {
 }
 
 func (c *Client) onMessage(data []byte) {
-	c.logger.Debugf("socketio receive %s", string(data))
+	c.logger.Debugf("socketio receive %s", c.payload(data))
 
 	msg, err := c.parser.Parse(data)
 	if err != nil {


### PR DESCRIPTION
## Context
Debug-level logs printed raw packet payloads (e.g. `handle packet: <full body>`, `receiveWs: <body>`, `socketio receive <body>`). In production this can leak auth tokens, user data, or PII into log aggregation systems.

## Change
Payload bodies in debug logs are now **redacted by default** to a size marker (e.g. `handle packet: [redacted 1234 bytes]`); the packet **type/prefix stays visible** for debugging. Verbose logging is opt-in via `WithDebugPayload(true)`, available on:

- the socket.io client (`socket.io/v5/client`)
- the engine.io client (`engine.io/v4/client`)
- both transports (polling, websocket)

A single `socketio.WithDebugPayload(true)` **propagates** down the default construction chain (socket.io client → engine.io client → default ws/polling transports), so you can flip verbose logging on in one place.

### Design note
Internally each component carries a `redactPayload` flag whose **zero value is "verbose"**, so existing direct `&Transport{}` / `&Client{}` construction (used throughout the tests) is unchanged. Every **public constructor** sets the production-safe redacting default, and `WithDebugPayload(enabled)` maps to `redactPayload = !enabled`. The public contract matches the issue: the option defaults to disabled → payloads redacted.

## Tests
- Per-component unit tests for the `payload()` helper (both branches) and `WithDebugPayload` (true/false).
- Existing payload-logging mock expectations preserved (verbose) via zero-value semantics; the polling `sendHttp` expectations were updated from `[]byte` to the `%s` string form now produced by the helper.
- Full suite green; **overall coverage 100.0%**.

Closes #29

https://claude.ai/code/session_01Gkv7LscaX5vY63HQFudXTi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gkv7LscaX5vY63HQFudXTi)_