### PR TITLE
[5.3] Add Docker-based E2E tests against a real Socket.IO server

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,46 @@
+name: E2E
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  integration:
+    name: Integration (Docker)
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: stable
+        check-latest: true
+
+    - name: Cache Go modules
+      uses: actions/cache@v4
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-e2e-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-e2e-
+
+    - name: Start Socket.IO servers
+      run: docker compose -f e2e/docker-compose.yml up -d --build --wait
+
+    - name: Run E2E tests
+      env:
+        E2E_SERVER_URL: http://localhost:3000
+        E2E_SERVER_URL_POLLING: http://localhost:3001
+      run: go test -tags e2e -v ./e2e/...
+
+    - name: Server logs on failure
+      if: failure()
+      run: docker compose -f e2e/docker-compose.yml logs
+
+    - name: Teardown
+      if: always()
+      run: docker compose -f e2e/docker-compose.yml down -v

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 .fleet
 coverage.*
 *.sarif
+
+# e2e Node server dependencies / lockfile (installed in CI/Docker)
+e2e/server/node_modules/
+e2e/server/package-lock.json

--- a/Makefile
+++ b/Makefile
@@ -18,5 +18,11 @@ test:
 	golangci-lint run ./...	
 bench:
 	go test -bench=. ./... -benchmem
+integration-test:
+	docker compose -f e2e/docker-compose.yml up -d --build --wait
+	E2E_SERVER_URL=http://localhost:3000 E2E_SERVER_URL_POLLING=http://localhost:3001 \
+		go test -tags e2e -v ./e2e/... ; status=$$? ; \
+		docker compose -f e2e/docker-compose.yml down -v ; \
+		exit $$status
 act-ci-test:
 	DOCKER_HOST=`docker context inspect --format '{{.Endpoints.docker.Host}}'` act

--- a/e2e/doc.go
+++ b/e2e/doc.go
@@ -1,0 +1,13 @@
+// Package e2e contains end-to-end integration tests that run the Go client
+// against a real Socket.IO server.
+//
+// The tests are guarded by the "e2e" build tag, so they are excluded from the
+// default `go test ./...` run (and therefore from the unit-test coverage gate).
+// Run them with a reachable server via:
+//
+//	make integration-test
+//
+// or, against an already-running server, with:
+//
+//	E2E_SERVER_URL=http://localhost:3000 go test -tags e2e ./e2e/...
+package e2e

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  # Default server: advertises websocket upgrades (exercises polling->ws
+  # upgrade and websocket-only connections).
+  socketio-server:
+    build:
+      context: ./server
+    image: go-socketio-e2e-server
+    ports:
+      - "3000:3000"
+    environment:
+      PORT: "3000"
+      ALLOW_UPGRADES: "true"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/socket.io/?EIO=4&transport=polling"]
+      interval: 2s
+      timeout: 3s
+      retries: 15
+
+  # Polling-only server: no upgrades advertised (exercises pure long-polling).
+  socketio-server-polling:
+    image: go-socketio-e2e-server
+    depends_on:
+      - socketio-server
+    ports:
+      - "3001:3001"
+    environment:
+      PORT: "3001"
+      ALLOW_UPGRADES: "false"
+      PING_INTERVAL: "500"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3001/socket.io/?EIO=4&transport=polling"]
+      interval: 2s
+      timeout: 3s
+      retries: 15

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,0 +1,174 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	engineio "github.com/maldikhan/go.socket.io/engine.io/v4/client"
+	polling "github.com/maldikhan/go.socket.io/engine.io/v4/client/transport/polling"
+	ws "github.com/maldikhan/go.socket.io/engine.io/v4/client/transport/websocket"
+	socketio "github.com/maldikhan/go.socket.io/socket.io/v5/client"
+	"github.com/maldikhan/go.socket.io/socket.io/v5/client/emit"
+)
+
+// serverURL returns the address of the default (upgrade-capable) Socket.IO
+// server under test.
+func serverURL() string {
+	if u := os.Getenv("E2E_SERVER_URL"); u != "" {
+		return u
+	}
+	return "http://localhost:3000"
+}
+
+// pollingServerURL returns the address of the polling-only server (no websocket
+// upgrade advertised), used by the polling-only scenario.
+func pollingServerURL() string {
+	if u := os.Getenv("E2E_SERVER_URL_POLLING"); u != "" {
+		return u
+	}
+	return "http://localhost:3001"
+}
+
+// newClient builds a socket.io client constrained to the given transport mode:
+//   - "default":   polling with automatic upgrade to websocket
+//   - "polling":   HTTP long-polling only (no upgrade offered)
+//   - "websocket": websocket only (connects directly, no polling phase)
+func newClient(t *testing.T, mode string) *socketio.Client {
+	t.Helper()
+	url := serverURL()
+	if mode == "polling" {
+		url = pollingServerURL()
+	}
+
+	if mode == "default" {
+		client, err := socketio.NewClient(socketio.WithRawURL(url))
+		if err != nil {
+			t.Fatalf("new default client: %v", err)
+		}
+		return client
+	}
+
+	var primary engineio.Transport
+	switch mode {
+	case "polling":
+		pt, err := polling.NewTransport()
+		if err != nil {
+			t.Fatalf("new polling transport: %v", err)
+		}
+		primary = pt
+	case "websocket":
+		wt, err := ws.NewTransport()
+		if err != nil {
+			t.Fatalf("new websocket transport: %v", err)
+		}
+		primary = wt
+	default:
+		t.Fatalf("unknown transport mode %q", mode)
+	}
+
+	// The engine.io client (unlike the socket.io client) does not inject the
+	// default "/socket.io/" path, so add it explicitly when building a client
+	// directly from a transport.
+	engineURL := strings.TrimRight(url, "/") + "/socket.io/"
+	engine, err := engineio.NewClient(
+		engineio.WithRawURL(engineURL),
+		engineio.WithSupportedTransports([]engineio.Transport{primary}),
+		engineio.WithTransport(primary),
+	)
+	if err != nil {
+		t.Fatalf("new engine client (%s): %v", mode, err)
+	}
+
+	client, err := socketio.NewClient(socketio.WithEngineIOClient(engine))
+	if err != nil {
+		t.Fatalf("new socket.io client (%s): %v", mode, err)
+	}
+	return client
+}
+
+// runScenario exercises the core protocol surface: connect, a server-pushed
+// event, an acknowledgement round-trip, and a clean disconnect.
+func runScenario(t *testing.T, client *socketio.Client) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	welcome := make(chan string, 1)
+	client.On("welcome", func(msg string) {
+		select {
+		case welcome <- msg:
+		default:
+		}
+	})
+
+	// Detect connection via the "connect" event (zero-arg handler, matching the
+	// documented usage) registered before Connect so it is never missed.
+	connected := make(chan struct{}, 1)
+	client.On("connect", func() {
+		select {
+		case connected <- struct{}{}:
+		default:
+		}
+	})
+
+	if err := client.Connect(ctx); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer client.Close()
+
+	select {
+	case <-connected:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for connect event")
+	}
+
+	// Server-pushed event: emit "hello", expect a "welcome" back.
+	if err := client.Emit("hello", "world"); err != nil {
+		t.Fatalf("emit hello: %v", err)
+	}
+	select {
+	case msg := <-welcome:
+		if msg != "hello world" {
+			t.Fatalf("welcome payload = %q, want %q", msg, "hello world")
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for welcome event")
+	}
+
+	// Acknowledgement round-trip: emit "echo" with an ack callback.
+	ack := make(chan string, 1)
+	if err := client.Emit("echo", "ping", emit.WithAck(func(s string) {
+		select {
+		case ack <- s:
+		default:
+		}
+	})); err != nil {
+		t.Fatalf("emit echo: %v", err)
+	}
+	select {
+	case s := <-ack:
+		if s != "ping" {
+			t.Fatalf("ack payload = %q, want %q", s, "ping")
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for ack")
+	}
+}
+
+func TestE2E_DefaultTransport(t *testing.T) {
+	runScenario(t, newClient(t, "default"))
+}
+
+func TestE2E_PollingOnly(t *testing.T) {
+	runScenario(t, newClient(t, "polling"))
+}
+
+func TestE2E_WebsocketOnly(t *testing.T) {
+	runScenario(t, newClient(t, "websocket"))
+}

--- a/e2e/server/Dockerfile
+++ b/e2e/server/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+# Install dependencies first to leverage Docker layer caching.
+COPY package.json ./
+RUN npm install --omit=dev
+
+COPY index.js ./
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=2s --timeout=3s --retries=15 \
+  CMD wget -qO- "http://localhost:3000/socket.io/?EIO=4&transport=polling" >/dev/null 2>&1 || exit 1
+
+CMD ["node", "index.js"]

--- a/e2e/server/index.js
+++ b/e2e/server/index.js
@@ -1,0 +1,46 @@
+'use strict';
+
+// Minimal Socket.IO 4.x server used by the Go end-to-end tests.
+// Exercises: connect, server-pushed events, acknowledgements and namespaces,
+// over both HTTP long-polling and WebSocket (with upgrade enabled).
+
+const { Server } = require('socket.io');
+
+const PORT = parseInt(process.env.PORT || '3000', 10);
+// When ALLOW_UPGRADES=false the server advertises no upgrades, so a
+// polling-only client is never offered a websocket upgrade. This is used by
+// the dedicated polling-only test instance.
+const ALLOW_UPGRADES = (process.env.ALLOW_UPGRADES || 'true') !== 'false';
+// The Go polling transport fetches data once per ping interval, so a short
+// interval keeps server->client latency low for the polling-only test.
+const PING_INTERVAL = parseInt(process.env.PING_INTERVAL || '25000', 10);
+
+const io = new Server(PORT, {
+  cors: { origin: '*' },
+  allowUpgrades: ALLOW_UPGRADES,
+  transports: ALLOW_UPGRADES ? ['polling', 'websocket'] : ['polling'],
+  pingInterval: PING_INTERVAL,
+});
+
+function wire(socket, ns) {
+  // "echo" replies through the ack callback with the same payload.
+  socket.on('echo', (msg, ack) => {
+    if (typeof ack === 'function') {
+      ack(msg);
+    }
+  });
+
+  // "hello" triggers a server-pushed "welcome" event.
+  socket.on('hello', (name) => {
+    socket.emit('welcome', 'hello ' + name);
+  });
+
+  // eslint-disable-next-line no-console
+  console.log('client connected on namespace ' + ns + ': ' + socket.id);
+}
+
+io.on('connection', (socket) => wire(socket, '/'));
+io.of('/admin').on('connection', (socket) => wire(socket, '/admin'));
+
+// eslint-disable-next-line no-console
+console.log('socket.io e2e server listening on port ' + PORT + ' (upgrades=' + ALLOW_UPGRADES + ')');

--- a/e2e/server/package.json
+++ b/e2e/server/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "go-socketio-e2e-server",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Socket.IO 4.x server for go.socket.io end-to-end tests",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "socket.io": "^4.7.0"
+  }
+}


### PR DESCRIPTION
## Context
All tests were mock-based; nothing exercised the client against a real Socket.IO server, so protocol-level regressions (framing, keepalive, upgrade, acks) could slip through.

## Change
Adds a Docker-based end-to-end suite:

- **`e2e/server/`** — a `socket.io@4` Node server: `echo` (ack round-trip), `hello`→`welcome` (server-pushed event), and an `/admin` namespace. Parameterized by `PORT` / `ALLOW_UPGRADES` / `PING_INTERVAL`.
- **`e2e/docker-compose.yml`** — two services: the default server (advertises websocket upgrade) on `:3000`, and a polling-only server (no upgrades advertised) on `:3001`.
- **`e2e/e2e_test.go`** — core scenario (connect → server-pushed event → ack → disconnect) run across a **transport matrix**: default (polling→ws upgrade), polling-only, websocket-only. Guarded by the **`e2e` build tag**, so it is excluded from the default `go test ./...` and from the unit-coverage gate; the package stays valid via `doc.go`.
- **`Makefile`** `integration-test` target (compose up `--wait` → test → teardown) and a dedicated **`.github/workflows/e2e.yaml`** CI job (Docker is available on `ubuntu-latest`).

All three transport scenarios pass locally against the Node server.

## Findings surfaced by the E2E suite (out of scope for this PR)
The harness immediately caught two real client behaviors, worth separate issues:

1. **Polling-only against an upgrade-advertising server hangs.** When the handshake offers a `websocket` upgrade the client can't perform, `waitUpgrade` is never published, so the socket.io CONNECT `Send()` blocks forever. Worked around here by giving the polling-only test a server with `allowUpgrades:false`.
2. **The polling transport fetches data only once per ping interval** (`pollingLoop` polls on the pinger tick), so server→client latency can be up to `pingInterval`. Worked around by setting the polling test server's `pingInterval` to 500ms; the test still genuinely exercises the long-polling path.

These are noted so they can be tracked; happy to open issues if you'd like.

## Notes
- No new Go dependencies; `go.mod` unchanged. `e2e/server/node_modules` and the npm lockfile are git-ignored.
- Unit suite and `go vet ./...` unaffected (e2e is tag-gated).

Closes #31

https://claude.ai/code/session_01Gkv7LscaX5vY63HQFudXTi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gkv7LscaX5vY63HQFudXTi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test suite validating Socket.IO protocol across multiple transport modes.

* **Chores**
  * Added automated testing infrastructure with Docker containerization and GitHub Actions CI/CD integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/maldikhan/go.socket.io/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->