### PR TITLE
Fix HTTP long-polling: poll continuously instead of once per ping interval

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -34,7 +34,6 @@ jobs:
     - name: Run E2E tests
       env:
         E2E_SERVER_URL: http://localhost:3000
-        E2E_SERVER_URL_POLLING: http://localhost:3001
       run: go test -tags e2e -v ./e2e/...
 
     - name: Server logs on failure

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ bench:
 	go test -bench=. ./... -benchmem
 integration-test:
 	docker compose -f e2e/docker-compose.yml up -d --build --wait
-	E2E_SERVER_URL=http://localhost:3000 E2E_SERVER_URL_POLLING=http://localhost:3001 \
+	E2E_SERVER_URL=http://localhost:3000 \
 		go test -tags e2e -v ./e2e/... ; status=$$? ; \
 		docker compose -f e2e/docker-compose.yml down -v ; \
 		exit $$status

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -26,7 +26,6 @@ services:
     environment:
       PORT: "3001"
       ALLOW_UPGRADES: "false"
-      PING_INTERVAL: "500"
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:3001/socket.io/?EIO=4&transport=polling"]
       interval: 2s

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
-  # Default server: advertises websocket upgrades (exercises polling->ws
-  # upgrade and websocket-only connections).
+  # Socket.IO server that advertises websocket upgrades. Every transport mode
+  # (polling-only, websocket-only, polling->websocket upgrade) is tested against
+  # this single realistic endpoint.
   socketio-server:
     build:
       context: ./server
@@ -9,25 +10,8 @@ services:
       - "3000:3000"
     environment:
       PORT: "3000"
-      ALLOW_UPGRADES: "true"
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:3000/socket.io/?EIO=4&transport=polling"]
-      interval: 2s
-      timeout: 3s
-      retries: 15
-
-  # Polling-only server: no upgrades advertised (exercises pure long-polling).
-  socketio-server-polling:
-    image: go-socketio-e2e-server
-    depends_on:
-      - socketio-server
-    ports:
-      - "3001:3001"
-    environment:
-      PORT: "3001"
-      ALLOW_UPGRADES: "false"
-    healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3001/socket.io/?EIO=4&transport=polling"]
       interval: 2s
       timeout: 3s
       retries: 15

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -16,8 +16,9 @@ import (
 	"github.com/maldikhan/go.socket.io/socket.io/v5/client/emit"
 )
 
-// serverURL returns the address of the default (upgrade-capable) Socket.IO
-// server under test.
+// serverURL returns the address of the Socket.IO server under test (a single
+// server that advertises a websocket upgrade, so every transport mode is
+// exercised against the same realistic endpoint).
 func serverURL() string {
 	if u := os.Getenv("E2E_SERVER_URL"); u != "" {
 		return u
@@ -25,25 +26,15 @@ func serverURL() string {
 	return "http://localhost:3000"
 }
 
-// pollingServerURL returns the address of the polling-only server (no websocket
-// upgrade advertised), used by the polling-only scenario.
-func pollingServerURL() string {
-	if u := os.Getenv("E2E_SERVER_URL_POLLING"); u != "" {
-		return u
-	}
-	return "http://localhost:3001"
-}
-
-// newClient builds a socket.io client constrained to the given transport mode:
+// newClient builds a socket.io client constrained to the given transport mode,
+// all against the same upgrade-advertising server:
 //   - "default":   polling with automatic upgrade to websocket
-//   - "polling":   HTTP long-polling only (no upgrade offered)
+//   - "polling":   HTTP long-polling only (no upgrade performed, even though the
+//     server offers one)
 //   - "websocket": websocket only (connects directly, no polling phase)
 func newClient(t *testing.T, mode string) *socketio.Client {
 	t.Helper()
 	url := serverURL()
-	if mode == "polling" {
-		url = pollingServerURL()
-	}
 
 	if mode == "default" {
 		client, err := socketio.NewClient(socketio.WithRawURL(url))

--- a/e2e/server/index.js
+++ b/e2e/server/index.js
@@ -11,8 +11,7 @@ const PORT = parseInt(process.env.PORT || '3000', 10);
 // polling-only client is never offered a websocket upgrade. This is used by
 // the dedicated polling-only test instance.
 const ALLOW_UPGRADES = (process.env.ALLOW_UPGRADES || 'true') !== 'false';
-// The Go polling transport fetches data once per ping interval, so a short
-// interval keeps server->client latency low for the polling-only test.
+// Server keepalive ping interval; defaults to the Socket.IO default (25s).
 const PING_INTERVAL = parseInt(process.env.PING_INTERVAL || '25000', 10);
 
 const io = new Server(PORT, {

--- a/e2e/server/index.js
+++ b/e2e/server/index.js
@@ -7,18 +7,12 @@
 const { Server } = require('socket.io');
 
 const PORT = parseInt(process.env.PORT || '3000', 10);
-// When ALLOW_UPGRADES=false the server advertises no upgrades, so a
-// polling-only client is never offered a websocket upgrade. This is used by
-// the dedicated polling-only test instance.
-const ALLOW_UPGRADES = (process.env.ALLOW_UPGRADES || 'true') !== 'false';
-// Server keepalive ping interval; defaults to the Socket.IO default (25s).
-const PING_INTERVAL = parseInt(process.env.PING_INTERVAL || '25000', 10);
 
 const io = new Server(PORT, {
   cors: { origin: '*' },
-  allowUpgrades: ALLOW_UPGRADES,
-  transports: ALLOW_UPGRADES ? ['polling', 'websocket'] : ['polling'],
-  pingInterval: PING_INTERVAL,
+  // Offer both transports so the client can connect polling-only,
+  // websocket-only, or start on polling and upgrade.
+  transports: ['polling', 'websocket'],
 });
 
 function wire(socket, ns) {
@@ -42,4 +36,4 @@ io.on('connection', (socket) => wire(socket, '/'));
 io.of('/admin').on('connection', (socket) => wire(socket, '/admin'));
 
 // eslint-disable-next-line no-console
-console.log('socket.io e2e server listening on port ' + PORT + ' (upgrades=' + ALLOW_UPGRADES + ')');
+console.log('socket.io e2e server listening on port ' + PORT);

--- a/engine.io/v4/client/client.go
+++ b/engine.io/v4/client/client.go
@@ -231,7 +231,7 @@ func (c *Client) handleHandshake(data []byte) error {
 
 				break
 			} else {
-				c.log.Warnf("unsupported upgrade: %s", handshakeResp.Upgrades[0])
+				c.log.Warnf("unsupported upgrade: %s", newTransportName)
 			}
 		}
 	}

--- a/engine.io/v4/client/client_test.go
+++ b/engine.io/v4/client/client_test.go
@@ -437,17 +437,20 @@ func TestClient_handleHandshake(t *testing.T) {
 	})
 
 	t.Run("Successful handshake with wrong upgrade", func(t *testing.T) {
+		// Multiple unsupported upgrades: each must be logged by its own name
+		// (regression guard — the warning previously always logged Upgrades[0]).
 		handshakeResp := &engineio_v4.HandshakeResponse{
 			Sid:          "test-sid",
 			PingInterval: 25000,
 			PingTimeout:  5000,
-			Upgrades:     []string{"xyz"},
+			Upgrades:     []string{"xyz", "abc"},
 		}
 		data, _ := json.Marshal(handshakeResp)
 
 		mockTransportPolling.EXPECT().SetHandshake(handshakeResp)
 		mockTransportWs.EXPECT().SetHandshake(handshakeResp)
 		mockLogger.EXPECT().Warnf("unsupported upgrade: %s", "xyz")
+		mockLogger.EXPECT().Warnf("unsupported upgrade: %s", "abc")
 
 		client.hadHandshake = sync.Once{}
 		client.waitHandshake = make(chan struct{})

--- a/engine.io/v4/client/transport/polling/constructor.go
+++ b/engine.io/v4/client/transport/polling/constructor.go
@@ -24,8 +24,9 @@ func NewTransport(options ...EngineTransportOption) (*Transport, error) {
 		pinger:         time.NewTicker(10 * time.Second),
 		stopPooling:    make(chan struct{}, 1),
 		stopCh:         make(chan struct{}),
-		maxPayloadSize: 4 * 1024 * 1024, // 4MB default, matches socket.io JS maxHttpBufferSize
-		redactPayload:  true,            // production-safe default; WithDebugPayload(true) opts out
+		maxPayloadSize:   4 * 1024 * 1024, // 4MB default, matches socket.io JS maxHttpBufferSize
+		redactPayload:    true,            // production-safe default; WithDebugPayload(true) opts out
+		pollErrorBackoff: defaultPollErrorBackoff,
 	}
 
 	// Apply options

--- a/engine.io/v4/client/transport/polling/transport.go
+++ b/engine.io/v4/client/transport/polling/transport.go
@@ -44,12 +44,14 @@ type Transport struct {
 	reqCtx     context.Context
 	pollCancel context.CancelFunc
 
-	// handshakeDone is closed by SetHandshake once the engine.io handshake has
-	// assigned a session id. The continuous polling loop waits on it so it never
-	// issues a GET while RequestHandshake()'s own poll is in flight — engine.io
-	// rejects two concurrent polls on the same session.
+	// handshakeDone gates the continuous polling loop until a session id is
+	// known, so it never issues a GET while RequestHandshake()'s own poll is in
+	// flight — engine.io rejects two concurrent polls on the same session. It is
+	// closed by SetHandshake(), or immediately by Run() when the session id is
+	// already known (e.g. this transport is the target of an upgrade), so the
+	// gate is order-independent and can't deadlock if SetHandshake() happens to
+	// run before Run(). Guarded by mu.
 	handshakeDone chan struct{}
-	handshakeOnce sync.Once
 
 	// stopCh is closed by Stop() to broadcast the stop signal to any goroutine
 	// currently blocked inside poll(). Using a closed channel (instead of a
@@ -92,8 +94,23 @@ func (c *Transport) SetHandshake(handshake *engineio_v4.HandshakeResponse) {
 	}
 	c.pinger.Reset(pingInterval)
 	// Release the polling loop now that a session id is available.
-	if c.handshakeDone != nil {
-		c.handshakeOnce.Do(func() { close(c.handshakeDone) })
+	c.mu.Lock()
+	c.markHandshakeDoneLocked()
+	c.mu.Unlock()
+}
+
+// markHandshakeDoneLocked closes the handshake gate exactly once. The caller
+// must hold c.mu. It is a no-op if the gate has not been allocated yet (Run()
+// not called) or is already closed.
+func (c *Transport) markHandshakeDoneLocked() {
+	if c.handshakeDone == nil {
+		return
+	}
+	select {
+	case <-c.handshakeDone:
+		// already closed
+	default:
+		close(c.handshakeDone)
 	}
 }
 
@@ -128,15 +145,20 @@ func (c *Transport) Run(
 	c.reqCtx, c.pollCancel = context.WithCancel(ctx)
 	c.mu.Lock()
 	c.sid = sid
+	// Fresh handshake gate for this run. If a session id is already known (e.g.
+	// this transport is the target of an upgrade, where SetHandshake() has
+	// already run with handshakeDone still nil), open it immediately so
+	// pollingLoop never waits for a SetHandshake() that won't come again.
+	c.handshakeDone = make(chan struct{})
+	if sid != "" {
+		c.markHandshakeDoneLocked()
+	}
 	c.mu.Unlock()
 	c.url = url
 	c.messages = messagesChan
 	c.onClose = onClose
 	// Reset the stop state so the transport can be safely reused after a Stop().
 	atomic.StoreUint32(&c.stopped, 0)
-	// Fresh handshake gate for this run.
-	c.handshakeDone = make(chan struct{})
-	c.handshakeOnce = sync.Once{}
 	// Reinitialize stopPooling channel to ensure fresh channel for new run.
 	c.stopPooling = make(chan struct{}, 1)
 	// Reinitialize the stop broadcast channel and its sync.Once as well —
@@ -197,9 +219,12 @@ func (c *Transport) pollingLoop() error {
 	// earlier would race RequestHandshake()'s poll and trigger a concurrent-poll
 	// rejection from the server. A nil gate (transport driven without Run, e.g.
 	// in unit tests) means "already handshaked".
-	if c.handshakeDone != nil {
+	c.mu.RLock()
+	gate := c.handshakeDone
+	c.mu.RUnlock()
+	if gate != nil {
 		select {
-		case <-c.handshakeDone:
+		case <-gate:
 		case <-c.stopPooling:
 			return c.finishPolling(true, nil)
 		case <-c.ctx.Done():

--- a/engine.io/v4/client/transport/polling/transport.go
+++ b/engine.io/v4/client/transport/polling/transport.go
@@ -37,6 +37,20 @@ type Transport struct {
 	onClose     chan<- error
 	stopPooling chan struct{}
 
+	// reqCtx scopes the in-flight poll/handshake HTTP request. It is derived
+	// from the run context in Run() and cancelled by Stop(), so Stop() can
+	// interrupt a long-poll GET that the server is holding open (e.g. during a
+	// polling->websocket upgrade) instead of waiting up to one ping interval.
+	reqCtx     context.Context
+	pollCancel context.CancelFunc
+
+	// handshakeDone is closed by SetHandshake once the engine.io handshake has
+	// assigned a session id. The continuous polling loop waits on it so it never
+	// issues a GET while RequestHandshake()'s own poll is in flight — engine.io
+	// rejects two concurrent polls on the same session.
+	handshakeDone chan struct{}
+	handshakeOnce sync.Once
+
 	// stopCh is closed by Stop() to broadcast the stop signal to any goroutine
 	// currently blocked inside poll(). Using a closed channel (instead of a
 	// buffered send) means both poll() and pollingLoop can observe the stop
@@ -46,6 +60,10 @@ type Transport struct {
 
 	stopped        uint32 // atomic; 0 = running, 1 = stopped
 	maxPayloadSize int64
+
+	// pollErrorBackoff is the pause after a failed poll before retrying, so a
+	// persistently failing server does not turn the loop into a hot spin.
+	pollErrorBackoff time.Duration
 
 	// mu guards the sid field, which is written by SetHandshake()/Run() and
 	// read by buildHttpUrl() from the polling goroutine.
@@ -73,6 +91,10 @@ func (c *Transport) SetHandshake(handshake *engineio_v4.HandshakeResponse) {
 		pingInterval = time.Duration(handshake.PingInterval) * time.Millisecond
 	}
 	c.pinger.Reset(pingInterval)
+	// Release the polling loop now that a session id is available.
+	if c.handshakeDone != nil {
+		c.handshakeOnce.Do(func() { close(c.handshakeDone) })
+	}
 }
 
 func (c *Transport) RequestHandshake() error {
@@ -101,6 +123,9 @@ func (c *Transport) Run(
 	onClose chan<- error,
 ) error {
 	c.ctx = ctx
+	// Derive a request-scoped context that Stop() can cancel independently of
+	// the parent context, so an in-flight long-poll can be interrupted promptly.
+	c.reqCtx, c.pollCancel = context.WithCancel(ctx)
 	c.mu.Lock()
 	c.sid = sid
 	c.mu.Unlock()
@@ -109,6 +134,9 @@ func (c *Transport) Run(
 	c.onClose = onClose
 	// Reset the stop state so the transport can be safely reused after a Stop().
 	atomic.StoreUint32(&c.stopped, 0)
+	// Fresh handshake gate for this run.
+	c.handshakeDone = make(chan struct{})
+	c.handshakeOnce = sync.Once{}
 	// Reinitialize stopPooling channel to ensure fresh channel for new run.
 	c.stopPooling = make(chan struct{}, 1)
 	// Reinitialize the stop broadcast channel and its sync.Once as well —
@@ -136,9 +164,13 @@ func (c *Transport) Stop() error {
 		return nil
 	}
 	// Close stopCh to broadcast the stop signal to any poll() call that is
-	// currently blocked sending to c.messages. sync.Once guarantees we only
-	// close once even if Stop() is called from multiple goroutines.
+	// currently blocked sending to c.messages, and cancel reqCtx to interrupt a
+	// poll that is blocked waiting for the server's long-poll response. sync.Once
+	// guarantees we only do this once even if Stop() is called concurrently.
 	c.stopOnce.Do(func() {
+		if c.pollCancel != nil {
+			c.pollCancel()
+		}
 		close(c.stopCh)
 	})
 	// Non-blocking send: if pollingLoop already exited (e.g. via
@@ -151,42 +183,82 @@ func (c *Transport) Stop() error {
 	return nil
 }
 
+// defaultPollErrorBackoff is the default pause after a failed poll before
+// retrying (see Transport.pollErrorBackoff).
+const defaultPollErrorBackoff = time.Second
+
+// pollingLoop continuously long-polls the server. Each poll() issues a GET that
+// the server holds open until it has data (or sends a keepalive ping), then the
+// loop immediately issues the next one. This keeps server->client latency low,
+// independent of the ping interval; a successful poll returns quickly when data
+// is queued and otherwise blocks until the server responds.
 func (c *Transport) pollingLoop() error {
-	for {
+	// Wait for the handshake to assign a session id before polling. Polling
+	// earlier would race RequestHandshake()'s poll and trigger a concurrent-poll
+	// rejection from the server. A nil gate (transport driven without Run, e.g.
+	// in unit tests) means "already handshaked".
+	if c.handshakeDone != nil {
 		select {
-		case _, ok := <-c.pinger.C:
-			if !ok {
-				c.log.Warnf("pinger closed: stop pooling")
-				return errors.New("pinger closed")
-			}
-			err := c.poll()
-			if errors.Is(err, errTransportStopped) {
-				c.log.Debugf("stop polling")
-				atomic.StoreUint32(&c.stopped, 1)
-				if c.onClose != nil {
-					c.onClose <- c.ctx.Err()
-				}
-				return nil
-			}
-			if err != nil {
-				c.log.Errorf("poll error: %s", err)
-			}
+		case <-c.handshakeDone:
 		case <-c.stopPooling:
-			c.log.Debugf("stop polling")
-			atomic.StoreUint32(&c.stopped, 1)
-			if c.onClose != nil {
-				c.onClose <- c.ctx.Err()
-			}
-			return nil
+			return c.finishPolling(true, nil)
 		case <-c.ctx.Done():
-			c.log.Debugf("context done, stop http polling")
-			atomic.StoreUint32(&c.stopped, 1)
-			if c.onClose != nil {
-				c.onClose <- c.ctx.Err()
-			}
-			return c.ctx.Err()
+			return c.finishPolling(false, c.ctx.Err())
 		}
 	}
+
+	for {
+		// Honor a stop/cancel requested between polls before issuing a new GET.
+		select {
+		case <-c.stopPooling:
+			return c.finishPolling(true, nil)
+		case <-c.ctx.Done():
+			return c.finishPolling(false, c.ctx.Err())
+		default:
+		}
+
+		err := c.poll()
+		if errors.Is(err, errTransportStopped) {
+			return c.finishPolling(true, nil)
+		}
+		if err != nil {
+			// A request cancelled by Stop() (reqCtx) or by the parent context is
+			// a normal shutdown, not a transport error.
+			if atomic.LoadUint32(&c.stopped) == 1 {
+				return c.finishPolling(true, nil)
+			}
+			if c.ctx.Err() != nil {
+				return c.finishPolling(false, c.ctx.Err())
+			}
+			// Genuine transient error (network blip, server hiccup): log and back
+			// off briefly, but stay responsive to stop/cancel during the pause.
+			c.log.Errorf("poll error: %s", err)
+			select {
+			case <-time.After(c.pollErrorBackoff):
+			case <-c.stopPooling:
+				return c.finishPolling(true, nil)
+			case <-c.ctx.Done():
+				return c.finishPolling(false, c.ctx.Err())
+			}
+		}
+	}
+}
+
+// finishPolling performs the shared loop teardown: it marks the transport
+// stopped and notifies the engine client (onClose always carries the run
+// context's error — nil for an upgrade/Stop-driven exit, the cancellation cause
+// for a context shutdown). stopRequested selects the matching debug log.
+func (c *Transport) finishPolling(stopRequested bool, ret error) error {
+	if stopRequested {
+		c.log.Debugf("stop polling")
+	} else {
+		c.log.Debugf("context done, stop http polling")
+	}
+	atomic.StoreUint32(&c.stopped, 1)
+	if c.onClose != nil {
+		c.onClose <- c.ctx.Err()
+	}
+	return ret
 }
 
 func (c *Transport) buildHttpUrl() *url.URL {
@@ -218,7 +290,14 @@ func (c *Transport) poll() error {
 		return errors.New("messages channel is nil")
 	}
 
-	req, err := http.NewRequestWithContext(c.ctx, "GET", c.buildHttpUrl().String(), nil)
+	// Use the request-scoped context so Stop() can cancel a long-poll that the
+	// server is holding open. Fall back to the run context when the transport is
+	// driven directly (e.g. in unit tests) without Run() setting reqCtx.
+	reqCtx := c.reqCtx
+	if reqCtx == nil {
+		reqCtx = c.ctx
+	}
+	req, err := http.NewRequestWithContext(reqCtx, "GET", c.buildHttpUrl().String(), nil)
 	if err != nil {
 		return fmt.Errorf("error creating request: %w", err)
 	}
@@ -228,6 +307,14 @@ func (c *Transport) poll() error {
 		return err
 	}
 	defer resp.Body.Close() //nolint:errcheck
+
+	// A non-2xx response (e.g. 400 "Session ID unknown" after the session was
+	// dropped) is surfaced as an error so the loop backs off instead of
+	// forwarding the error body as an engine.io packet and hot-spinning.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("unexpected polling response status %d", resp.StatusCode)
+	}
 
 	// Limit payload size to guard against OOM from a malicious/buggy server.
 	// maxPayloadSize <= 0 means unlimited (e.g. a Transport built directly

--- a/engine.io/v4/client/transport/polling/transport_test.go
+++ b/engine.io/v4/client/transport/polling/transport_test.go
@@ -1579,3 +1579,61 @@ func TestTransport_WithDebugPayload(t *testing.T) {
 	assert.NoError(t, WithDebugPayload(false)(c))
 	assert.True(t, c.redactPayload)
 }
+
+// TestHandshakeGateUpgradeToPolling is a regression guard: when polling is the
+// target of an upgrade, the engine client calls SetHandshake() on it (a no-op
+// while handshakeDone is still nil) before Run(), and Run() receives a known
+// session id. The gate must open from Run() so pollingLoop does not deadlock
+// waiting for a SetHandshake() that will not come again.
+func TestHandshakeGateUpgradeToPolling(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := mocks.NewMockLogger(ctrl)
+	mockHttpClient := mocks.NewMockHttpClient(ctrl)
+	mockLogger.EXPECT().Debugf(gomock.Any()).AnyTimes()
+	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
+
+	polled := make(chan struct{})
+	var once sync.Once
+	mockHttpClient.EXPECT().Do(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
+		once.Do(func() { close(polled) })
+		<-req.Context().Done()
+		return nil, req.Context().Err()
+	}).AnyTimes()
+
+	transport := &Transport{
+		log:        mockLogger,
+		httpClient: mockHttpClient,
+		pinger:     time.NewTicker(time.Minute),
+	}
+
+	// SetHandshake happens first, while handshakeDone is still nil (no-op).
+	transport.SetHandshake(&engineio_v4.HandshakeResponse{Sid: "known-sid", PingInterval: 1000})
+	transport.mu.RLock()
+	preRunGate := transport.handshakeDone
+	transport.mu.RUnlock()
+	assert.Nil(t, preRunGate, "handshakeDone must not be allocated before Run()")
+
+	// The upgrade then runs the transport with the known session id.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	onClose := make(chan error, 1)
+	err := transport.Run(ctx, &url.URL{Scheme: "http", Host: "localhost", Path: "/socket.io/"}, "known-sid", make(chan []byte, 1), onClose)
+	assert.NoError(t, err)
+
+	// pollingLoop must reach poll() instead of blocking on the gate.
+	select {
+	case <-polled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("pollingLoop deadlocked on handshake gate after upgrade-to-polling")
+	}
+
+	assert.NoError(t, transport.Stop())
+	select {
+	case <-onClose:
+	case <-time.After(time.Second):
+		t.Fatal("expected onClose after Stop")
+	}
+}

--- a/engine.io/v4/client/transport/polling/transport_test.go
+++ b/engine.io/v4/client/transport/polling/transport_test.go
@@ -37,6 +37,28 @@ func TestSetHandshake(t *testing.T) {
 	assert.NotNil(t, client.pinger)
 }
 
+func TestSetHandshakeReleasesGate(t *testing.T) {
+	t.Parallel()
+	client := &Transport{
+		pinger:        time.NewTicker(time.Minute),
+		handshakeDone: make(chan struct{}),
+	}
+
+	client.SetHandshake(&engineio_v4.HandshakeResponse{Sid: "sid", PingInterval: 1000})
+
+	select {
+	case <-client.handshakeDone:
+		// gate released as expected
+	default:
+		t.Fatal("SetHandshake did not close the handshake gate")
+	}
+
+	// A second call must not panic on the already-closed gate.
+	assert.NotPanics(t, func() {
+		client.SetHandshake(&engineio_v4.HandshakeResponse{Sid: "sid2", PingInterval: 1000})
+	})
+}
+
 func TestRequestHandshake(t *testing.T) {
 	t.Parallel()
 	ctrl := gomock.NewController(t)
@@ -239,16 +261,14 @@ func TestPollingLoop(t *testing.T) {
 
 		client := &Transport{
 			log:         mockLogger,
-			pinger:      time.NewTicker(time.Minute),
 			stopPooling: make(chan struct{}),
 			ctx:         ctx,
 			onClose:     make(chan error, 1),
 		}
 
-		go func() {
-			time.Sleep(10 * time.Millisecond)
-			close(client.stopPooling)
-		}()
+		// A stop requested before the loop issues a poll exits cleanly without
+		// touching the network.
+		close(client.stopPooling)
 
 		err := client.pollingLoop()
 		assert.NoError(t, err)
@@ -264,21 +284,14 @@ func TestPollingLoop(t *testing.T) {
 		mockLogger.EXPECT().Debugf("context done, stop http polling")
 
 		ctx, cancel := context.WithCancel(context.Background())
-		ctx, timeout := context.WithTimeout(ctx, 5*time.Second)
-		defer timeout()
+		cancel() // cancelled before the loop runs
 
 		client := &Transport{
 			log:         mockLogger,
-			pinger:      time.NewTicker(time.Minute),
 			stopPooling: make(chan struct{}),
 			ctx:         ctx,
 			onClose:     make(chan error, 1),
 		}
-
-		go func() {
-			time.Sleep(10 * time.Millisecond)
-			cancel()
-		}()
 
 		err := client.pollingLoop()
 		assert.Error(t, err)
@@ -309,15 +322,16 @@ func TestPollingLoop(t *testing.T) {
 
 		onClose := make(chan error, 1)
 		client := &Transport{
-			url:         &url.URL{Scheme: "http", Host: "localhost"},
-			httpClient:  mockHttpClient,
-			log:         mockLogger,
-			pinger:      time.NewTicker(10 * time.Millisecond),
-			stopPooling: make(chan struct{}, 1),
-			stopCh:      make(chan struct{}),
-			ctx:         ctx,
-			onClose:     onClose,
-			messages:    make(chan []byte, 1),
+			url:              &url.URL{Scheme: "http", Host: "localhost"},
+			httpClient:       mockHttpClient,
+			log:              mockLogger,
+			pinger:           time.NewTicker(10 * time.Millisecond),
+			stopPooling:      make(chan struct{}, 1),
+			stopCh:           make(chan struct{}),
+			ctx:              ctx,
+			onClose:          onClose,
+			messages:         make(chan []byte, 1),
+			pollErrorBackoff: time.Second, // long enough that Stop() interrupts the backoff
 		}
 
 		go func() {
@@ -352,7 +366,7 @@ func TestPollingLoop(t *testing.T) {
 
 	})
 
-	t.Run("Ping interval closed chan", func(t *testing.T) {
+	t.Run("Stop interrupts in-flight poll", func(t *testing.T) {
 		t.Parallel()
 
 		ctrl := gomock.NewController(t)
@@ -361,24 +375,285 @@ func TestPollingLoop(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		tickerChan := make(chan time.Time)
-		close(tickerChan)
-		ticker := &time.Ticker{
-			C: tickerChan,
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockHttpClient := mocks.NewMockHttpClient(ctrl)
+		mockLogger.EXPECT().Debugf("run polling").MinTimes(1)
+		mockLogger.EXPECT().Debugf("stop polling").MinTimes(1)
+
+		// Do blocks until the request context is cancelled, simulating a
+		// long-poll that the server holds open. Stop() must interrupt it via
+		// reqCtx rather than waiting for a response.
+		mockHttpClient.EXPECT().Do(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		}).MinTimes(1)
+
+		onClose := make(chan error, 1)
+		client := &Transport{
+			url:         &url.URL{Scheme: "http", Host: "localhost"},
+			httpClient:  mockHttpClient,
+			log:         mockLogger,
+			stopPooling: make(chan struct{}, 1),
+			stopCh:      make(chan struct{}),
+			ctx:         ctx,
+			onClose:     onClose,
+			messages:    make(chan []byte, 1),
 		}
+		// Run() normally wires these; set them up directly for the unit test.
+		client.reqCtx, client.pollCancel = context.WithCancel(ctx)
+
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			assert.NoError(t, client.Stop())
+		}()
+
+		err := client.pollingLoop()
+		assert.NoError(t, err)
+
+		select {
+		case e := <-onClose:
+			assert.NoError(t, e) // parent ctx still alive -> nil
+		case <-time.After(100 * time.Millisecond):
+			assert.Fail(t, "expected onClose")
+		}
+	})
+
+	t.Run("Waits for handshake before polling", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
 
 		mockLogger := mocks.NewMockLogger(ctrl)
-		mockLogger.EXPECT().Warnf("pinger closed: stop pooling")
+		mockHttpClient := mocks.NewMockHttpClient(ctrl)
+		mockLogger.EXPECT().Debugf("run polling").MinTimes(1)
+		mockLogger.EXPECT().Debugf("stop polling").MinTimes(1)
+
+		polled := make(chan struct{})
+		var polledOnce sync.Once
+		mockHttpClient.EXPECT().Do(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
+			polledOnce.Do(func() { close(polled) })
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		}).MinTimes(1)
 
 		client := &Transport{
-			log:         mockLogger,
-			pinger:      ticker,
-			stopPooling: make(chan struct{}),
-			ctx:         ctx,
+			url:           &url.URL{Scheme: "http", Host: "localhost"},
+			httpClient:    mockHttpClient,
+			log:           mockLogger,
+			stopPooling:   make(chan struct{}, 1),
+			stopCh:        make(chan struct{}),
+			ctx:           ctx,
+			onClose:       make(chan error, 1),
+			messages:      make(chan []byte, 1),
+			handshakeDone: make(chan struct{}),
+		}
+		client.reqCtx, client.pollCancel = context.WithCancel(ctx)
+
+		exited := make(chan error, 1)
+		go func() { exited <- client.pollingLoop() }()
+
+		// No poll must happen until the handshake gate is released.
+		select {
+		case <-polled:
+			assert.Fail(t, "polled before handshake completed")
+		case <-time.After(20 * time.Millisecond):
+		}
+
+		close(client.handshakeDone)
+
+		select {
+		case <-polled:
+		case <-time.After(time.Second):
+			assert.Fail(t, "expected a poll after handshake")
+		}
+
+		assert.NoError(t, client.Stop())
+		select {
+		case err := <-exited:
+			assert.NoError(t, err)
+		case <-time.After(time.Second):
+			assert.Fail(t, "pollingLoop did not exit")
+		}
+	})
+
+	t.Run("Stop during handshake wait", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockLogger.EXPECT().Debugf("stop polling")
+
+		client := &Transport{
+			log:           mockLogger,
+			stopPooling:   make(chan struct{}, 1),
+			ctx:           ctx,
+			onClose:       make(chan error, 1),
+			handshakeDone: make(chan struct{}), // never released
+		}
+
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			close(client.stopPooling)
+		}()
+
+		err := client.pollingLoop()
+		assert.NoError(t, err)
+	})
+
+	t.Run("Context cancelled during handshake wait", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockLogger.EXPECT().Debugf("context done, stop http polling")
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // cancelled before the loop runs
+
+		client := &Transport{
+			log:           mockLogger,
+			stopPooling:   make(chan struct{}),
+			ctx:           ctx,
+			onClose:       make(chan error, 1),
+			handshakeDone: make(chan struct{}), // never released
 		}
 
 		err := client.pollingLoop()
-		assert.ErrorContains(t, err, "pinger closed")
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, context.Canceled))
+	})
+
+	t.Run("Context error after poll", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockHttpClient := mocks.NewMockHttpClient(ctrl)
+		mockLogger.EXPECT().Debugf("run polling").MinTimes(1)
+		mockLogger.EXPECT().Debugf("context done, stop http polling")
+
+		mockHttpClient.EXPECT().Do(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
+			cancel() // parent context cancelled mid-poll (not via Stop)
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		}).MinTimes(1)
+
+		client := &Transport{
+			url:         &url.URL{Scheme: "http", Host: "localhost"},
+			httpClient:  mockHttpClient,
+			log:         mockLogger,
+			stopPooling: make(chan struct{}, 1),
+			stopCh:      make(chan struct{}),
+			ctx:         ctx,
+			onClose:     make(chan error, 1),
+			messages:    make(chan []byte, 1),
+		}
+		client.reqCtx, client.pollCancel = context.WithCancel(ctx)
+
+		err := client.pollingLoop()
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, context.Canceled))
+	})
+
+	t.Run("Backoff then retry", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockHttpClient := mocks.NewMockHttpClient(ctrl)
+		mockLogger.EXPECT().Debugf("run polling").MinTimes(2)
+		mockLogger.EXPECT().Errorf("poll error: %s", gomock.Any()).MinTimes(1)
+		mockLogger.EXPECT().Debugf("stop polling").MinTimes(1)
+
+		var calls int32
+		mockHttpClient.EXPECT().Do(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
+			if atomic.AddInt32(&calls, 1) == 1 {
+				return nil, errors.New("transient") // first poll fails -> backoff
+			}
+			<-req.Context().Done() // second poll blocks until Stop
+			return nil, req.Context().Err()
+		}).MinTimes(2)
+
+		client := &Transport{
+			url:              &url.URL{Scheme: "http", Host: "localhost"},
+			httpClient:       mockHttpClient,
+			log:              mockLogger,
+			stopPooling:      make(chan struct{}, 1),
+			stopCh:           make(chan struct{}),
+			ctx:              ctx,
+			onClose:          make(chan error, 1),
+			messages:         make(chan []byte, 1),
+			pollErrorBackoff: 5 * time.Millisecond,
+		}
+		client.reqCtx, client.pollCancel = context.WithCancel(ctx)
+
+		go func() {
+			time.Sleep(60 * time.Millisecond)
+			assert.NoError(t, client.Stop())
+		}()
+
+		err := client.pollingLoop()
+		assert.NoError(t, err)
+	})
+
+	t.Run("Backoff interrupted by context", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockHttpClient := mocks.NewMockHttpClient(ctrl)
+		mockLogger.EXPECT().Debugf("run polling").MinTimes(1)
+		mockLogger.EXPECT().Errorf("poll error: %s", gomock.Any()).MinTimes(1)
+		mockLogger.EXPECT().Debugf("context done, stop http polling")
+
+		mockHttpClient.EXPECT().Do(gomock.Any()).Return(nil, errors.New("transient")).MinTimes(1)
+
+		client := &Transport{
+			url:              &url.URL{Scheme: "http", Host: "localhost"},
+			httpClient:       mockHttpClient,
+			log:              mockLogger,
+			stopPooling:      make(chan struct{}, 1),
+			stopCh:           make(chan struct{}),
+			ctx:              ctx,
+			onClose:          make(chan error, 1),
+			messages:         make(chan []byte, 1),
+			pollErrorBackoff: time.Second, // long, so the context cancel wins
+		}
+		client.reqCtx, client.pollCancel = context.WithCancel(ctx)
+
+		go func() {
+			time.Sleep(20 * time.Millisecond)
+			cancel()
+		}()
+
+		err := client.pollingLoop()
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, context.Canceled))
 	})
 }
 
@@ -496,6 +771,39 @@ func TestPoll(t *testing.T) {
 		case <-time.After(time.Second):
 			t.Fatal("Timeout waiting for poll to complete")
 		}
+	})
+
+	t.Run("Non-2xx response status", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockHTTPClient := mocks.NewMockHttpClient(ctrl)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		messagesChan := make(chan []byte, 1)
+		client := &Transport{
+			log:        mockLogger,
+			httpClient: mockHTTPClient,
+			url:        &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
+			sid:        "test-sid",
+			ctx:        ctx,
+			messages:   messagesChan,
+		}
+
+		mockLogger.EXPECT().Debugf("run polling")
+		mockHTTPClient.EXPECT().Do(gomock.Any()).Return(&http.Response{
+			StatusCode: 400,
+			Body:       io.NopCloser(strings.NewReader(`{"code":1,"message":"Session ID unknown"}`)),
+		}, nil)
+
+		err := client.poll()
+		assert.ErrorContains(t, err, "unexpected polling response status 400")
+		// The error body must not be forwarded as an engine.io packet.
+		assert.Equal(t, 0, len(messagesChan))
 	})
 
 	t.Run("Error creating request", func(t *testing.T) {


### PR DESCRIPTION
## Problem
The polling transport issued a data `GET` only on each pinger tick, and the pinger is reset to the handshake `pingInterval` (25s default). Between ticks no `GET` is open, so the server can't push data — server→client latency was up to one ping interval, and a **polling-only** connection effectively hung (the socket.io `CONNECT` ack arrived ~25s after the handshake). Surfaced by the Docker E2E suite (#31). Fixes #56 and #58.

## Changes
**Long-polling (engine.io polling transport)**
- Rewrite `pollingLoop()` to long-poll continuously — each `poll()` issues a `GET` the server holds open until it has data (or sends a keepalive ping), then the loop immediately re-issues.
- **Handshake gate**: the loop waits for a session id before polling so it never races `RequestHandshake()`'s own poll (engine.io rejects two concurrent polls per session). The gate is **order-independent** (mutex-guarded close): `Run()` opens it immediately when the session id is already known, so it can't deadlock if `SetHandshake()` runs before `Run()` (e.g. polling is the *target* of an upgrade). _(Thanks @coderabbitai for catching the ordering edge case.)_
- **Request-scoped context** (`reqCtx`/`pollCancel`): `Stop()` cancels the in-flight long-poll, so the common polling→websocket upgrade and Close interrupt promptly.
- **Non-2xx handling**: a non-2xx response (e.g. `400 "Session ID unknown"`) is surfaced as an error with a backoff (`pollErrorBackoff`, default 1s) instead of being forwarded as a packet and hot-spinning.

**Engine.io client**
- The `unsupported upgrade` warning now logs the actual transport evaluated instead of always `Upgrades[0]` (#58).

**E2E**
- Removed the dedicated polling-only workaround server. All three transport modes (polling-only / websocket-only / polling→ws upgrade) now run against a **single** upgrade-advertising server with the **default 25s** ping interval — proving the latency fix without any workaround.

## Validation
- E2E matrix passes in ~10ms against the realistic server (was a 20s hang for polling-only).
- Polling package unit coverage **100%**; new tests: handshake gate (release / stop-/ctx-during-wait / upgrade-to-polling regression), `Stop()` interrupting an in-flight poll, non-2xx status, error-backoff paths; engine client multi-upgrade warning.
- `go test -race ./engine.io/... ./socket.io/...` clean; full suite + `go vet ./...` pass; project coverage 100%.

## Notes
- The `pinger` field/options are retained (constructor/`SetHandshake` compatibility) but no longer gate read cadence.

https://claude.ai/code/session_01Gkv7LscaX5vY63HQFudXTi