### PR TITLE
Fix namespace support: connect and emit acks to the configured namespace

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -32,12 +32,14 @@ func serverURL() string {
 //   - "polling":   HTTP long-polling only (no upgrade performed, even though the
 //     server offers one)
 //   - "websocket": websocket only (connects directly, no polling phase)
-func newClient(t *testing.T, mode string) *socketio.Client {
+//
+// Extra socket.io options (e.g. a non-default namespace) may be supplied.
+func newClient(t *testing.T, mode string, opts ...socketio.ClientOption) *socketio.Client {
 	t.Helper()
 	url := serverURL()
 
 	if mode == "default" {
-		client, err := socketio.NewClient(socketio.WithRawURL(url))
+		client, err := socketio.NewClient(append([]socketio.ClientOption{socketio.WithRawURL(url)}, opts...)...)
 		if err != nil {
 			t.Fatalf("new default client: %v", err)
 		}
@@ -75,7 +77,7 @@ func newClient(t *testing.T, mode string) *socketio.Client {
 		t.Fatalf("new engine client (%s): %v", mode, err)
 	}
 
-	client, err := socketio.NewClient(socketio.WithEngineIOClient(engine))
+	client, err := socketio.NewClient(append([]socketio.ClientOption{socketio.WithEngineIOClient(engine)}, opts...)...)
 	if err != nil {
 		t.Fatalf("new socket.io client (%s): %v", mode, err)
 	}
@@ -162,4 +164,10 @@ func TestE2E_PollingOnly(t *testing.T) {
 
 func TestE2E_WebsocketOnly(t *testing.T) {
 	runScenario(t, newClient(t, "websocket"))
+}
+
+// TestE2E_Namespace runs the same scenario on a non-default namespace ("/admin")
+// to cover the namespace connect/emit/ack path end-to-end.
+func TestE2E_Namespace(t *testing.T) {
+	runScenario(t, newClient(t, "default", socketio.WithDefaultNamespace("/admin")))
 }

--- a/socket.io/v5/client/client.go
+++ b/socket.io/v5/client/client.go
@@ -73,6 +73,7 @@ func (c *Client) connectSocketIO(_ []byte) {
 
 	err := c.sendPacket(&socketio_v5.Message{
 		Type:    socketio_v5.PacketConnect,
+		NS:      c.defaultNs.name,
 		Payload: handshakeData,
 	})
 

--- a/socket.io/v5/client/client_test.go
+++ b/socket.io/v5/client/client_test.go
@@ -45,10 +45,12 @@ func TestConnectSocketIO(t *testing.T) {
 		parser:        mockParser,
 		logger:        mockLogger,
 		handshakeData: map[string]interface{}{"foo": "bar"},
+		defaultNs:     &namespace{name: "/"},
 	}
 
 	expectedPacket := &socketio_v5.Message{
 		Type:    socketio_v5.PacketConnect,
+		NS:      "/",
 		Payload: client.handshakeData,
 	}
 
@@ -62,6 +64,18 @@ func TestConnectSocketIO(t *testing.T) {
 		str := fmt.Sprintf(format, v...)
 		assert.Contains(t, str, "send error")
 	})
+
+	client.connectSocketIO(nil)
+
+	// The CONNECT packet must target the configured default namespace, not "/".
+	client.defaultNs = &namespace{name: "/admin"}
+	adminPacket := &socketio_v5.Message{
+		Type:    socketio_v5.PacketConnect,
+		NS:      "/admin",
+		Payload: client.handshakeData,
+	}
+	mockParser.EXPECT().Serialize(gomock.Eq(adminPacket)).Return([]byte("encoded_packet"), nil)
+	mockEngineIO.EXPECT().Send(gomock.Any()).Return(nil)
 
 	client.connectSocketIO(nil)
 }
@@ -286,6 +300,7 @@ func TestConcurrentSetHandshakeDataAndConnect(t *testing.T) {
 		engineio:      mockEngineIO,
 		handshakeData: make(map[string]interface{}),
 		mutex:         sync.RWMutex{},
+		defaultNs:     &namespace{name: "/"},
 	}
 
 	mockParser.EXPECT().Serialize(gomock.Any()).Return([]byte("packet"), nil).AnyTimes()

--- a/socket.io/v5/client/emitters.go
+++ b/socket.io/v5/client/emitters.go
@@ -73,6 +73,7 @@ func (n *namespace) Emit(event interface{}, args ...interface{}) error {
 
 	return n.client.sendPacketWithAckTimeout(
 		&socketio_v5.Message{
+			NS:    n.name,
 			Type:  socketio_v5.PacketEvent,
 			Event: emitEvent,
 		},

--- a/socket.io/v5/client/emitters_test.go
+++ b/socket.io/v5/client/emitters_test.go
@@ -194,6 +194,54 @@ func TestNamespaceEmit(t *testing.T) {
 	}
 }
 
+// TestNamespaceEmitCarriesNamespace is a regression guard: emits from a
+// non-default namespace must serialize with that namespace set, both for plain
+// events and for events with an ack callback (the ack path previously dropped
+// the namespace, so the server received the packet on "/").
+func TestNamespaceEmitCarriesNamespace(t *testing.T) {
+	for _, withAck := range []bool{false, true} {
+		name := "plain event"
+		if withAck {
+			name = "event with ack"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockEngineIO := mocks.NewMockEngineIOClient(ctrl)
+			mockParser := mocks.NewMockParser(ctrl)
+			mockLogger := mocks.NewMockLogger(ctrl)
+
+			client := &Client{
+				engineio:     mockEngineIO,
+				parser:       mockParser,
+				ackCallbacks: make(map[int]func([]interface{})),
+				logger:       mockLogger,
+				ctx:          context.Background(),
+			}
+			ns := &namespace{client: client, name: "/admin"}
+
+			mockParser.EXPECT().Serialize(gomock.Any()).DoAndReturn(func(msg *socketio_v5.Message) ([]byte, error) {
+				assert.Equal(t, "/admin", msg.NS, "emit must target the namespace")
+				assert.Equal(t, socketio_v5.PacketEvent, msg.Type)
+				if withAck {
+					assert.NotNil(t, msg.AckId, "ack emit must carry an ack id")
+				}
+				return []byte{}, nil
+			})
+			mockEngineIO.EXPECT().Send(gomock.Any()).Return(nil)
+
+			var args []interface{}
+			if withAck {
+				mockParser.EXPECT().WrapCallback(gomock.Any()).Return(func(in []interface{}) {})
+				args = []interface{}{emit.WithAck(func() {})}
+			}
+
+			assert.NoError(t, ns.Emit("echo", args...))
+		})
+	}
+}
+
 func TestSendPacketWithAckTimeout(t *testing.T) {
 	tests := []struct {
 		name            string


### PR DESCRIPTION
## Problem
A client built with `WithDefaultNamespace(ns)` did not actually work on a non-default namespace — two defects combined to make it unusable (surfaced by an end-to-end `/admin` test added on top of the Docker E2E suite). Closes #59.

1. **Connect ignored the namespace.** `connectSocketIO()` sent the `CONNECT` packet with no `NS`, so the client always joined `/` regardless of `WithDefaultNamespace`. The configured namespace's `connect` event never fired.
2. **Ack emits dropped the namespace.** `namespace.Emit()`'s ack path built the `EVENT` message without `NS`. An ack emit on `/admin` serialized as `42<id>[...]` (namespace `/`) instead of `42/admin,<id>[...]`. The server received an ack on a namespace the socket wasn't connected to and **closed the connection**. (The plain-event path already set `NS`, which is why non-ack emits looked fine.)

Captured frames before the fix:
```
sendWs: 42/admin,["hello","world"]   # plain event — namespace OK
sendWs: 421["echo","ping"]           # ack emit — namespace dropped!
receiveWsError: EOF                  # server drops the connection
```

## Fix
Both paths now set `NS` to the namespace name:
- `connectSocketIO`: `NS: c.defaultNs.name`
- `namespace.Emit` (ack path): `NS: n.name`

`NS == "/"` keeps the default-namespace behavior byte-for-byte.

## Tests
- **E2E**: new `TestE2E_Namespace` runs the full connect → server-push → ack scenario on `/admin` (the existing server already exposes `io.of('/admin')`).
- **Unit**: `TestNamespaceEmitCarriesNamespace` asserts both emit paths (with/without ack) serialize with the namespace; `TestConnectSocketIO` extended to assert the `CONNECT` packet targets the default namespace (`/` and `/admin`).

## Validation
- All four E2E transport/namespace scenarios pass (`/admin` was a 20s hang before).
- `go test -race ./...` clean; full suite + `go vet ./...` pass; project coverage 100%.

https://claude.ai/code/session_01Gkv7LscaX5vY63HQFudXTi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gkv7LscaX5vY63HQFudXTi)_