### PR TITLE
[4.1] Automatic reconnection with exponential backoff

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -32,12 +32,14 @@ func serverURL() string {
 //   - "polling":   HTTP long-polling only (no upgrade performed, even though the
 //     server offers one)
 //   - "websocket": websocket only (connects directly, no polling phase)
-func newClient(t *testing.T, mode string) *socketio.Client {
+//
+// Extra socket.io options (e.g. a non-default namespace) may be supplied.
+func newClient(t *testing.T, mode string, opts ...socketio.ClientOption) *socketio.Client {
 	t.Helper()
 	url := serverURL()
 
 	if mode == "default" {
-		client, err := socketio.NewClient(socketio.WithRawURL(url))
+		client, err := socketio.NewClient(append([]socketio.ClientOption{socketio.WithRawURL(url)}, opts...)...)
 		if err != nil {
 			t.Fatalf("new default client: %v", err)
 		}
@@ -75,7 +77,7 @@ func newClient(t *testing.T, mode string) *socketio.Client {
 		t.Fatalf("new engine client (%s): %v", mode, err)
 	}
 
-	client, err := socketio.NewClient(socketio.WithEngineIOClient(engine))
+	client, err := socketio.NewClient(append([]socketio.ClientOption{socketio.WithEngineIOClient(engine)}, opts...)...)
 	if err != nil {
 		t.Fatalf("new socket.io client (%s): %v", mode, err)
 	}
@@ -162,4 +164,173 @@ func TestE2E_PollingOnly(t *testing.T) {
 
 func TestE2E_WebsocketOnly(t *testing.T) {
 	runScenario(t, newClient(t, "websocket"))
+}
+
+// TestE2E_Namespace runs the same scenario on a non-default namespace ("/admin")
+// to cover the namespace connect/emit/ack path end-to-end.
+func TestE2E_Namespace(t *testing.T) {
+	runScenario(t, newClient(t, "default", socketio.WithDefaultNamespace("/admin")))
+}
+
+// newReconnectClient builds a socket.io client in the given transport mode with
+// fast reconnect settings (200ms base backoff) so the reconnect scenarios run
+// quickly. Reconnection itself is on by default; only the waits are tuned.
+func newReconnectClient(t *testing.T, mode string) *socketio.Client {
+	t.Helper()
+
+	var transports []engineio.Transport
+	var primary engineio.Transport
+	switch mode {
+	case "default":
+		pt, err := polling.NewTransport()
+		if err != nil {
+			t.Fatalf("new polling transport: %v", err)
+		}
+		wt, err := ws.NewTransport()
+		if err != nil {
+			t.Fatalf("new websocket transport: %v", err)
+		}
+		transports = []engineio.Transport{pt, wt}
+		primary = pt
+	case "polling":
+		pt, err := polling.NewTransport()
+		if err != nil {
+			t.Fatalf("new polling transport: %v", err)
+		}
+		transports = []engineio.Transport{pt}
+		primary = pt
+	case "websocket":
+		wt, err := ws.NewTransport()
+		if err != nil {
+			t.Fatalf("new websocket transport: %v", err)
+		}
+		transports = []engineio.Transport{wt}
+		primary = wt
+	default:
+		t.Fatalf("unknown transport mode %q", mode)
+	}
+
+	engineURL := strings.TrimRight(serverURL(), "/") + "/socket.io/"
+	engine, err := engineio.NewClient(
+		engineio.WithRawURL(engineURL),
+		engineio.WithSupportedTransports(transports),
+		engineio.WithTransport(primary),
+		engineio.WithReconnectWait(200*time.Millisecond),
+		engineio.WithReconnectAttempts(10),
+	)
+	if err != nil {
+		t.Fatalf("new engine client (%s): %v", mode, err)
+	}
+
+	client, err := socketio.NewClient(socketio.WithEngineIOClient(engine))
+	if err != nil {
+		t.Fatalf("new socket.io client (%s): %v", mode, err)
+	}
+	return client
+}
+
+// runReconnectScenario proves automatic reconnection against the real server:
+// connect, verify the session works, have the server abruptly drop the
+// underlying engine.io connection ("kick"), observe the reconnecting/reconnect
+// lifecycle events, wait for the namespace CONNECT to be re-acknowledged (a
+// second "connect" event) and verify an acknowledgement round-trip still works
+// on the re-established session.
+func runReconnectScenario(t *testing.T, client *socketio.Client) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	connects := make(chan struct{}, 4)
+	client.On("connect", func() {
+		select {
+		case connects <- struct{}{}:
+		default:
+		}
+	})
+	reconnecting := make(chan struct{}, 4)
+	client.On("reconnecting", func() {
+		select {
+		case reconnecting <- struct{}{}:
+		default:
+		}
+	})
+	reconnected := make(chan struct{}, 4)
+	client.On("reconnect", func() {
+		select {
+		case reconnected <- struct{}{}:
+		default:
+		}
+	})
+
+	if err := client.Connect(ctx); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer client.Close()
+
+	select {
+	case <-connects:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for initial connect event")
+	}
+
+	echo := func(stage string) {
+		ack := make(chan string, 1)
+		if err := client.Emit("echo", stage, emit.WithAck(func(s string) {
+			select {
+			case ack <- s:
+			default:
+			}
+		})); err != nil {
+			t.Fatalf("emit echo (%s): %v", stage, err)
+		}
+		select {
+		case s := <-ack:
+			if s != stage {
+				t.Fatalf("echo ack (%s) = %q, want %q", stage, s, stage)
+			}
+		case <-ctx.Done():
+			t.Fatalf("timed out waiting for echo ack (%s)", stage)
+		}
+	}
+	echo("before-drop")
+
+	// Ask the server to abruptly close the engine.io connection, simulating a
+	// network drop. The client must notice, reconnect with a fresh handshake
+	// and re-join the namespace on its own.
+	if err := client.Emit("kick"); err != nil {
+		t.Fatalf("emit kick: %v", err)
+	}
+
+	select {
+	case <-reconnecting:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for reconnecting event")
+	}
+	select {
+	case <-reconnected:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for reconnect event")
+	}
+	// The namespace CONNECT is re-acknowledged by the real server: the
+	// socket.io-level "connect" event must fire a second time.
+	select {
+	case <-connects:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for post-reconnect connect event")
+	}
+
+	echo("after-reconnect")
+}
+
+func TestE2E_Reconnect_DefaultTransport(t *testing.T) {
+	runReconnectScenario(t, newReconnectClient(t, "default"))
+}
+
+func TestE2E_Reconnect_PollingOnly(t *testing.T) {
+	runReconnectScenario(t, newReconnectClient(t, "polling"))
+}
+
+func TestE2E_Reconnect_WebsocketOnly(t *testing.T) {
+	runReconnectScenario(t, newReconnectClient(t, "websocket"))
 }

--- a/e2e/server/index.js
+++ b/e2e/server/index.js
@@ -28,6 +28,14 @@ function wire(socket, ns) {
     socket.emit('welcome', 'hello ' + name);
   });
 
+
+  // "kick" abruptly closes the underlying engine.io connection (as a network
+  // drop / server restart would), letting clients exercise their automatic
+  // reconnection: the socket.io session itself is NOT gracefully disconnected.
+  socket.on('kick', () => {
+    socket.conn.close(true);
+  });
+
   // eslint-disable-next-line no-console
   console.log('client connected on namespace ' + ns + ': ' + socket.id);
 }

--- a/engine.io/v4/client/client.go
+++ b/engine.io/v4/client/client.go
@@ -7,10 +7,14 @@ import (
 	"fmt"
 	"net/url"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	engineio_v4 "github.com/maldikhan/go.socket.io/engine.io/v4"
 )
+
+// errClientClosed is returned by connection attempts that race with Close().
+var errClientClosed = errors.New("client is closed")
 
 type Client struct {
 	url                 *url.URL
@@ -26,6 +30,10 @@ type Client struct {
 	closeHandler        func()
 	reconnectAttempts   int
 	reconnectWait       time.Duration
+	reconnect           bool
+	reconnectHandler    func()
+	reconnectFailedHand func()
+	reconnectingHandler func()
 	waitUpgrade         chan struct{}
 	hadUpgrade          sync.Once
 	waitHandshake       chan struct{}
@@ -35,6 +43,24 @@ type Client struct {
 	afterConnect        func()
 	messages            chan []byte
 	messagesDone        chan struct{} // closed when messageLoop exits
+
+	// closing is set to 1 by Close() before the transport is stopped so the
+	// reconnect supervisor can distinguish an intentional shutdown from an
+	// unexpected drop. It is read/written with sync/atomic for goroutine safety
+	// (atomic.Bool is unavailable on Go 1.18).
+	closing uint32
+
+	// superviseOnce guards startSupervisor so exactly one supervisor goroutine
+	// runs per connection cycle. It is reset before every (re)connect attempt.
+	superviseOnce sync.Once
+	// supervisorStarted is 1 while a supervisor goroutine is responsible for
+	// draining transportClosed for the current cycle. Close() reads it to decide
+	// whether to wait on the supervisor or drain transportClosed itself.
+	supervisorStarted uint32
+	// supervisorDone is closed when the supervisor goroutine for the current
+	// connection cycle exits. Close() waits on it instead of reading
+	// transportClosed directly, because the supervisor owns that channel.
+	supervisorDone chan struct{}
 
 	// transportMu serializes access to the transport field and
 	// the waitUpgrade / waitHandshake channels so that Send() never
@@ -66,46 +92,91 @@ func (c *Client) payload(data []byte) string {
 
 func (c *Client) Connect(ctx context.Context) error {
 	c.ctx = ctx
+	// Mark the client as live so that an unexpected transport drop triggers a
+	// reconnect rather than being mistaken for an intentional Close.
+	atomic.StoreUint32(&c.closing, 0)
+	return c.startConnection(ctx)
+}
+
+// startConnection runs a single connection cycle: it (re)initialises every
+// per-connection channel and sync.Once guard, runs the transport, starts the
+// message loop and requests the handshake. It is called by Connect for the
+// initial connection and by the reconnect supervisor for each retry, so it must
+// fully reset the connection state before touching the transport — otherwise a
+// stale, already-closed channel or a fired sync.Once would deadlock or
+// double-close on a reconnect.
+func (c *Client) startConnection(ctx context.Context) error {
+	// Snapshot the transport under the lock. Close() sets it to nil; if a
+	// reconnect attempt races with Close() we must bail out instead of
+	// dereferencing a nil transport.
+	c.transportMu.RLock()
+	transport := c.transport
+	c.transportMu.RUnlock()
+	if transport == nil {
+		return errClientClosed
+	}
 
 	c.messages = make(chan []byte, 100)
+
+	// Reset the supervisor guard so the next successful handshake starts a fresh
+	// supervisor for this connection cycle, and create the done channel it will
+	// close on exit.
+	c.superviseOnce = sync.Once{}
+	c.supervisorDone = make(chan struct{})
+
+	// Reset the upgrade gate: a previous cycle may have left waitUpgrade closed
+	// and hadUpgrade fired. They are re-armed lazily by transportUpgrade(), but
+	// clearing them here keeps Send() from observing a stale, closed gate from
+	// the prior connection.
+	c.transportMu.Lock()
+	c.hadUpgrade = sync.Once{}
+	c.waitUpgrade = nil
+	c.transportMu.Unlock()
 
 	// Run transport before starting the message loop so that a Run()
 	// failure doesn't leak a goroutine.
 	c.transportClosed = make(chan error, 1)
-	err := c.transport.Run(ctx, c.url, c.sid, c.messages, c.transportClosed)
+	err := transport.Run(ctx, c.url, c.sid, c.messages, c.transportClosed)
 	if err != nil {
 		close(c.transportClosed)
+		close(c.supervisorDone)
 		return err
 	}
 
-	// Start the message loop only after Run() succeeds.
-	c.messagesDone = make(chan struct{})
-	go c.messageLoop(ctx, c.messages)
+	// Start the message loop only after Run() succeeds. messagesDone and
+	// messages are captured locally and passed to messageLoop so the goroutine
+	// owns this cycle's channels and never races with a later reconnect cycle
+	// that reassigns the c.messages / c.messagesDone fields.
+	messagesDone := make(chan struct{})
+	messages := c.messages
+	c.messagesDone = messagesDone
+	go c.messageLoop(ctx, messages, messagesDone)
 
 	c.transportMu.Lock()
 	c.hadHandshake = sync.Once{}
 	c.waitHandshake = make(chan struct{}, 1)
 	c.transportMu.Unlock()
 
-	err = c.transport.RequestHandshake()
+	err = transport.RequestHandshake()
 	if err != nil {
 		// Clean up: stop transport and wait for the message loop to exit
 		// so we don't leak a goroutine.
-		_ = c.transport.Stop()
+		_ = transport.Stop()
 		if c.transportClosed != nil {
 			<-c.transportClosed
 		}
 		close(c.messages)
 		<-c.messagesDone
+		close(c.supervisorDone)
 		return err
 	}
 
 	return nil
 }
 
-func (c *Client) messageLoop(ctx context.Context, messages <-chan []byte) {
-	if c.messagesDone != nil {
-		defer close(c.messagesDone)
+func (c *Client) messageLoop(ctx context.Context, messages <-chan []byte, messagesDone chan struct{}) {
+	if messagesDone != nil {
+		defer close(messagesDone)
 	}
 	if messages == nil {
 		c.log.Errorf("messages channel is nil, can't read transport messages")
@@ -241,6 +312,13 @@ func (c *Client) handleHandshake(data []byte) error {
 	c.hadHandshake.Do(func() {
 		close(c.waitHandshake)
 	})
+
+	// Start the reconnect supervisor now that the connection is fully
+	// established (handshake done, any upgrade complete). Starting it here —
+	// rather than in Connect — guarantees the supervisor watches the final
+	// transportClosed channel for this cycle and never competes with the
+	// synchronous <-transportClosed read performed by transportUpgrade().
+	c.startSupervisor()
 
 	// Call onConnect hook in a goroutine so that messageLoop can continue
 	// processing engine.io packets (e.g. the WebSocket upgrade probe response
@@ -379,10 +457,21 @@ func (c *Client) On(event string, handler func([]byte)) {
 		c.messageHandler = handler
 	case "close":
 		c.closeHandler = func() { handler(nil) }
+	case "reconnecting":
+		c.reconnectingHandler = func() { handler(nil) }
+	case "reconnect":
+		c.reconnectHandler = func() { handler(nil) }
+	case "reconnect_failed":
+		c.reconnectFailedHand = func() { handler(nil) }
 	}
 }
 
 func (c *Client) Close() error {
+	// Mark the client as intentionally closing BEFORE stopping the transport so
+	// the reconnect supervisor treats the resulting drop as a graceful shutdown
+	// and does not attempt to reconnect.
+	atomic.StoreUint32(&c.closing, 1)
+
 	// Write-lock to prevent new Send() calls from acquiring the transport
 	// while we are tearing it down. Setting transport to nil ensures that
 	// any Send() arriving after Close releases the lock will see nil and
@@ -390,6 +479,7 @@ func (c *Client) Close() error {
 	c.transportMu.Lock()
 	t := c.transport
 	c.transport = nil
+	transportClosed := c.transportClosed
 	c.transportMu.Unlock()
 
 	// Stop the ping ticker to prevent goroutine leak
@@ -405,9 +495,21 @@ func (c *Client) Close() error {
 	if err != nil {
 		return err
 	}
-	if c.transportClosed != nil {
-		<-c.transportClosed
+
+	// The reconnect supervisor is the sole owner of transportClosed once the
+	// connection is established. If it is running, let it drain transportClosed
+	// (Stop() just triggered the close notification) and wait for it to exit. If
+	// no supervisor is running — the handshake never completed, or we are being
+	// called from the supervisor itself on reconnect exhaustion — drain
+	// transportClosed here so the messageLoop teardown can proceed.
+	if atomic.LoadUint32(&c.supervisorStarted) == 1 {
+		if c.supervisorDone != nil {
+			<-c.supervisorDone
+		}
+	} else if transportClosed != nil {
+		<-transportClosed
 	}
+
 	if c.messages != nil {
 		close(c.messages)
 	}

--- a/engine.io/v4/client/client.go
+++ b/engine.io/v4/client/client.go
@@ -22,6 +22,12 @@ type Client struct {
 	log                 Logger
 	transport           Transport
 	supportedTransports map[engineio_v4.EngineIOTransport]Transport
+	// initialTransport is the transport the session started on, before any
+	// polling->websocket upgrade. It is captured once on the first connect and
+	// restored at the start of every reconnect attempt so a reconnect begins a
+	// fresh Engine.IO session on the original transport instead of reusing an
+	// upgraded websocket transport that carries a now-dead sid.
+	initialTransport    Transport
 	sid                 string
 	pingInterval        *time.Ticker
 	pingTimeout         time.Duration
@@ -43,6 +49,7 @@ type Client struct {
 	afterConnect        func()
 	messages            chan []byte
 	messagesDone        chan struct{} // closed when messageLoop exits
+	messagesStop        chan struct{} // closed to ask messageLoop to exit
 
 	// closing is set to 1 by Close() before the transport is stopped so the
 	// reconnect supervisor can distinguish an intentional shutdown from an
@@ -95,6 +102,14 @@ func (c *Client) Connect(ctx context.Context) error {
 	// Mark the client as live so that an unexpected transport drop triggers a
 	// reconnect rather than being mistaken for an intentional Close.
 	atomic.StoreUint32(&c.closing, 0)
+	// Capture the initial (pre-upgrade) transport once so that reconnects can
+	// always start a fresh session on it. Connect is the only entry point that
+	// runs before any upgrade, so c.transport is still the initial transport here.
+	c.transportMu.Lock()
+	if c.initialTransport == nil {
+		c.initialTransport = c.transport
+	}
+	c.transportMu.Unlock()
 	return c.startConnection(ctx)
 }
 
@@ -106,12 +121,27 @@ func (c *Client) Connect(ctx context.Context) error {
 // stale, already-closed channel or a fired sync.Once would deadlock or
 // double-close on a reconnect.
 func (c *Client) startConnection(ctx context.Context) error {
-	// Snapshot the transport under the lock. Close() sets it to nil; if a
-	// reconnect attempt races with Close() we must bail out instead of
+	// Tear down any message loop left running by a previous cycle before we
+	// replace its channels below. On a fresh connect there is nothing running,
+	// so this is a no-op; on a reconnect it stops the goroutine that was still
+	// reading the now-dead transport's messages channel, preventing a leak.
+	c.stopMessageLoop()
+
+	// Restore the initial transport and clear the stale sid so the cycle starts
+	// a brand-new Engine.IO session with a real handshake. On the first connect
+	// the transport is already the initial one and the sid is already empty, so
+	// this is a no-op; after a polling->websocket upgrade it reverts the upgraded
+	// websocket transport (whose RequestHandshake is a no-op) back to the polling
+	// transport that performs a real handshake. Close() sets the transport to nil;
+	// if a reconnect attempt races with Close() we must bail out instead of
 	// dereferencing a nil transport.
-	c.transportMu.RLock()
+	c.transportMu.Lock()
+	if c.initialTransport != nil {
+		c.transport = c.initialTransport
+	}
+	c.sid = ""
 	transport := c.transport
-	c.transportMu.RUnlock()
+	c.transportMu.Unlock()
 	if transport == nil {
 		return errClientClosed
 	}
@@ -148,9 +178,13 @@ func (c *Client) startConnection(ctx context.Context) error {
 	// owns this cycle's channels and never races with a later reconnect cycle
 	// that reassigns the c.messages / c.messagesDone fields.
 	messagesDone := make(chan struct{})
+	messagesStop := make(chan struct{})
 	messages := c.messages
+	c.transportMu.Lock()
 	c.messagesDone = messagesDone
-	go c.messageLoop(ctx, messages, messagesDone)
+	c.messagesStop = messagesStop
+	c.transportMu.Unlock()
+	go c.messageLoop(ctx, messages, messagesDone, messagesStop)
 
 	c.transportMu.Lock()
 	c.hadHandshake = sync.Once{}
@@ -159,14 +193,15 @@ func (c *Client) startConnection(ctx context.Context) error {
 
 	err = transport.RequestHandshake()
 	if err != nil {
-		// Clean up: stop transport and wait for the message loop to exit
-		// so we don't leak a goroutine.
+		// Clean up: stop transport and wait for the message loop to exit so we
+		// don't leak a goroutine. The cleanup operates on the channels captured
+		// for this cycle so it is unaffected by a later reconnect cycle.
 		_ = transport.Stop()
 		if c.transportClosed != nil {
 			<-c.transportClosed
 		}
-		close(c.messages)
-		<-c.messagesDone
+		close(messages)
+		<-messagesDone
 		close(c.supervisorDone)
 		return err
 	}
@@ -174,7 +209,7 @@ func (c *Client) startConnection(ctx context.Context) error {
 	return nil
 }
 
-func (c *Client) messageLoop(ctx context.Context, messages <-chan []byte, messagesDone chan struct{}) {
+func (c *Client) messageLoop(ctx context.Context, messages <-chan []byte, messagesDone chan struct{}, stop <-chan struct{}) {
 	if messagesDone != nil {
 		defer close(messagesDone)
 	}
@@ -192,10 +227,45 @@ func (c *Client) messageLoop(ctx context.Context, messages <-chan []byte, messag
 			if err != nil {
 				c.log.Errorf("handle packet error: %s", err)
 			}
+		case <-stop:
+			// A new connection cycle asked this loop to exit so it can take over
+			// with fresh channels (reconnect teardown).
+			return
 		case <-ctx.Done():
 			c.log.Warnf("context done, engine.io client stopped processing messages")
 			return
 		}
+	}
+}
+
+// stopMessageLoop signals the current cycle's messageLoop to exit and waits for
+// it to finish. It is idempotent and safe to call when no loop is running: a nil
+// stop channel means there is nothing to stop, and a stop channel that was
+// already closed is left untouched (a non-blocking receive detects the closed
+// state). The dropped transport has already stopped, so it will not write to the
+// old messages channel after this point; we therefore tear the loop down via the
+// dedicated stop signal rather than closing the messages channel here, leaving
+// that channel for Close() to close exactly once.
+func (c *Client) stopMessageLoop() {
+	c.transportMu.Lock()
+	stop := c.messagesStop
+	done := c.messagesDone
+	c.messagesStop = nil
+	c.messagesDone = nil
+	c.transportMu.Unlock()
+
+	if stop == nil {
+		return
+	}
+	// Close the stop channel unless a previous call already did. A non-blocking
+	// receive that succeeds means the channel is already closed.
+	select {
+	case <-stop:
+	default:
+		close(stop)
+	}
+	if done != nil {
+		<-done
 	}
 }
 

--- a/engine.io/v4/client/client.go
+++ b/engine.io/v4/client/client.go
@@ -69,6 +69,13 @@ type Client struct {
 	// transportClosed directly, because the supervisor owns that channel.
 	supervisorDone chan struct{}
 
+	// closeCh is closed exactly once by Close() to wake any goroutine parked in
+	// the reconnect backoff wait, so Close() returns promptly instead of blocking
+	// for the remaining backoff (which can be many seconds with WithReconnectWait).
+	// closeOnce guards the close so concurrent Close() calls never double-close it.
+	closeCh   chan struct{}
+	closeOnce sync.Once
+
 	// transportMu serializes access to the transport field and
 	// the waitUpgrade / waitHandshake channels so that Send() never
 	// races with transportUpgrade() or Close().
@@ -541,6 +548,15 @@ func (c *Client) Close() error {
 	// the reconnect supervisor treats the resulting drop as a graceful shutdown
 	// and does not attempt to reconnect.
 	atomic.StoreUint32(&c.closing, 1)
+
+	// Wake any goroutine parked in the reconnect backoff wait so Close() does not
+	// block for the remaining backoff. Guarded by closeOnce so concurrent Close()
+	// calls (or a Close() racing with reconnect exhaustion) never double-close it.
+	// closeCh is nil only for Clients built directly in tests without NewClient;
+	// guarding here keeps Close() safe in that case too.
+	if c.closeCh != nil {
+		c.closeOnce.Do(func() { close(c.closeCh) })
+	}
 
 	// Write-lock to prevent new Send() calls from acquiring the transport
 	// while we are tearing it down. Setting transport to nil ensures that

--- a/engine.io/v4/client/client.go
+++ b/engine.io/v4/client/client.go
@@ -68,6 +68,12 @@ type Client struct {
 	// connection cycle exits. Close() waits on it instead of reading
 	// transportClosed directly, because the supervisor owns that channel.
 	supervisorDone chan struct{}
+	// attemptInFlight is 1 while startConnection is between its first state
+	// reset and its final return. During that window the attempt owns the
+	// cycle's transportClosed teardown (every exit path drains and closes it,
+	// then closes supervisorDone), so Close() must wait on supervisorDone
+	// instead of competing for the single transportClosed value.
+	attemptInFlight uint32
 
 	// closeCh is closed exactly once by Close() to wake any goroutine parked in
 	// the reconnect backoff wait, so Close() returns promptly instead of blocking
@@ -141,8 +147,17 @@ func (c *Client) startConnection(ctx context.Context) error {
 	// websocket transport (whose RequestHandshake is a no-op) back to the polling
 	// transport that performs a real handshake. Close() sets the transport to nil;
 	// if a reconnect attempt races with Close() we must bail out instead of
-	// dereferencing a nil transport.
+	// dereferencing a nil transport — and we must not restore the transport after
+	// Close() already nil'ed it, or the attempt would resurrect a closed client.
 	c.transportMu.Lock()
+	if atomic.LoadUint32(&c.closing) == 1 {
+		c.transportMu.Unlock()
+		return errClientClosed
+	}
+	// From here on this attempt owns the cycle teardown; Close() observing the
+	// flag will wait on supervisorDone (closed by every exit path below)
+	// instead of draining transportClosed itself.
+	atomic.StoreUint32(&c.attemptInFlight, 1)
 	if c.initialTransport != nil {
 		c.transport = c.initialTransport
 	}
@@ -150,34 +165,55 @@ func (c *Client) startConnection(ctx context.Context) error {
 	transport := c.transport
 	c.transportMu.Unlock()
 	if transport == nil {
+		atomic.StoreUint32(&c.attemptInFlight, 0)
 		return errClientClosed
 	}
 
-	c.messages = make(chan []byte, 100)
-
-	// Reset the supervisor guard so the next successful handshake starts a fresh
-	// supervisor for this connection cycle, and create the done channel it will
-	// close on exit.
+	// Reset the per-cycle supervisor state under the lock so Close() observes a
+	// consistent pair: a fresh supervisorDone always comes with
+	// supervisorStarted == 0 (no goroutine owns the new channel until the next
+	// successful handshake runs startSupervisor). Without this, Close() racing
+	// with an in-flight reconnect attempt could wait on a supervisorDone channel
+	// that no goroutine will ever close — a deadlock.
+	transportClosed := make(chan error, 1)
+	messages := make(chan []byte, 100)
+	c.transportMu.Lock()
+	c.messages = messages
 	c.superviseOnce = sync.Once{}
 	c.supervisorDone = make(chan struct{})
+	atomic.StoreUint32(&c.supervisorStarted, 0)
 
 	// Reset the upgrade gate: a previous cycle may have left waitUpgrade closed
 	// and hadUpgrade fired. They are re-armed lazily by transportUpgrade(), but
 	// clearing them here keeps Send() from observing a stale, closed gate from
 	// the prior connection.
-	c.transportMu.Lock()
 	c.hadUpgrade = sync.Once{}
 	c.waitUpgrade = nil
-	c.transportMu.Unlock()
 
 	// Run transport before starting the message loop so that a Run()
 	// failure doesn't leak a goroutine.
-	c.transportClosed = make(chan error, 1)
-	err := transport.Run(ctx, c.url, c.sid, c.messages, c.transportClosed)
+	c.transportClosed = transportClosed
+	c.transportMu.Unlock()
+
+	err := transport.Run(ctx, c.url, c.sid, messages, transportClosed)
 	if err != nil {
-		close(c.transportClosed)
+		close(transportClosed)
 		close(c.supervisorDone)
+		atomic.StoreUint32(&c.attemptInFlight, 0)
 		return err
+	}
+
+	// Close() may have raced with this attempt between the closing check above
+	// and transport.Run: such a Close() stopped a transport that was not running
+	// yet, so its stop had no effect. Re-check and tear the fresh transport down
+	// ourselves instead of leaving a live connection behind on a closed client.
+	if atomic.LoadUint32(&c.closing) == 1 {
+		_ = transport.Stop()
+		<-transportClosed
+		close(transportClosed)
+		close(c.supervisorDone)
+		atomic.StoreUint32(&c.attemptInFlight, 0)
+		return errClientClosed
 	}
 
 	// Start the message loop only after Run() succeeds. messagesDone and
@@ -186,7 +222,6 @@ func (c *Client) startConnection(ctx context.Context) error {
 	// that reassigns the c.messages / c.messagesDone fields.
 	messagesDone := make(chan struct{})
 	messagesStop := make(chan struct{})
-	messages := c.messages
 	c.transportMu.Lock()
 	c.messagesDone = messagesDone
 	c.messagesStop = messagesStop
@@ -204,13 +239,48 @@ func (c *Client) startConnection(ctx context.Context) error {
 		// don't leak a goroutine. The cleanup operates on the channels captured
 		// for this cycle so it is unaffected by a later reconnect cycle.
 		_ = transport.Stop()
-		if c.transportClosed != nil {
-			<-c.transportClosed
-		}
+		<-transportClosed
+		// The single close notification is consumed and no sender remains;
+		// close the channel so a later Close() that drains transportClosed
+		// returns immediately instead of blocking forever.
+		close(transportClosed)
 		close(messages)
 		<-messagesDone
+		// Detach the closed channels from the client so a later Close() (e.g.
+		// after reconnect exhaustion) doesn't close messages a second time or
+		// wait on the already-finished loop.
+		c.transportMu.Lock()
+		if c.messages == messages {
+			c.messages = nil
+		}
+		if c.messagesDone == messagesDone {
+			c.messagesDone = nil
+		}
+		c.messagesStop = nil
+		c.transportMu.Unlock()
 		close(c.supervisorDone)
+		atomic.StoreUint32(&c.attemptInFlight, 0)
 		return err
+	}
+
+	// Final closing check, atomic with clearing attemptInFlight: a Close() that
+	// raced with the handshake request either locked before us (it saw
+	// attemptInFlight == 1 and is waiting on supervisorDone, which the teardown
+	// below closes) or locks after us and sees attemptInFlight == 0 with the
+	// transportClosed channel already drained and closed.
+	c.transportMu.Lock()
+	closingNow := atomic.LoadUint32(&c.closing) == 1
+	atomic.StoreUint32(&c.attemptInFlight, 0)
+	c.transportMu.Unlock()
+	if closingNow {
+		_ = transport.Stop()
+		<-transportClosed
+		close(transportClosed)
+		// Stop the message loop via its stop signal; the messages channel is
+		// left for Close() to close exactly once.
+		c.stopMessageLoop()
+		close(c.supervisorDone)
+		return errClientClosed
 	}
 
 	return nil
@@ -561,11 +631,23 @@ func (c *Client) Close() error {
 	// Write-lock to prevent new Send() calls from acquiring the transport
 	// while we are tearing it down. Setting transport to nil ensures that
 	// any Send() arriving after Close releases the lock will see nil and
-	// fail fast instead of writing on a stopped transport.
+	// fail fast instead of writing on a stopped transport. All per-cycle
+	// channels are snapshotted in the same critical section that mutates them
+	// in startConnection, so the supervisorStarted/supervisorDone pair is
+	// always consistent: a fresh (unowned) supervisorDone is only ever seen
+	// together with supervisorStarted == 0.
 	c.transportMu.Lock()
 	t := c.transport
 	c.transport = nil
 	transportClosed := c.transportClosed
+	// Wait on supervisorDone when either a supervisor goroutine owns the
+	// cycle's transportClosed channel, or a startConnection attempt is in
+	// flight (its exit paths drain transportClosed and close supervisorDone).
+	// Competing with them for the single transportClosed value would leave one
+	// of the parties blocked forever.
+	waitForCycle := atomic.LoadUint32(&c.supervisorStarted) == 1 ||
+		atomic.LoadUint32(&c.attemptInFlight) == 1
+	supervisorDone := c.supervisorDone
 	c.transportMu.Unlock()
 
 	// Stop the ping ticker to prevent goroutine leak
@@ -588,22 +670,33 @@ func (c *Client) Close() error {
 	// no supervisor is running — the handshake never completed, or we are being
 	// called from the supervisor itself on reconnect exhaustion — drain
 	// transportClosed here so the messageLoop teardown can proceed.
-	if atomic.LoadUint32(&c.supervisorStarted) == 1 {
-		if c.supervisorDone != nil {
-			<-c.supervisorDone
+	if waitForCycle {
+		if supervisorDone != nil {
+			<-supervisorDone
 		}
 	} else if transportClosed != nil {
 		<-transportClosed
 	}
 
-	if c.messages != nil {
-		close(c.messages)
+	// Read the message channels only after the cycle owner has finished: a
+	// failing startConnection attempt closes the messages channel and detaches
+	// it under the lock, so snapshotting it before the wait above could make
+	// Close() close the same channel a second time.
+	c.transportMu.Lock()
+	messages := c.messages
+	c.messages = nil
+	messagesDone := c.messagesDone
+	c.messagesDone = nil
+	c.transportMu.Unlock()
+
+	if messages != nil {
+		close(messages)
 	}
 	// Wait for messageLoop goroutine to finish so that no mock/logger
 	// calls happen after the caller returns (prevents test panics and
 	// ensures clean shutdown).
-	if c.messagesDone != nil {
-		<-c.messagesDone
+	if messagesDone != nil {
+		<-messagesDone
 	}
 	return nil
 }

--- a/engine.io/v4/client/client.go
+++ b/engine.io/v4/client/client.go
@@ -265,6 +265,11 @@ func (c *Client) startConnection(ctx context.Context) error {
 		}
 		c.messagesStop = nil
 		c.transportMu.Unlock()
+		// The handshake gate armed above will never be closed by a handshake;
+		// release it so Send() callers parked on it fail fast against the
+		// stopped transport instead of waiting on a channel no future cycle
+		// closes (every cycle arms a fresh one).
+		c.releaseGates()
 		close(c.supervisorDone)
 		atomic.StoreUint32(&c.attemptInFlight, 0)
 		return err
@@ -286,6 +291,10 @@ func (c *Client) startConnection(ctx context.Context) error {
 		// Stop the message loop via its stop signal; the messages channel is
 		// left for Close() to close exactly once.
 		c.stopMessageLoop()
+		// The concurrent Close() released the gates of the PREVIOUS cycle; the
+		// fresh gate armed above (after Close's release) must be released by
+		// this teardown, or Send() callers parked on it would never wake.
+		c.releaseGates()
 		close(c.supervisorDone)
 		return errClientClosed
 	}
@@ -627,6 +636,28 @@ func (c *Client) On(event string, handler func([]byte)) {
 	}
 }
 
+// releaseGates closes the current cycle's handshake/upgrade gates (each via
+// its sync.Once guard) so Send() callers parked on them wake up, observe the
+// dead/nil transport and fail fast. Every (re)connect cycle arms a FRESH
+// waitHandshake channel, so a gate left open by an abandoned cycle would park
+// its waiters forever — no future cycle ever closes the old channel object.
+// Called when a cycle is abandoned (handshake never completed), when its
+// handshake request fails after the gate was armed, and by Close().
+func (c *Client) releaseGates() {
+	c.transportMu.Lock()
+	defer c.transportMu.Unlock()
+	c.hadHandshake.Do(func() {
+		if c.waitHandshake != nil {
+			close(c.waitHandshake)
+		}
+	})
+	c.hadUpgrade.Do(func() {
+		if c.waitUpgrade != nil {
+			close(c.waitUpgrade)
+		}
+	})
+}
+
 func (c *Client) Close() error {
 	// Mark the client as intentionally closing BEFORE stopping the transport so
 	// the reconnect supervisor treats the resulting drop as a graceful shutdown
@@ -663,6 +694,12 @@ func (c *Client) Close() error {
 		atomic.LoadUint32(&c.attemptInFlight) == 1
 	supervisorDone := c.supervisorDone
 	c.transportMu.Unlock()
+
+	// Release the handshake/upgrade gates AFTER the transport is nil'ed above:
+	// a Send() parked on a gate wakes, re-reads the transport, sees nil and
+	// fails fast with "client is closed" instead of blocking forever on a gate
+	// that no future cycle will close.
+	c.releaseGates()
 
 	// Stop the ping ticker to prevent goroutine leak
 	if c.pingInterval != nil {

--- a/engine.io/v4/client/client.go
+++ b/engine.io/v4/client/client.go
@@ -74,6 +74,12 @@ type Client struct {
 	// then closes supervisorDone), so Close() must wait on supervisorDone
 	// instead of competing for the single transportClosed value.
 	attemptInFlight uint32
+	// cycleAbandoned is set to 1 by awaitConnectionEstablished when a reconnect
+	// attempt's handshake does not complete within its bound: a late-arriving
+	// OPEN packet must then no longer upgrade the transport or start a
+	// supervisor, because the reconnect loop has already torn the cycle down
+	// and will retry. Reset to 0 by startConnection for every new cycle.
+	cycleAbandoned uint32
 
 	// closeCh is closed exactly once by Close() to wake any goroutine parked in
 	// the reconnect backoff wait, so Close() returns promptly instead of blocking
@@ -182,6 +188,7 @@ func (c *Client) startConnection(ctx context.Context) error {
 	c.superviseOnce = sync.Once{}
 	c.supervisorDone = make(chan struct{})
 	atomic.StoreUint32(&c.supervisorStarted, 0)
+	atomic.StoreUint32(&c.cycleAbandoned, 0)
 
 	// Reset the upgrade gate: a previous cycle may have left waitUpgrade closed
 	// and hadUpgrade fired. They are re-armed lazily by transportUpgrade(), but
@@ -360,6 +367,13 @@ func (c *Client) transportUpgrade(transport Transport) error {
 		})
 		c.transportMu.Unlock()
 		return err
+	}
+
+	// A reconnect attempt that timed out has already torn this cycle down (and
+	// owns the transportClosed drain); a late upgrade must not stop/replace the
+	// transport or compete for the close notification.
+	if atomic.LoadUint32(&c.cycleAbandoned) == 1 {
+		return failUpgrade(errClientClosed)
 	}
 
 	err := c.transport.Stop()

--- a/engine.io/v4/client/client.go
+++ b/engine.io/v4/client/client.go
@@ -93,6 +93,13 @@ type Client struct {
 	// races with transportUpgrade() or Close().
 	transportMu sync.RWMutex
 
+	// handshakeErr records a handshake/upgrade failure that released the
+	// handshake gate without establishing the session, so a reconnect attempt
+	// waiting on that gate reports the failure instead of success. Set by
+	// handleHandshake's upgrade-error path before the gate is closed, cleared
+	// by startConnection when the gate is re-armed. Guarded by transportMu.
+	handshakeErr error
+
 	// handlerMu protects access to the handler fields
 	// (messageHandler, closeHandler, afterConnect).
 	// On() writes them from the user goroutine, while handlePacket()
@@ -238,6 +245,7 @@ func (c *Client) startConnection(ctx context.Context) error {
 	c.transportMu.Lock()
 	c.hadHandshake = sync.Once{}
 	c.waitHandshake = make(chan struct{}, 1)
+	c.handshakeErr = nil
 	c.transportMu.Unlock()
 
 	err = transport.RequestHandshake()
@@ -462,6 +470,14 @@ func (c *Client) handleHandshake(data []byte) error {
 			if newTransport, found := c.supportedTransports[engineio_v4.EngineIOTransport(newTransportName)]; found {
 				err = c.transportUpgrade(newTransport)
 				if err != nil {
+					// Record the failure BEFORE releasing the gate: a reconnect
+					// attempt waiting on waitHandshake must observe it and
+					// report the failed upgrade instead of a successful
+					// reconnect (gate closure alone does not mean the session
+					// was established).
+					c.transportMu.Lock()
+					c.handshakeErr = err
+					c.transportMu.Unlock()
 					// Close the handshake gate so that any Send() caller
 					// waiting on waitHandshake doesn't block forever.
 					c.hadHandshake.Do(func() {

--- a/engine.io/v4/client/client_test.go
+++ b/engine.io/v4/client/client_test.go
@@ -161,7 +161,7 @@ func TestClient_messageLoop(t *testing.T) {
 	t.Run("Handle packet", func(t *testing.T) {
 		mockParser.EXPECT().Parse([]byte("test")).Return(&engineio_v4.Message{Type: engineio_v4.PacketMessage}, nil)
 
-		go client.messageLoop(ctx, client.messages, nil)
+		go client.messageLoop(ctx, client.messages, nil, nil)
 		client.messages <- []byte("test")
 		time.Sleep(10 * time.Millisecond)
 	})
@@ -170,7 +170,7 @@ func TestClient_messageLoop(t *testing.T) {
 		mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).Times(2)
 		mockParser.EXPECT().Parse([]byte("error")).Return(nil, errors.New("parse error"))
 
-		go client.messageLoop(ctx, client.messages, nil)
+		go client.messageLoop(ctx, client.messages, nil, nil)
 		client.messages <- []byte("error")
 		time.Sleep(10 * time.Millisecond)
 	})
@@ -178,14 +178,14 @@ func TestClient_messageLoop(t *testing.T) {
 	t.Run("Context done", func(t *testing.T) {
 		mockLogger.EXPECT().Warnf("context done, engine.io client stopped processing messages").AnyTimes()
 		messages := make(chan []byte, 1)
-		go client.messageLoop(ctx, messages, nil)
+		go client.messageLoop(ctx, messages, nil, nil)
 		cancel()
 		time.Sleep(10 * time.Millisecond)
 	})
 
 	t.Run("NIL messages channel", func(t *testing.T) {
 		mockLogger.EXPECT().Errorf("messages channel is nil, can't read transport messages")
-		client.messageLoop(ctx, nil, nil)
+		client.messageLoop(ctx, nil, nil, nil)
 	})
 }
 

--- a/engine.io/v4/client/client_test.go
+++ b/engine.io/v4/client/client_test.go
@@ -161,7 +161,7 @@ func TestClient_messageLoop(t *testing.T) {
 	t.Run("Handle packet", func(t *testing.T) {
 		mockParser.EXPECT().Parse([]byte("test")).Return(&engineio_v4.Message{Type: engineio_v4.PacketMessage}, nil)
 
-		go client.messageLoop(ctx, client.messages)
+		go client.messageLoop(ctx, client.messages, nil)
 		client.messages <- []byte("test")
 		time.Sleep(10 * time.Millisecond)
 	})
@@ -170,7 +170,7 @@ func TestClient_messageLoop(t *testing.T) {
 		mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).Times(2)
 		mockParser.EXPECT().Parse([]byte("error")).Return(nil, errors.New("parse error"))
 
-		go client.messageLoop(ctx, client.messages)
+		go client.messageLoop(ctx, client.messages, nil)
 		client.messages <- []byte("error")
 		time.Sleep(10 * time.Millisecond)
 	})
@@ -178,14 +178,14 @@ func TestClient_messageLoop(t *testing.T) {
 	t.Run("Context done", func(t *testing.T) {
 		mockLogger.EXPECT().Warnf("context done, engine.io client stopped processing messages").AnyTimes()
 		messages := make(chan []byte, 1)
-		go client.messageLoop(ctx, messages)
+		go client.messageLoop(ctx, messages, nil)
 		cancel()
 		time.Sleep(10 * time.Millisecond)
 	})
 
 	t.Run("NIL messages channel", func(t *testing.T) {
 		mockLogger.EXPECT().Errorf("messages channel is nil, can't read transport messages")
-		client.messageLoop(ctx, nil)
+		client.messageLoop(ctx, nil, nil)
 	})
 }
 

--- a/engine.io/v4/client/constructor.go
+++ b/engine.io/v4/client/constructor.go
@@ -29,7 +29,9 @@ func NewClient(options ...EngineClientOption) (*Client, error) {
 		pingInterval:    time.NewTicker(10 * time.Second),
 		stopPooling:     make(chan struct{}, 1),
 		transportClosed: make(chan error, 1),
-		redactPayload:   true, // production-safe default; WithDebugPayload(true) opts out
+		// closeCh is closed by Close() to wake the reconnect backoff wait promptly.
+		closeCh:       make(chan struct{}),
+		redactPayload: true, // production-safe default; WithDebugPayload(true) opts out
 	}
 
 	for _, opt := range options {

--- a/engine.io/v4/client/constructor.go
+++ b/engine.io/v4/client/constructor.go
@@ -22,10 +22,14 @@ func NewClient(options ...EngineClientOption) (*Client, error) {
 		parser:            &engineio_v4_parser.EngineIOV4Parser{},
 		reconnectAttempts: 5,
 		reconnectWait:     5 * time.Second,
-		pingInterval:      time.NewTicker(10 * time.Second),
-		stopPooling:       make(chan struct{}, 1),
-		transportClosed:   make(chan error, 1),
-		redactPayload:     true, // production-safe default; WithDebugPayload(true) opts out
+		// Reconnection is enabled by default to match the behaviour of the
+		// reference JavaScript client. WithReconnect(false) restores the
+		// pre-reconnect behaviour (the client stops on the first drop).
+		reconnect:       true,
+		pingInterval:    time.NewTicker(10 * time.Second),
+		stopPooling:     make(chan struct{}, 1),
+		transportClosed: make(chan error, 1),
+		redactPayload:   true, // production-safe default; WithDebugPayload(true) opts out
 	}
 
 	for _, opt := range options {
@@ -151,6 +155,46 @@ func WithReconnectAttempts(attempts int) EngineClientOption {
 func WithReconnectWait(wait time.Duration) EngineClientOption {
 	return func(c *Client) error {
 		c.reconnectWait = wait
+		return nil
+	}
+}
+
+// WithReconnect enables or disables automatic reconnection with exponential
+// backoff. It is enabled by default; passing false makes the client stop on the
+// first unexpected transport drop, exactly as it behaved before reconnection
+// was added.
+func WithReconnect(enabled bool) EngineClientOption {
+	return func(c *Client) error {
+		c.reconnect = enabled
+		return nil
+	}
+}
+
+// WithOnReconnecting registers a hook fired when an unexpected drop is detected
+// and the client begins its reconnect attempts. Equivalent to
+// On("reconnecting", ...).
+func WithOnReconnecting(handler func()) EngineClientOption {
+	return func(c *Client) error {
+		c.reconnectingHandler = handler
+		return nil
+	}
+}
+
+// WithOnReconnect registers a hook fired after the client successfully
+// re-establishes the connection. Equivalent to On("reconnect", ...).
+func WithOnReconnect(handler func()) EngineClientOption {
+	return func(c *Client) error {
+		c.reconnectHandler = handler
+		return nil
+	}
+}
+
+// WithOnReconnectFailed registers a hook fired when all reconnect attempts are
+// exhausted (the client is then closed). Equivalent to
+// On("reconnect_failed", ...).
+func WithOnReconnectFailed(handler func()) EngineClientOption {
+	return func(c *Client) error {
+		c.reconnectFailedHand = handler
 		return nil
 	}
 }

--- a/engine.io/v4/client/constructor_test.go
+++ b/engine.io/v4/client/constructor_test.go
@@ -396,3 +396,39 @@ func TestWithReconnectWait(t *testing.T) {
 		})
 	}
 }
+
+func TestWithReconnect(t *testing.T) {
+	client := &Client{}
+
+	assert.NoError(t, WithReconnect(false)(client))
+	assert.False(t, client.reconnect)
+
+	assert.NoError(t, WithReconnect(true)(client))
+	assert.True(t, client.reconnect)
+}
+
+func TestWithReconnectHooks(t *testing.T) {
+	t.Run("WithOnReconnecting", func(t *testing.T) {
+		client := &Client{}
+		assert.NoError(t, WithOnReconnecting(func() {})(client))
+		assert.NotNil(t, client.reconnectingHandler)
+	})
+
+	t.Run("WithOnReconnect", func(t *testing.T) {
+		client := &Client{}
+		assert.NoError(t, WithOnReconnect(func() {})(client))
+		assert.NotNil(t, client.reconnectHandler)
+	})
+
+	t.Run("WithOnReconnectFailed", func(t *testing.T) {
+		client := &Client{}
+		assert.NoError(t, WithOnReconnectFailed(func() {})(client))
+		assert.NotNil(t, client.reconnectFailedHand)
+	})
+
+	t.Run("default reconnect enabled", func(t *testing.T) {
+		client, err := NewClient(WithRawURL("http://example.com"))
+		require.NoError(t, err)
+		assert.True(t, client.reconnect, "reconnect must default to true")
+	})
+}

--- a/engine.io/v4/client/reconnect.go
+++ b/engine.io/v4/client/reconnect.go
@@ -105,6 +105,14 @@ func (c *Client) reconnectLoop(cause error) {
 	backoff := base
 	maxBackoff := base * 8
 
+	// ctxDone is nil when no run context was assigned (defensive: the normal
+	// Connect path always sets one). A receive on a nil channel blocks forever,
+	// so the wait select simply falls through to the backoff timer in that case.
+	var ctxDone <-chan struct{}
+	if c.ctx != nil {
+		ctxDone = c.ctx.Done()
+	}
+
 	for attempt := 1; attempt <= c.reconnectAttempts; attempt++ {
 		// Respect cancellation/close before waiting and retrying.
 		if c.stopRequested() {
@@ -113,7 +121,7 @@ func (c *Client) reconnectLoop(cause error) {
 
 		select {
 		case <-time.After(backoff):
-		case <-c.ctx.Done():
+		case <-ctxDone:
 			return
 		}
 
@@ -153,6 +161,11 @@ func (c *Client) reconnectLoop(cause error) {
 func (c *Client) stopRequested() bool {
 	if atomic.LoadUint32(&c.closing) == 1 {
 		return true
+	}
+	// A nil run context (never assigned) is treated as "not cancelled" so the
+	// loop does not dereference a nil context. supervise applies the same guard.
+	if c.ctx == nil {
+		return false
 	}
 	select {
 	case <-c.ctx.Done():

--- a/engine.io/v4/client/reconnect.go
+++ b/engine.io/v4/client/reconnect.go
@@ -1,0 +1,190 @@
+package engineio_v4_client
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// startSupervisor launches the reconnect supervisor for the current connection
+// cycle. It is invoked once per successful handshake (guarded by superviseOnce,
+// which is reset on every (re)connect attempt) so that exactly one supervisor
+// goroutine watches the live transport at any time.
+//
+// The supervisor is the sole consumer of c.transportClosed once the connection
+// is established: it blocks until the transport reports it is gone. A nil value
+// means a graceful stop (Close, or an in-progress upgrade that already drained
+// the channel) and the supervisor simply exits; a non-nil error means the
+// connection dropped unexpectedly and, when reconnect is enabled, triggers the
+// exponential-backoff reconnect loop.
+//
+// When the handshake is exercised in isolation (no Connect/startConnection set
+// up the cycle), there is no transportClosed channel to watch, so startSupervisor
+// is a no-op — there is nothing to supervise.
+func (c *Client) startSupervisor() {
+	c.superviseOnce.Do(func() {
+		c.transportMu.RLock()
+		closed := c.transportClosed
+		c.transportMu.RUnlock()
+		if closed == nil {
+			return
+		}
+		// Capture the done channel for THIS cycle. A successful reconnect
+		// replaces c.supervisorDone with a fresh channel, so the supervisor must
+		// close the one it was started with, not the current field.
+		done := c.supervisorDone
+		atomic.StoreUint32(&c.supervisorStarted, 1)
+		go c.supervise(closed, done)
+	})
+}
+
+// supervise waits for the given connection's transportClosed channel to report a
+// drop and reacts to it. closed and done are snapshotted by startSupervisor so
+// that the supervisor watches the channels that belong to this connection cycle
+// even if the fields are later replaced by a reconnect attempt.
+func (c *Client) supervise(closed chan error, done chan struct{}) {
+	if done != nil {
+		defer close(done)
+	}
+
+	// ctxDone is the cancellation channel for the run context. It is nil when a
+	// context was never assigned (defensive: the normal Connect path always sets
+	// one), in which case the select simply blocks on the transport close.
+	var ctxDone <-chan struct{}
+	if c.ctx != nil {
+		ctxDone = c.ctx.Done()
+	}
+
+	var err error
+	select {
+	case err = <-closed:
+	case <-ctxDone:
+		return
+	}
+
+	// A nil error means a graceful stop (Close or upgrade already drained the
+	// channel for us). Nothing to do.
+	if err == nil {
+		return
+	}
+
+	// Close() sets closing before stopping the transport. If the drop is the
+	// result of an intentional Close we must not attempt to reconnect.
+	if atomic.LoadUint32(&c.closing) == 1 {
+		return
+	}
+
+	if !c.reconnect {
+		// Reconnection disabled: surface the drop to the close handler so the
+		// behaviour matches the pre-reconnect client exactly.
+		c.handlerMu.RLock()
+		handler := c.closeHandler
+		c.handlerMu.RUnlock()
+		if handler != nil {
+			handler()
+		}
+		return
+	}
+
+	c.reconnectLoop(err)
+}
+
+// reconnectLoop performs the exponential-backoff reconnect attempts. It fires
+// the "reconnecting" notification before the first attempt, retries up to
+// reconnectAttempts times doubling the wait each time (capped at 8x the base
+// wait), fires "reconnect" on success and "reconnect_failed" (followed by
+// Close) when the attempts are exhausted. The loop stops promptly when the
+// parent context is cancelled or Close() is called.
+func (c *Client) reconnectLoop(cause error) {
+	c.log.Warnf("engine.io connection dropped: %s, reconnecting", cause)
+	c.fireReconnecting()
+
+	base := c.reconnectWait
+	if base <= 0 {
+		base = time.Second
+	}
+	backoff := base
+	maxBackoff := base * 8
+
+	for attempt := 1; attempt <= c.reconnectAttempts; attempt++ {
+		// Respect cancellation/close before waiting and retrying.
+		if c.stopRequested() {
+			return
+		}
+
+		select {
+		case <-time.After(backoff):
+		case <-c.ctx.Done():
+			return
+		}
+
+		if c.stopRequested() {
+			return
+		}
+
+		c.log.Debugf("reconnect attempt %d/%d", attempt, c.reconnectAttempts)
+		err := c.startConnection(c.ctx)
+		if err == nil {
+			c.log.Infof("engine.io reconnected on attempt %d", attempt)
+			c.fireReconnect()
+			return
+		}
+		c.log.Errorf("reconnect attempt %d failed: %s", attempt, err)
+
+		// Exponential backoff with an upper bound so a long-lived outage does
+		// not produce ever-growing waits.
+		backoff *= 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+	}
+
+	c.log.Errorf("engine.io reconnect failed after %d attempts", c.reconnectAttempts)
+	c.fireReconnectFailed()
+
+	// We are running on the supervisor goroutine, so clear supervisorStarted
+	// before calling Close(): otherwise Close() would wait on supervisorDone,
+	// which this very goroutine only closes after Close() returns — a deadlock.
+	atomic.StoreUint32(&c.supervisorStarted, 0)
+	_ = c.Close()
+}
+
+// stopRequested reports whether the reconnect loop should abort because the
+// client is closing or the parent context has been cancelled.
+func (c *Client) stopRequested() bool {
+	if atomic.LoadUint32(&c.closing) == 1 {
+		return true
+	}
+	select {
+	case <-c.ctx.Done():
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *Client) fireReconnecting() {
+	c.handlerMu.RLock()
+	handler := c.reconnectingHandler
+	c.handlerMu.RUnlock()
+	if handler != nil {
+		handler()
+	}
+}
+
+func (c *Client) fireReconnect() {
+	c.handlerMu.RLock()
+	handler := c.reconnectHandler
+	c.handlerMu.RUnlock()
+	if handler != nil {
+		handler()
+	}
+}
+
+func (c *Client) fireReconnectFailed() {
+	c.handlerMu.RLock()
+	handler := c.reconnectFailedHand
+	c.handlerMu.RUnlock()
+	if handler != nil {
+		handler()
+	}
+}

--- a/engine.io/v4/client/reconnect.go
+++ b/engine.io/v4/client/reconnect.go
@@ -113,6 +113,12 @@ func (c *Client) reconnectLoop(cause error) {
 		ctxDone = c.ctx.Done()
 	}
 
+	// closeCh is closed by Close() to wake this backoff wait immediately instead
+	// of blocking for the remaining (possibly multi-second) backoff duration. It
+	// is nil only in tests that build a Client without NewClient; a receive on a
+	// nil channel blocks forever, so the wait simply falls back to the timer/ctx.
+	closeCh := c.closeCh
+
 	for attempt := 1; attempt <= c.reconnectAttempts; attempt++ {
 		// Respect cancellation/close before waiting and retrying.
 		if c.stopRequested() {
@@ -122,6 +128,9 @@ func (c *Client) reconnectLoop(cause error) {
 		select {
 		case <-time.After(backoff):
 		case <-ctxDone:
+			return
+		case <-closeCh:
+			// Close() was called during the backoff wait; stop promptly.
 			return
 		}
 

--- a/engine.io/v4/client/reconnect.go
+++ b/engine.io/v4/client/reconnect.go
@@ -37,7 +37,8 @@ func (c *Client) startSupervisor() {
 		// replaces c.supervisorDone with a fresh channel, so the supervisor must
 		// close the one it was started with, not the current field.
 		done := c.supervisorDone
-		closing := atomic.LoadUint32(&c.closing) == 1
+		closing := atomic.LoadUint32(&c.closing) == 1 ||
+			atomic.LoadUint32(&c.cycleAbandoned) == 1
 		if closed != nil && !closing {
 			atomic.StoreUint32(&c.supervisorStarted, 1)
 		}
@@ -46,8 +47,10 @@ func (c *Client) startSupervisor() {
 			return
 		}
 		if closing {
-			// Close() already ran: it drained transportClosed itself, so a
-			// supervisor started now would block forever on an empty channel.
+			// Close() already ran (or the reconnect loop abandoned this cycle):
+			// the teardown owner drains transportClosed itself, so a supervisor
+			// started now would compete for — or block forever on — that
+			// channel.
 			return
 		}
 		go c.supervise(closed, done)
@@ -204,8 +207,6 @@ func (c *Client) reconnectLoop(cause error) {
 func (c *Client) awaitConnectionEstablished(bound time.Duration) bool {
 	c.transportMu.RLock()
 	wh := c.waitHandshake
-	closed := c.transportClosed
-	transport := c.transport
 	c.transportMu.RUnlock()
 
 	// nil channels block forever in a select, which is exactly the desired
@@ -219,18 +220,14 @@ func (c *Client) awaitConnectionEstablished(bound time.Duration) bool {
 	timer := time.NewTimer(bound)
 	defer timer.Stop()
 
+	// Deliberately NOT selecting on transportClosed here: during a
+	// polling->websocket upgrade, transportUpgrade (running on the message
+	// loop goroutine) must consume the old transport's close notification from
+	// that very channel — stealing it here would leave the upgrade blocked. A
+	// transport that dies before the handshake is instead caught by the timer.
 	select {
 	case <-wh:
 		return true
-	case <-closed:
-		// The transport died before the handshake completed. No supervisor is
-		// watching this cycle yet (it only starts once the handshake is
-		// processed), so this loop owns the teardown: close the drained channel
-		// so a later Close() doesn't block on it, and stop the orphaned
-		// message loop.
-		close(closed)
-		c.stopMessageLoop()
-		return false
 	case <-ctxDone:
 		// Context cancellation winds the transports and the message loop down
 		// on its own; nothing to tear down here.
@@ -240,26 +237,42 @@ func (c *Client) awaitConnectionEstablished(bound time.Duration) bool {
 		// so it drains transportClosed itself).
 		return false
 	case <-timer.C:
-		// The handshake did not complete in time: stop the half-open transport
-		// so the next retry starts clean.
-		if transport == nil {
-			c.stopMessageLoop()
-			return false
-		}
+	}
+
+	// The bound elapsed. Re-check the gate under the lock and abandon the
+	// cycle before touching the transport: transportUpgrade serialises its
+	// drain of transportClosed under transportMu and bails out once the cycle
+	// is abandoned, so after this section there is exactly one consumer (us or
+	// an already-started supervisor) for the close notification.
+	c.transportMu.Lock()
+	select {
+	case <-wh:
+		c.transportMu.Unlock()
+		return true
+	default:
+	}
+	atomic.StoreUint32(&c.cycleAbandoned, 1)
+	transport := c.transport
+	closed := c.transportClosed
+	c.transportMu.Unlock()
+
+	if transport != nil {
 		_ = transport.Stop()
 		select {
 		case <-closed:
+			// Single close notification consumed; close the channel so a later
+			// Close() doesn't block draining it.
 			close(closed)
 		case <-wh:
-			// The handshake completed at the very moment the bound elapsed and
-			// its supervisor now owns transportClosed; it will observe the
-			// Stop() above as a graceful close and exit. The transport is
-			// stopped either way, so still report failure and let the loop
+			// Photo-finish: the handshake completed while we were stopping the
+			// transport and its supervisor consumed the close notification (it
+			// observes the Stop() as a graceful close and exits). The transport
+			// is stopped either way, so still report failure and let the loop
 			// retry with fresh state.
 		}
-		c.stopMessageLoop()
-		return false
 	}
+	c.stopMessageLoop()
+	return false
 }
 
 // stopRequested reports whether the reconnect loop should abort because the

--- a/engine.io/v4/client/reconnect.go
+++ b/engine.io/v4/client/reconnect.go
@@ -22,17 +22,28 @@ import (
 // is a no-op — there is nothing to supervise.
 func (c *Client) startSupervisor() {
 	c.superviseOnce.Do(func() {
+		// Snapshot the cycle's channels and flip supervisorStarted in the same
+		// critical section that startConnection/Close use, so Close() always
+		// observes a consistent supervisorStarted/supervisorDone pair.
 		c.transportMu.RLock()
 		closed := c.transportClosed
-		c.transportMu.RUnlock()
-		if closed == nil {
-			return
-		}
 		// Capture the done channel for THIS cycle. A successful reconnect
 		// replaces c.supervisorDone with a fresh channel, so the supervisor must
 		// close the one it was started with, not the current field.
 		done := c.supervisorDone
-		atomic.StoreUint32(&c.supervisorStarted, 1)
+		closing := atomic.LoadUint32(&c.closing) == 1
+		if closed != nil && !closing {
+			atomic.StoreUint32(&c.supervisorStarted, 1)
+		}
+		c.transportMu.RUnlock()
+		if closed == nil {
+			return
+		}
+		if closing {
+			// Close() already ran: it drained transportClosed itself, so a
+			// supervisor started now would block forever on an empty channel.
+			return
+		}
 		go c.supervise(closed, done)
 	})
 }

--- a/engine.io/v4/client/reconnect.go
+++ b/engine.io/v4/client/reconnect.go
@@ -97,8 +97,20 @@ func (c *Client) supervise(closed chan error, done chan struct{}) {
 	}
 
 	if !c.reconnect {
-		// Reconnection disabled: surface the drop to the close handler so the
-		// behaviour matches the pre-reconnect client exactly.
+		// Reconnection disabled: the drop is terminal for this client. Release
+		// the cycle state BEFORE surfacing it to the close handler, because a
+		// handler that reacts by calling Close() must not deadlock: with
+		// supervisorStarted still set, Close() would wait on supervisorDone —
+		// which this goroutine only closes after the handler returns — and
+		// with the flag cleared it would instead block draining the
+		// transportClosed channel whose single notification was already
+		// consumed above. The channel is closed here (the dead transport sends
+		// exactly one value) so that drain returns immediately.
+		atomic.StoreUint32(&c.supervisorStarted, 0)
+		close(closed)
+
+		// Surface the drop to the close handler so the behaviour matches the
+		// pre-reconnect client exactly.
 		c.handlerMu.RLock()
 		handler := c.closeHandler
 		c.handlerMu.RUnlock()

--- a/engine.io/v4/client/reconnect.go
+++ b/engine.io/v4/client/reconnect.go
@@ -1,9 +1,15 @@
 package engineio_v4_client
 
 import (
+	"errors"
 	"sync/atomic"
 	"time"
 )
+
+// errHandshakeIncomplete marks a reconnect attempt whose transport came up but
+// whose Engine.IO handshake never completed (malformed OPEN packet, failed
+// upgrade, or a transport drop before the OPEN arrived).
+var errHandshakeIncomplete = errors.New("engine.io handshake did not complete")
 
 // startSupervisor launches the reconnect supervisor for the current connection
 // cycle. It is invoked once per successful handshake (guarded by superviseOnce,
@@ -152,9 +158,22 @@ func (c *Client) reconnectLoop(cause error) {
 		c.log.Debugf("reconnect attempt %d/%d", attempt, c.reconnectAttempts)
 		err := c.startConnection(c.ctx)
 		if err == nil {
-			c.log.Infof("engine.io reconnected on attempt %d", attempt)
-			c.fireReconnect()
-			return
+			// startConnection only guarantees the handshake request was sent
+			// (for polling it returns once the first poll response is queued);
+			// the OPEN packet is processed asynchronously by the message loop.
+			// Only declare the reconnect successful once the handshake actually
+			// completed — otherwise a malformed response or a failed upgrade
+			// would fire "reconnect" for a session that never opened and
+			// silently end the retry loop.
+			if c.awaitConnectionEstablished(maxBackoff) {
+				c.log.Infof("engine.io reconnected on attempt %d", attempt)
+				c.fireReconnect()
+				return
+			}
+			if c.stopRequested() {
+				return
+			}
+			err = errHandshakeIncomplete
 		}
 		c.log.Errorf("reconnect attempt %d failed: %s", attempt, err)
 
@@ -174,6 +193,73 @@ func (c *Client) reconnectLoop(cause error) {
 	// which this very goroutine only closes after Close() returns — a deadlock.
 	atomic.StoreUint32(&c.supervisorStarted, 0)
 	_ = c.Close()
+}
+
+// awaitConnectionEstablished waits for the attempt started by startConnection
+// to finish its Engine.IO handshake: handleHandshake closes the waitHandshake
+// gate only after the OPEN packet is processed and an eventual transport
+// upgrade completed. It returns false — after tearing the half-open attempt
+// down — when the transport dies first, the bound elapses, the run context is
+// cancelled or Close() is called.
+func (c *Client) awaitConnectionEstablished(bound time.Duration) bool {
+	c.transportMu.RLock()
+	wh := c.waitHandshake
+	closed := c.transportClosed
+	transport := c.transport
+	c.transportMu.RUnlock()
+
+	// nil channels block forever in a select, which is exactly the desired
+	// fallback for clients built without NewClient/Connect (tests).
+	var ctxDone <-chan struct{}
+	if c.ctx != nil {
+		ctxDone = c.ctx.Done()
+	}
+	closeCh := c.closeCh
+
+	timer := time.NewTimer(bound)
+	defer timer.Stop()
+
+	select {
+	case <-wh:
+		return true
+	case <-closed:
+		// The transport died before the handshake completed. No supervisor is
+		// watching this cycle yet (it only starts once the handshake is
+		// processed), so this loop owns the teardown: close the drained channel
+		// so a later Close() doesn't block on it, and stop the orphaned
+		// message loop.
+		close(closed)
+		c.stopMessageLoop()
+		return false
+	case <-ctxDone:
+		// Context cancellation winds the transports and the message loop down
+		// on its own; nothing to tear down here.
+		return false
+	case <-closeCh:
+		// Close() owns the teardown (attempt finished, supervisor not started,
+		// so it drains transportClosed itself).
+		return false
+	case <-timer.C:
+		// The handshake did not complete in time: stop the half-open transport
+		// so the next retry starts clean.
+		if transport == nil {
+			c.stopMessageLoop()
+			return false
+		}
+		_ = transport.Stop()
+		select {
+		case <-closed:
+			close(closed)
+		case <-wh:
+			// The handshake completed at the very moment the bound elapsed and
+			// its supervisor now owns transportClosed; it will observe the
+			// Stop() above as a graceful close and exit. The transport is
+			// stopped either way, so still report failure and let the loop
+			// retry with fresh state.
+		}
+		c.stopMessageLoop()
+		return false
+	}
 }
 
 // stopRequested reports whether the reconnect loop should abort because the

--- a/engine.io/v4/client/reconnect.go
+++ b/engine.io/v4/client/reconnect.go
@@ -87,9 +87,12 @@ func (c *Client) supervise(closed chan error, done chan struct{}) {
 		return
 	}
 
-	// Close() sets closing before stopping the transport. If the drop is the
-	// result of an intentional Close we must not attempt to reconnect.
-	if atomic.LoadUint32(&c.closing) == 1 {
+	// Close() sets closing before stopping the transport, and a cancelled run
+	// context makes the transports report ctx.Err() on transportClosed — this
+	// select may receive that error before noticing ctxDone. Both are
+	// intentional shutdowns: starting reconnect logic (or invoking the close
+	// handler below) would emit spurious lifecycle events, so bail out first.
+	if c.stopRequested() {
 		return
 	}
 
@@ -230,7 +233,17 @@ func (c *Client) awaitConnectionEstablished(bound time.Duration) bool {
 		// Close() also releases the handshake gate (so parked Send()s fail
 		// fast); a gate closed by that teardown — not by a real handshake —
 		// must not be reported as a successful reconnect.
-		return !c.stopRequested()
+		if c.stopRequested() {
+			return false
+		}
+		if c.handshakeFailure() == nil {
+			return true
+		}
+		// The gate was released by handleHandshake's upgrade-error path: the
+		// handshake never established a session and the half-open attempt may
+		// have already stopped its transports mid-upgrade. Fall through to the
+		// abandon teardown below so the loop retries with fresh state instead
+		// of firing "reconnect" for a dead connection.
 	case <-ctxDone:
 		// Context cancellation winds the transports and the message loop down
 		// on its own, but nothing ever closes this cycle's handshake gate;
@@ -250,13 +263,17 @@ func (c *Client) awaitConnectionEstablished(bound time.Duration) bool {
 	// is abandoned, so after this section there is exactly one consumer (us or
 	// an already-started supervisor) for the close notification.
 	c.transportMu.Lock()
+	completed := false
 	select {
 	case <-wh:
-		c.transportMu.Unlock()
-		// Same guard as above: a gate released by Close()'s teardown is not a
-		// completed handshake.
-		return !c.stopRequested()
+		// Same guards as above: a gate released by Close()'s teardown or by a
+		// failed upgrade is not a completed handshake.
+		completed = c.handshakeErr == nil
 	default:
+	}
+	if completed {
+		c.transportMu.Unlock()
+		return !c.stopRequested()
 	}
 	atomic.StoreUint32(&c.cycleAbandoned, 1)
 	transport := c.transport
@@ -266,10 +283,14 @@ func (c *Client) awaitConnectionEstablished(bound time.Duration) bool {
 	if transport != nil {
 		_ = transport.Stop()
 		select {
-		case <-closed:
+		case _, ok := <-closed:
 			// Single close notification consumed; close the channel so a later
-			// Close() doesn't block draining it.
-			close(closed)
+			// Close() doesn't block draining it. When the failed upgrade
+			// already closed the channel (its new transport never ran), ok is
+			// false and there is nothing left to close.
+			if ok {
+				close(closed)
+			}
 		case <-wh:
 			// Photo-finish: the handshake completed while we were stopping the
 			// transport and its supervisor consumed the close notification (it
@@ -286,6 +307,15 @@ func (c *Client) awaitConnectionEstablished(bound time.Duration) bool {
 	// fast against the stopped transport.
 	c.releaseGates()
 	return false
+}
+
+// handshakeFailure returns the handshake/upgrade error recorded for the
+// current connection cycle, if any. A non-nil value means the handshake gate
+// was released by a failure path, not by an established session.
+func (c *Client) handshakeFailure() error {
+	c.transportMu.RLock()
+	defer c.transportMu.RUnlock()
+	return c.handshakeErr
 }
 
 // stopRequested reports whether the reconnect loop should abort because the

--- a/engine.io/v4/client/reconnect.go
+++ b/engine.io/v4/client/reconnect.go
@@ -227,14 +227,19 @@ func (c *Client) awaitConnectionEstablished(bound time.Duration) bool {
 	// transport that dies before the handshake is instead caught by the timer.
 	select {
 	case <-wh:
-		return true
+		// Close() also releases the handshake gate (so parked Send()s fail
+		// fast); a gate closed by that teardown — not by a real handshake —
+		// must not be reported as a successful reconnect.
+		return !c.stopRequested()
 	case <-ctxDone:
 		// Context cancellation winds the transports and the message loop down
-		// on its own; nothing to tear down here.
+		// on its own, but nothing ever closes this cycle's handshake gate;
+		// release it so Send() callers parked there fail fast.
+		c.releaseGates()
 		return false
 	case <-closeCh:
 		// Close() owns the teardown (attempt finished, supervisor not started,
-		// so it drains transportClosed itself).
+		// so it drains transportClosed itself) and releases the gates.
 		return false
 	case <-timer.C:
 	}
@@ -248,7 +253,9 @@ func (c *Client) awaitConnectionEstablished(bound time.Duration) bool {
 	select {
 	case <-wh:
 		c.transportMu.Unlock()
-		return true
+		// Same guard as above: a gate released by Close()'s teardown is not a
+		// completed handshake.
+		return !c.stopRequested()
 	default:
 	}
 	atomic.StoreUint32(&c.cycleAbandoned, 1)
@@ -272,6 +279,12 @@ func (c *Client) awaitConnectionEstablished(bound time.Duration) bool {
 		}
 	}
 	c.stopMessageLoop()
+	// Release this cycle's handshake gate: nothing will ever close it (the
+	// handshake never completed and the next attempt arms a fresh channel), so
+	// a Send() parked on it — including emitters released by a final
+	// "reconnect_failed" — would otherwise block forever instead of failing
+	// fast against the stopped transport.
+	c.releaseGates()
 	return false
 }
 

--- a/engine.io/v4/client/reconnect_close_race_test.go
+++ b/engine.io/v4/client/reconnect_close_race_test.go
@@ -230,3 +230,22 @@ func TestStartSupervisorSkippedWhenClosing(t *testing.T) {
 	assert.Equal(t, uint32(0), atomic.LoadUint32(&client.supervisorStarted),
 		"supervisor must not be started on a closing client")
 }
+
+// TestStopMessageLoopAlreadyClosedStop covers the defensive branch where the
+// stop channel observed by stopMessageLoop was already closed: the call must
+// not double-close it and must still wait for the loop's done channel.
+func TestStopMessageLoopAlreadyClosedStop(t *testing.T) {
+	t.Parallel()
+	client, _, _, _ := newReconnectClient(t)
+
+	stop := make(chan struct{})
+	close(stop)
+	done := make(chan struct{})
+	close(done)
+	client.transportMu.Lock()
+	client.messagesStop = stop
+	client.messagesDone = done
+	client.transportMu.Unlock()
+
+	assert.NotPanics(t, func() { client.stopMessageLoop() })
+}

--- a/engine.io/v4/client/reconnect_close_race_test.go
+++ b/engine.io/v4/client/reconnect_close_race_test.go
@@ -698,3 +698,53 @@ func TestSuperviseContextErrorOnTransportClosed(t *testing.T) {
 	default:
 	}
 }
+
+// TestSuperviseCloseHandlerCallsClose reproduces the review finding: with
+// reconnect disabled, the close handler runs on the supervisor goroutine, and
+// a handler that reacts to the drop by calling Close() must not deadlock —
+// neither waiting on supervisorDone (closed only after the handler returns)
+// nor draining the transportClosed channel whose single notification the
+// supervisor already consumed.
+func TestSuperviseCloseHandlerCallsClose(t *testing.T) {
+	t.Parallel()
+	client, transport, _, _ := newReconnectClient(t)
+	client.reconnect = false
+
+	closed := make(chan error, 1)
+	closed <- errors.New("dropped")
+	client.transportMu.Lock()
+	client.transportClosed = closed
+	client.transportMu.Unlock()
+	atomic.StoreUint32(&client.supervisorStarted, 1)
+
+	transport.EXPECT().Stop().Return(nil).AnyTimes()
+
+	closeErr := make(chan error, 1)
+	client.closeHandler = func() {
+		closeErr <- client.Close()
+	}
+
+	done := make(chan struct{})
+	finished := make(chan struct{})
+	go func() {
+		client.supervise(closed, done)
+		close(finished)
+	}()
+
+	select {
+	case err := <-closeErr:
+		assert.NoError(t, err, "Close from the close handler must complete")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close called from the close handler deadlocked")
+	}
+	select {
+	case <-finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("supervise did not return")
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("supervisorDone was not closed")
+	}
+}

--- a/engine.io/v4/client/reconnect_close_race_test.go
+++ b/engine.io/v4/client/reconnect_close_race_test.go
@@ -1,0 +1,232 @@
+package engineio_v4_client
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCloseDuringInFlightAttemptHandshake reproduces the review finding: Close()
+// racing with a reconnect attempt that is blocked in RequestHandshake. The stale
+// supervisorStarted flag from the old supervisor must not make Close() wait on
+// the attempt's fresh (unowned) supervisorDone channel forever, and Close() must
+// not compete with the attempt's cleanup for the single transportClosed value.
+func TestCloseDuringInFlightAttemptHandshake(t *testing.T) {
+	t.Parallel()
+	client, transport, _, _ := newReconnectClient(t)
+
+	// Simulate the reconnect context: the old supervisor goroutine (which would
+	// be running reconnectLoop -> startConnection) left its flag set.
+	atomic.StoreUint32(&client.supervisorStarted, 1)
+
+	handshakeStarted := make(chan struct{})
+	handshakeAbort := make(chan struct{})
+	var abortOnce sync.Once
+
+	var onCloseCh atomic.Value // chan<- error
+	transport.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *url.URL, _ string, _ chan<- []byte, onClose chan<- error) error {
+			onCloseCh.Store(onClose)
+			return nil
+		})
+	transport.EXPECT().RequestHandshake().DoAndReturn(func() error {
+		close(handshakeStarted)
+		<-handshakeAbort
+		return errors.New("handshake aborted")
+	})
+	transport.EXPECT().Stop().DoAndReturn(func() error {
+		abortOnce.Do(func() {
+			// The transport loop exits and reports once.
+			if ch, ok := onCloseCh.Load().(chan<- error); ok {
+				ch <- nil
+			}
+			close(handshakeAbort)
+		})
+		return nil
+	}).AnyTimes()
+
+	attemptDone := make(chan error, 1)
+	go func() {
+		attemptDone <- client.startConnection(context.Background())
+	}()
+
+	<-handshakeStarted
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- client.Close()
+	}()
+
+	select {
+	case err := <-closeDone:
+		assert.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close deadlocked during an in-flight reconnect attempt")
+	}
+
+	select {
+	case err := <-attemptDone:
+		assert.Error(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("startConnection did not finish after Close")
+	}
+}
+
+// TestStartConnectionAfterClose verifies the entry guard: an attempt that runs
+// after Close() must bail out with errClientClosed and must not resurrect the
+// transport that Close() already nil'ed.
+func TestStartConnectionAfterClose(t *testing.T) {
+	t.Parallel()
+	client, transport, _, _ := newReconnectClient(t)
+	client.initialTransport = transport
+
+	atomic.StoreUint32(&client.closing, 1)
+	client.transportMu.Lock()
+	client.transport = nil
+	client.transportMu.Unlock()
+
+	err := client.startConnection(context.Background())
+	assert.ErrorIs(t, err, errClientClosed)
+
+	client.transportMu.RLock()
+	defer client.transportMu.RUnlock()
+	assert.Nil(t, client.transport, "startConnection must not resurrect the transport after Close")
+}
+
+// TestStartConnectionCloseRaceAfterRun covers the window between transport.Run
+// and the message loop start: a Close() that hit that window stopped a transport
+// that was not running yet, so the attempt itself must tear the fresh transport
+// down and report errClientClosed.
+func TestStartConnectionCloseRaceAfterRun(t *testing.T) {
+	t.Parallel()
+	client, transport, _, _ := newReconnectClient(t)
+
+	var onCloseCh chan<- error
+	transport.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *url.URL, _ string, _ chan<- []byte, onClose chan<- error) error {
+			onCloseCh = onClose
+			// Close() lands exactly between Run() and the post-Run check.
+			atomic.StoreUint32(&client.closing, 1)
+			return nil
+		})
+	transport.EXPECT().Stop().DoAndReturn(func() error {
+		onCloseCh <- nil
+		return nil
+	})
+
+	err := client.startConnection(context.Background())
+	assert.ErrorIs(t, err, errClientClosed)
+
+	// The cycle's channels are fully torn down: supervisorDone closed,
+	// transportClosed drained and closed.
+	select {
+	case <-client.supervisorDone:
+	default:
+		t.Fatal("supervisorDone was not closed by the teardown")
+	}
+}
+
+// TestStartConnectionCloseRaceAfterHandshake covers the window between a
+// successful RequestHandshake and startConnection's return: the final closing
+// check must tear the connection down instead of leaving it running on a closed
+// client.
+func TestStartConnectionCloseRaceAfterHandshake(t *testing.T) {
+	t.Parallel()
+	client, transport, _, _ := newReconnectClient(t)
+
+	var onCloseCh chan<- error
+	transport.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *url.URL, _ string, _ chan<- []byte, onClose chan<- error) error {
+			onCloseCh = onClose
+			return nil
+		})
+	transport.EXPECT().RequestHandshake().DoAndReturn(func() error {
+		// Close() lands while the handshake request is completing.
+		atomic.StoreUint32(&client.closing, 1)
+		return nil
+	})
+	transport.EXPECT().Stop().DoAndReturn(func() error {
+		onCloseCh <- nil
+		return nil
+	})
+
+	err := client.startConnection(context.Background())
+	assert.ErrorIs(t, err, errClientClosed)
+
+	select {
+	case <-client.supervisorDone:
+	default:
+		t.Fatal("supervisorDone was not closed by the teardown")
+	}
+	// The message loop was stopped via its stop signal.
+	client.transportMu.RLock()
+	assert.Nil(t, client.messagesStop)
+	client.transportMu.RUnlock()
+}
+
+// TestCloseAfterHandshakeErrorAttempt verifies that a Close() issued after a
+// failed attempt (e.g. on reconnect exhaustion) does not block draining the
+// already-consumed transportClosed channel and does not double-close the
+// messages channel that the failed attempt already closed.
+func TestCloseAfterHandshakeErrorAttempt(t *testing.T) {
+	t.Parallel()
+	client, transport, _, _ := newReconnectClient(t)
+	hsErr := errors.New("handshake failed")
+
+	var onCloseCh chan<- error
+	transport.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *url.URL, _ string, _ chan<- []byte, onClose chan<- error) error {
+			onCloseCh = onClose
+			return nil
+		})
+	transport.EXPECT().RequestHandshake().Return(hsErr)
+	var deliverOnce sync.Once
+	transport.EXPECT().Stop().DoAndReturn(func() error {
+		// The transport reports its loop exit exactly once; a second Stop()
+		// (from Close) must not send again — the attempt's cleanup has already
+		// drained and closed the channel.
+		deliverOnce.Do(func() {
+			if onCloseCh != nil {
+				onCloseCh <- nil
+			}
+		})
+		return nil
+	}).AnyTimes()
+
+	err := client.startConnection(context.Background())
+	require.ErrorIs(t, err, hsErr)
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- client.Close()
+	}()
+	select {
+	case err := <-closeDone:
+		assert.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close blocked after a failed connection attempt")
+	}
+}
+
+// TestStartSupervisorSkippedWhenClosing ensures a handshake that completes
+// after Close() does not start a supervisor that would block forever on the
+// transportClosed channel Close() already drained.
+func TestStartSupervisorSkippedWhenClosing(t *testing.T) {
+	t.Parallel()
+	client, _, _, _ := newReconnectClient(t)
+	client.supervisorDone = make(chan struct{})
+
+	atomic.StoreUint32(&client.closing, 1)
+	client.startSupervisor()
+
+	assert.Equal(t, uint32(0), atomic.LoadUint32(&client.supervisorStarted),
+		"supervisor must not be started on a closing client")
+}

--- a/engine.io/v4/client/reconnect_close_race_test.go
+++ b/engine.io/v4/client/reconnect_close_race_test.go
@@ -515,3 +515,84 @@ func TestAwaitConnectionEstablishedPhotoFinish(t *testing.T) {
 		t.Fatal("awaitConnectionEstablished did not return")
 	}
 }
+
+// TestAbandonedAttemptReleasesHandshakeGate reproduces the review finding: a
+// reconnect attempt that is abandoned because its handshake never completed
+// must close the cycle's waitHandshake gate. Every cycle arms a FRESH channel,
+// so a Send() parked on an abandoned cycle's gate would otherwise block
+// forever — even after a later successful reconnect or a final
+// "reconnect_failed" — instead of failing fast against the dead transport.
+func TestAbandonedAttemptReleasesHandshakeGate(t *testing.T) {
+	t.Parallel()
+	client, transport, parser, _ := newReconnectClient(t)
+	client.transportMu.Lock()
+	client.waitHandshake = make(chan struct{}, 1)
+	client.transportClosed = make(chan error, 1)
+	client.transportMu.Unlock()
+
+	transport.EXPECT().Stop().DoAndReturn(func() error {
+		client.transportClosed <- nil
+		return nil
+	})
+	// The woken Send() proceeds to the stopped transport and must surface its
+	// error instead of blocking on the gate.
+	sendErr := errors.New("transport stopped")
+	parser.EXPECT().Serialize(gomock.Any()).Return([]byte("4x"), nil).AnyTimes()
+	transport.EXPECT().SendMessage(gomock.Any()).Return(sendErr).AnyTimes()
+
+	// Park a Send() on the handshake gate before the attempt is abandoned.
+	sendDone := make(chan error, 1)
+	go func() { sendDone <- client.Send([]byte("x")) }()
+
+	assert.False(t, client.awaitConnectionEstablished(10*time.Millisecond))
+
+	select {
+	case err := <-sendDone:
+		assert.ErrorIs(t, err, sendErr, "the parked Send must fail against the stopped transport")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Send stayed parked on the abandoned cycle's handshake gate")
+	}
+
+	// The gate itself must be observably closed for future Send() snapshots.
+	client.transportMu.RLock()
+	wh := client.waitHandshake
+	client.transportMu.RUnlock()
+	select {
+	case <-wh:
+	default:
+		t.Fatal("waitHandshake left open after the attempt was abandoned")
+	}
+}
+
+// TestCloseReleasesGates verifies that Close() releases both the handshake and
+// the upgrade gate, so a Send() parked on either wakes, observes the nil
+// transport and fails fast with "client is closed".
+func TestCloseReleasesGates(t *testing.T) {
+	t.Parallel()
+	client, transport, _, _ := newReconnectClient(t)
+	client.transportMu.Lock()
+	client.waitHandshake = make(chan struct{}, 1)
+	client.waitUpgrade = make(chan struct{}, 1)
+	client.transportClosed = make(chan error, 1)
+	client.transportMu.Unlock()
+
+	transport.EXPECT().Stop().DoAndReturn(func() error {
+		client.transportClosed <- nil
+		return nil
+	})
+
+	// Park one Send() before Close(); it waits on both gates.
+	sendDone := make(chan error, 1)
+	go func() { sendDone <- client.Send([]byte("x")) }()
+	// Give the Send a moment to snapshot the gates and park.
+	time.Sleep(20 * time.Millisecond)
+
+	require.NoError(t, client.Close())
+
+	select {
+	case err := <-sendDone:
+		assert.ErrorContains(t, err, "client is closed")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Send stayed parked on the gates after Close")
+	}
+}

--- a/engine.io/v4/client/reconnect_close_race_test.go
+++ b/engine.io/v4/client/reconnect_close_race_test.go
@@ -249,3 +249,185 @@ func TestStopMessageLoopAlreadyClosedStop(t *testing.T) {
 
 	assert.NotPanics(t, func() { client.stopMessageLoop() })
 }
+
+// TestAwaitConnectionEstablished covers the failure arms of the
+// post-startConnection handshake wait introduced for reconnect attempts.
+func TestAwaitConnectionEstablished(t *testing.T) {
+	t.Parallel()
+
+	t.Run("transport dies before the handshake", func(t *testing.T) {
+		t.Parallel()
+		client, _, _, _ := newReconnectClient(t)
+		client.transportMu.Lock()
+		client.waitHandshake = make(chan struct{}, 1)
+		client.transportClosed = make(chan error, 1)
+		client.transportClosed <- errors.New("dropped")
+		closed := client.transportClosed
+		client.transportMu.Unlock()
+
+		assert.False(t, client.awaitConnectionEstablished(time.Second))
+		// The drained channel must be closed so a later Close() doesn't block.
+		select {
+		case _, ok := <-closed:
+			assert.False(t, ok, "transportClosed must be closed after the drain")
+		default:
+			t.Fatal("transportClosed left open")
+		}
+	})
+
+	t.Run("handshake never completes within the bound", func(t *testing.T) {
+		t.Parallel()
+		client, transport, _, _ := newReconnectClient(t)
+		client.transportMu.Lock()
+		client.waitHandshake = make(chan struct{}, 1)
+		client.transportClosed = make(chan error, 1)
+		client.transportMu.Unlock()
+
+		transport.EXPECT().Stop().DoAndReturn(func() error {
+			client.transportClosed <- nil
+			return nil
+		})
+
+		assert.False(t, client.awaitConnectionEstablished(10*time.Millisecond))
+	})
+
+	t.Run("handshake completes exactly at the bound", func(t *testing.T) {
+		t.Parallel()
+		client, transport, _, _ := newReconnectClient(t)
+		client.transportMu.Lock()
+		client.waitHandshake = make(chan struct{}, 1)
+		client.transportClosed = make(chan error, 1)
+		client.transportMu.Unlock()
+
+		// Stop() races a handshake that completes right after the bound: the
+		// teardown select must take the waitHandshake arm and not block on the
+		// transportClosed channel the new supervisor would own.
+		transport.EXPECT().Stop().DoAndReturn(func() error {
+			completeHandshake(client)
+			return nil
+		})
+
+		assert.False(t, client.awaitConnectionEstablished(10*time.Millisecond))
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		t.Parallel()
+		client, _, _, _ := newReconnectClient(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		client.ctx = ctx
+		client.transportMu.Lock()
+		client.waitHandshake = make(chan struct{}, 1)
+		client.transportClosed = make(chan error, 1)
+		client.transportMu.Unlock()
+
+		assert.False(t, client.awaitConnectionEstablished(time.Second))
+	})
+
+	t.Run("close wakes the wait", func(t *testing.T) {
+		t.Parallel()
+		client, _, _, _ := newReconnectClient(t)
+		client.closeCh = make(chan struct{})
+		close(client.closeCh)
+		client.transportMu.Lock()
+		client.waitHandshake = make(chan struct{}, 1)
+		client.transportClosed = make(chan error, 1)
+		client.transportMu.Unlock()
+
+		assert.False(t, client.awaitConnectionEstablished(time.Second))
+	})
+
+	t.Run("nil transport at timeout", func(t *testing.T) {
+		t.Parallel()
+		client, _, _, _ := newReconnectClient(t)
+		client.transportMu.Lock()
+		client.transport = nil
+		client.waitHandshake = make(chan struct{}, 1)
+		client.transportClosed = make(chan error, 1)
+		client.transportMu.Unlock()
+
+		assert.False(t, client.awaitConnectionEstablished(10*time.Millisecond))
+	})
+}
+
+// TestReconnectLoopHandshakeIncomplete verifies that an attempt whose
+// handshake never completes is treated as failed and retried instead of
+// firing "reconnect" for a session that never opened.
+func TestReconnectLoopHandshakeIncomplete(t *testing.T) {
+	t.Parallel()
+	client, transport, _, _ := newReconnectClient(t)
+	client.reconnectAttempts = 2
+
+	var reconnected int32
+	client.reconnectHandler = func() { atomic.AddInt32(&reconnected, 1) }
+	failedCh := make(chan struct{})
+	client.reconnectFailedHand = func() { close(failedCh) }
+
+	// Every attempt starts fine but the OPEN packet never arrives, so the
+	// handshake gate stays open and the bound elapses. The Stop mock delivers
+	// exactly one close notification per Run (like a real transport): the
+	// extra Stop() from the exhaustion Close() must not send again into a
+	// channel the await teardown already drained and closed.
+	var lifecycleMu sync.Mutex
+	pendingRuns := 0
+	transport.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(context.Context, *url.URL, string, chan<- []byte, chan<- error) error {
+			lifecycleMu.Lock()
+			pendingRuns++
+			lifecycleMu.Unlock()
+			return nil
+		}).Times(2)
+	transport.EXPECT().RequestHandshake().Return(nil).Times(2)
+	transport.EXPECT().Stop().DoAndReturn(func() error {
+		lifecycleMu.Lock()
+		defer lifecycleMu.Unlock()
+		if pendingRuns == 0 {
+			return nil
+		}
+		pendingRuns--
+		client.transportMu.RLock()
+		closed := client.transportClosed
+		client.transportMu.RUnlock()
+		closed <- nil
+		return nil
+	}).AnyTimes()
+
+	client.reconnectLoop(errors.New("connection dropped"))
+
+	select {
+	case <-failedCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reconnect_failed not fired for incomplete handshakes")
+	}
+	assert.Equal(t, int32(0), atomic.LoadInt32(&reconnected),
+		"reconnect must not fire when the handshake never completed")
+}
+
+// TestReconnectLoopStopDuringAwait verifies that a cancellation arriving while
+// the loop waits for the handshake makes the loop exit without further retries
+// or a reconnect_failed notification.
+func TestReconnectLoopStopDuringAwait(t *testing.T) {
+	t.Parallel()
+	client, transport, _, _ := newReconnectClient(t)
+	client.reconnectAttempts = 3
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client.ctx = ctx
+
+	var failed int32
+	client.reconnectFailedHand = func() { atomic.AddInt32(&failed, 1) }
+
+	transport.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).Times(1)
+	transport.EXPECT().RequestHandshake().DoAndReturn(func() error {
+		// The run context is cancelled while the loop is waiting for the
+		// handshake to complete.
+		cancel()
+		return nil
+	}).Times(1)
+
+	client.reconnectLoop(errors.New("connection dropped"))
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(&failed),
+		"a cancelled session must not be reported as reconnect_failed")
+}

--- a/engine.io/v4/client/reconnect_close_race_test.go
+++ b/engine.io/v4/client/reconnect_close_race_test.go
@@ -596,3 +596,105 @@ func TestCloseReleasesGates(t *testing.T) {
 		t.Fatal("Send stayed parked on the gates after Close")
 	}
 }
+
+// TestAwaitConnectionEstablishedUpgradeFailure reproduces the review finding:
+// handleHandshake's upgrade-error path closes waitHandshake (to wake parked
+// senders) after recording the failure in handshakeErr. A reconnect attempt
+// waiting on that gate must treat the closure as a FAILED attempt — tearing
+// the half-open cycle down and letting the loop retry — not as a successful
+// reconnect on a connection whose transports were stopped mid-upgrade.
+func TestAwaitConnectionEstablishedUpgradeFailure(t *testing.T) {
+	t.Parallel()
+
+	t.Run("probe failure leaves the new transport running", func(t *testing.T) {
+		t.Parallel()
+		client, transport, _, _ := newReconnectClient(t)
+		client.transportMu.Lock()
+		client.waitHandshake = make(chan struct{}, 1)
+		client.transportClosed = make(chan error, 1)
+		client.handshakeErr = errors.New("probe send failed")
+		client.transportMu.Unlock()
+		// The gate is released by the upgrade-error path after the error is
+		// recorded.
+		client.hadHandshake.Do(func() { close(client.waitHandshake) })
+
+		// The teardown must stop the still-running transport of the half-open
+		// attempt. Stop may race the photo-finish select arm, so the close
+		// notification may or may not be drained here — both are valid.
+		transport.EXPECT().Stop().DoAndReturn(func() error {
+			select {
+			case client.transportClosed <- nil:
+			default:
+			}
+			return nil
+		})
+
+		assert.False(t, client.awaitConnectionEstablished(time.Second),
+			"a failed upgrade must not be reported as a successful reconnect")
+	})
+
+	t.Run("upgrade run failure already closed transportClosed", func(t *testing.T) {
+		t.Parallel()
+		client, transport, _, _ := newReconnectClient(t)
+		client.transportMu.Lock()
+		client.waitHandshake = make(chan struct{}, 1)
+		// transportUpgrade closes the fresh channel itself when the new
+		// transport's Run fails; the teardown must not close it a second time.
+		closed := make(chan error)
+		close(closed)
+		client.transportClosed = closed
+		client.handshakeErr = errors.New("run websocket failed")
+		client.transportMu.Unlock()
+		client.hadHandshake.Do(func() { close(client.waitHandshake) })
+
+		transport.EXPECT().Stop().Return(nil)
+
+		assert.False(t, client.awaitConnectionEstablished(time.Second))
+	})
+}
+
+// A gate closed while Close() is in progress must not report success even when
+// the close raced ahead of the handshake (first-select arm of the wait).
+func TestAwaitConnectionEstablishedClosedGateWhileClosing(t *testing.T) {
+	t.Parallel()
+	client, _, _, _ := newReconnectClient(t)
+	client.transportMu.Lock()
+	client.waitHandshake = make(chan struct{}, 1)
+	client.transportMu.Unlock()
+	client.hadHandshake.Do(func() { close(client.waitHandshake) })
+	atomic.StoreUint32(&client.closing, 1)
+
+	assert.False(t, client.awaitConnectionEstablished(time.Second),
+		"a gate released by Close's teardown is not a completed handshake")
+}
+
+// TestSuperviseContextErrorOnTransportClosed reproduces the review finding: a
+// cancelled run context makes the transports report ctx.Err() on the
+// transportClosed channel, and the supervisor's select may receive that error
+// before noticing the context cancellation. That is a normal shutdown — it
+// must not fire "reconnecting" (or the close handler when reconnect is
+// disabled).
+func TestSuperviseContextErrorOnTransportClosed(t *testing.T) {
+	t.Parallel()
+	client, _, _, _ := newReconnectClient(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	client.ctx = ctx
+	cancel()
+
+	fired := make(chan struct{}, 1)
+	client.reconnectingHandler = func() { fired <- struct{}{} }
+	client.closeHandler = func() { fired <- struct{}{} }
+
+	// The transport reports the cancellation as a close error; the buffered
+	// value is available immediately, so the select can take the closed arm.
+	closed := make(chan error, 1)
+	closed <- ctx.Err()
+	done := make(chan struct{})
+	client.supervise(closed, done)
+
+	select {
+	case <-fired:
+		t.Fatal("supervise started reconnect logic for a context-based shutdown")
+	default:
+	}
+}

--- a/engine.io/v4/client/reconnect_close_race_test.go
+++ b/engine.io/v4/client/reconnect_close_race_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	mocks "github.com/maldikhan/go.socket.io/engine.io/v4/client/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -257,15 +258,20 @@ func TestAwaitConnectionEstablished(t *testing.T) {
 
 	t.Run("transport dies before the handshake", func(t *testing.T) {
 		t.Parallel()
-		client, _, _, _ := newReconnectClient(t)
+		client, transport, _, _ := newReconnectClient(t)
 		client.transportMu.Lock()
 		client.waitHandshake = make(chan struct{}, 1)
 		client.transportClosed = make(chan error, 1)
+		// The dead transport's close notification is already queued; the wait
+		// must not steal it early (an upgrade drain could own it) — the death
+		// is detected via the bound, after which this loop owns the drain.
 		client.transportClosed <- errors.New("dropped")
 		closed := client.transportClosed
 		client.transportMu.Unlock()
 
-		assert.False(t, client.awaitConnectionEstablished(time.Second))
+		transport.EXPECT().Stop().Return(nil)
+
+		assert.False(t, client.awaitConnectionEstablished(10*time.Millisecond))
 		// The drained channel must be closed so a later Close() doesn't block.
 		select {
 		case _, ok := <-closed:
@@ -430,4 +436,82 @@ func TestReconnectLoopStopDuringAwait(t *testing.T) {
 
 	assert.Equal(t, int32(0), atomic.LoadInt32(&failed),
 		"a cancelled session must not be reported as reconnect_failed")
+}
+
+// TestTransportUpgradeBailsOnAbandonedCycle reproduces the review finding: a
+// reconnect attempt that timed out owns the transportClosed drain, so a
+// late-arriving OPEN packet must not let transportUpgrade stop/replace the
+// transport or compete for the close notification.
+func TestTransportUpgradeBailsOnAbandonedCycle(t *testing.T) {
+	t.Parallel()
+	client, _, _, _ := newReconnectClient(t)
+	atomic.StoreUint32(&client.cycleAbandoned, 1)
+
+	newTransport := mocks.NewMockTransport(gomock.NewController(t))
+
+	err := client.transportUpgrade(newTransport)
+	assert.ErrorIs(t, err, errClientClosed)
+
+	// The upgrade gate must be released so Send() callers don't block.
+	client.transportMu.RLock()
+	wu := client.waitUpgrade
+	client.transportMu.RUnlock()
+	select {
+	case <-wu:
+	default:
+		t.Fatal("waitUpgrade left open after an abandoned upgrade")
+	}
+}
+
+// TestStartSupervisorSkippedWhenCycleAbandoned mirrors the closing guard: a
+// handshake that completes after the reconnect loop abandoned the cycle must
+// not start a supervisor that would compete for transportClosed.
+func TestStartSupervisorSkippedWhenCycleAbandoned(t *testing.T) {
+	t.Parallel()
+	client, _, _, _ := newReconnectClient(t)
+	client.supervisorDone = make(chan struct{})
+	atomic.StoreUint32(&client.cycleAbandoned, 1)
+
+	client.startSupervisor()
+	assert.Equal(t, uint32(0), atomic.LoadUint32(&client.supervisorStarted),
+		"supervisor must not start on an abandoned cycle")
+}
+
+// TestAwaitConnectionEstablishedPhotoFinish covers the under-lock re-check of
+// the handshake gate: the test holds transportMu while the bound elapses, so
+// the wait commits to the timeout arm, then closes the gate before releasing
+// the lock — the re-check must observe the completed handshake and report
+// success instead of tearing the established session down.
+func TestAwaitConnectionEstablishedPhotoFinish(t *testing.T) {
+	t.Parallel()
+	client, _, _, _ := newReconnectClient(t)
+
+	wh := make(chan struct{})
+	client.transportMu.Lock()
+	client.waitHandshake = wh
+	client.transportClosed = make(chan error, 1)
+	client.transportMu.Unlock()
+
+	result := make(chan bool, 1)
+	go func() {
+		result <- client.awaitConnectionEstablished(200 * time.Millisecond)
+	}()
+
+	// Let the wait pass its entry snapshot and enter the select, then block its
+	// post-timeout lock acquisition while the bound elapses.
+	time.Sleep(50 * time.Millisecond)
+	client.transportMu.Lock()
+	// The bound elapses while we hold the lock, so the wait commits to the
+	// timeout arm and parks on transportMu; complete the handshake before
+	// releasing the lock so the under-lock re-check observes it.
+	time.Sleep(300 * time.Millisecond)
+	close(wh)
+	client.transportMu.Unlock()
+
+	select {
+	case ok := <-result:
+		assert.True(t, ok, "a handshake completed before the re-check must be reported as success")
+	case <-time.After(2 * time.Second):
+		t.Fatal("awaitConnectionEstablished did not return")
+	}
 }

--- a/engine.io/v4/client/reconnect_close_test.go
+++ b/engine.io/v4/client/reconnect_close_test.go
@@ -1,0 +1,91 @@
+package engineio_v4_client
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestReconnectBackoffWakesOnClose is the issue-B regression test. When Close()
+// is called while the reconnect supervisor is parked in its backoff wait, the
+// loop must wake immediately via closeCh instead of blocking for the full (here
+// deliberately huge) backoff duration. We drive the wake signal exactly as
+// Close() does — set the closing flag, then close closeCh — and assert
+// reconnectLoop returns well under the configured backoff.
+func TestReconnectBackoffWakesOnClose(t *testing.T) {
+	client, _, _, _ := newReconnectClient(t)
+	// A backoff far larger than the test deadline: if the loop waited it out the
+	// test would time out, proving the wake came from closeCh and not the timer.
+	client.reconnectWait = 30 * time.Second
+	client.closeCh = make(chan struct{})
+
+	done := make(chan struct{})
+	start := time.Now()
+	go func() {
+		client.reconnectLoop(assertErr("dropped"))
+		close(done)
+	}()
+
+	// Let the loop reach its backoff wait, then signal Close() exactly as the real
+	// Close() does: mark closing first (so the post-wait stopRequested aborts) and
+	// then close closeCh to wake the select.
+	time.Sleep(20 * time.Millisecond)
+	atomic.StoreUint32(&client.closing, 1)
+	close(client.closeCh)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reconnectLoop did not wake promptly on closeCh during backoff")
+	}
+
+	assert.Less(t, time.Since(start), 5*time.Second,
+		"reconnectLoop must return well under the 30s backoff once Close signals closeCh")
+}
+
+// TestCloseReturnsPromptlyDuringBackoff exercises the full Close() path while a
+// reconnect backoff is in progress and asserts Close() itself returns promptly
+// (well under the backoff). The supervisor owns transportClosed here, so Close()
+// waits on supervisorDone; closing closeCh unblocks the backoff so the supervisor
+// goroutine can exit and Close() can return.
+func TestCloseReturnsPromptlyDuringBackoff(t *testing.T) {
+	client, transport, _, _ := newReconnectClient(t)
+	client.reconnectWait = 30 * time.Second
+	client.closeCh = make(chan struct{})
+	client.supervisorDone = make(chan struct{})
+
+	// Close() stops the live transport once during teardown.
+	transport.EXPECT().Stop().Return(nil)
+
+	// Mark a supervisor as running and drive supervise() so that, on a non-nil
+	// transport drop, it enters reconnectLoop and parks in the backoff wait.
+	atomic.StoreUint32(&client.supervisorStarted, 1)
+	closed := client.transportClosed
+	done := client.supervisorDone
+	go client.supervise(closed, done)
+
+	// Report an unexpected drop so supervise() proceeds into reconnectLoop.
+	closed <- assertErr("dropped")
+
+	// Give the supervisor time to enter the backoff wait.
+	time.Sleep(20 * time.Millisecond)
+
+	// Close() must return promptly: it closes closeCh (waking the backoff), then
+	// waits on supervisorDone, which the now-woken supervisor closes on exit.
+	closeReturned := make(chan struct{})
+	start := time.Now()
+	go func() {
+		_ = client.Close()
+		close(closeReturned)
+	}()
+
+	select {
+	case <-closeReturned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close() did not return promptly while a reconnect backoff was in progress")
+	}
+	assert.Less(t, time.Since(start), 5*time.Second,
+		"Close() must not block for the full backoff duration")
+}

--- a/engine.io/v4/client/reconnect_fix_test.go
+++ b/engine.io/v4/client/reconnect_fix_test.go
@@ -1,0 +1,206 @@
+package engineio_v4_client
+
+import (
+	"context"
+	"net/url"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	engineio_v4 "github.com/maldikhan/go.socket.io/engine.io/v4"
+	mocks "github.com/maldikhan/go.socket.io/engine.io/v4/client/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestReconnectRestoresInitialTransportAndClearsSid is the Bug 1 regression
+// test. After a polling->websocket upgrade c.transport is the websocket
+// transport and c.sid is the live session id. A reconnect must start a FRESH
+// Engine.IO session: it must dial on the INITIAL (polling) transport with an
+// EMPTY sid so the server performs a brand-new handshake rather than rejecting
+// a resume of a dead session.
+func TestReconnectRestoresInitialTransportAndClearsSid(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	logger := mocks.NewMockLogger(ctrl)
+	logger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+	logger.EXPECT().Infof(gomock.Any(), gomock.Any()).AnyTimes()
+	logger.EXPECT().Warnf(gomock.Any(), gomock.Any()).AnyTimes()
+	logger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
+
+	initial := mocks.NewMockTransport(ctrl)  // polling transport (real handshake)
+	upgraded := mocks.NewMockTransport(ctrl) // websocket transport (no-op handshake)
+
+	client := &Client{
+		url:               &url.URL{Scheme: "http", Host: "localhost:8080"},
+		transport:         upgraded, // post-upgrade state
+		initialTransport:  initial,  // captured on the first connect
+		sid:               "dead-session-id",
+		parser:            mocks.NewMockParser(ctrl),
+		log:               logger,
+		pingInterval:      time.NewTicker(time.Second),
+		reconnect:         true,
+		reconnectAttempts: 3,
+		reconnectWait:     time.Millisecond,
+		supportedTransports: map[engineio_v4.EngineIOTransport]Transport{
+			engineio_v4.TransportPolling: initial,
+		},
+		transportClosed: make(chan error, 1),
+	}
+	client.ctx = context.Background()
+
+	// The reconnect attempt MUST run on the initial transport with an empty sid.
+	var ranSid string
+	initial.EXPECT().
+		Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *url.URL, sid string, _ chan<- []byte, _ chan<- error) error {
+			ranSid = sid
+			return nil
+		})
+	initial.EXPECT().RequestHandshake().Return(nil)
+
+	err := client.startConnection(client.ctx)
+	assert.NoError(t, err)
+
+	// The upgraded (websocket) transport must NOT have been dialed.
+	assert.Same(t, initial, client.transport, "reconnect must restore the initial transport")
+	assert.Equal(t, "", ranSid, "reconnect must dial with an empty sid for a fresh session")
+	assert.Equal(t, "", client.sid, "stale sid must be cleared before reconnecting")
+
+	// Clean up the message loop the successful cycle started.
+	client.transportClosed <- nil
+	initial.EXPECT().Stop().Return(nil)
+	_ = client.Close()
+}
+
+// TestConnectCapturesInitialTransport verifies Connect records the pre-upgrade
+// transport on the first connect (covering the initial-transport capture branch).
+func TestConnectCapturesInitialTransport(t *testing.T) {
+	client, transport, _, _ := newReconnectClient(t)
+	client.initialTransport = nil
+
+	transport.EXPECT().
+		Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+	transport.EXPECT().RequestHandshake().Return(nil).AnyTimes()
+
+	err := client.Connect(context.Background())
+	assert.NoError(t, err)
+	assert.Same(t, transport, client.initialTransport, "Connect must capture the initial transport")
+
+	// Clean up the cycle's message loop.
+	client.transportClosed <- nil
+	transport.EXPECT().Stop().Return(nil)
+	_ = client.Close()
+}
+
+// TestNoMessageLoopLeakAcrossReconnect is the Bug 2 regression test. On a
+// reconnect, startConnection must tear down the previous cycle's messageLoop
+// (closing its messagesDone) before installing fresh channels, so the old
+// goroutine never leaks. We assert both that the first cycle's messagesDone is
+// closed after the reconnect and that the live goroutine count returns to its
+// pre-reconnect baseline.
+func TestNoMessageLoopLeakAcrossReconnect(t *testing.T) {
+	client, transport, _, _ := newReconnectClient(t)
+
+	transport.EXPECT().
+		Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).
+		AnyTimes()
+	transport.EXPECT().RequestHandshake().Return(nil).AnyTimes()
+
+	// First cycle: starts a messageLoop reading the first messages channel.
+	err := client.startConnection(context.Background())
+	assert.NoError(t, err)
+	firstDone := client.messagesDone
+	assert.NotNil(t, firstDone)
+
+	// Let the first loop reach its select, then snapshot the goroutine count.
+	waitGoroutines := func() int {
+		runtime.Gosched()
+		time.Sleep(10 * time.Millisecond)
+		return runtime.NumGoroutine()
+	}
+	baseline := waitGoroutines()
+
+	// Second cycle (reconnect): must stop the first loop before swapping channels.
+	err = client.startConnection(context.Background())
+	assert.NoError(t, err)
+
+	// The first cycle's loop must have exited (its done channel is closed).
+	select {
+	case <-firstDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("previous messageLoop did not exit on reconnect (goroutine leak)")
+	}
+
+	// The goroutine count must not have grown by an extra leaked loop.
+	after := waitGoroutines()
+	assert.LessOrEqual(t, after, baseline, "reconnect must not leak a messageLoop goroutine")
+
+	// Clean up the second cycle's loop.
+	client.transportClosed <- nil
+	transport.EXPECT().Stop().Return(nil)
+	_ = client.Close()
+}
+
+// TestStopMessageLoopNoop verifies stopMessageLoop is safe when no loop is
+// running (nil stop channel) and idempotent when called twice.
+func TestStopMessageLoopNoop(t *testing.T) {
+	client, _, _, _ := newReconnectClient(t)
+	client.messagesStop = nil
+	client.messagesDone = nil
+	client.stopMessageLoop() // nil stop: must return without blocking
+	client.stopMessageLoop() // still nil: idempotent
+}
+
+// TestMessageLoopStopSignal verifies messageLoop exits when its dedicated stop
+// channel is closed even though the messages channel is never closed and the
+// context is never cancelled.
+func TestMessageLoopStopSignal(t *testing.T) {
+	client, _, _, _ := newReconnectClient(t)
+	messages := make(chan []byte) // never written/closed
+	done := make(chan struct{})
+	stop := make(chan struct{})
+
+	go client.messageLoop(context.Background(), messages, done, stop)
+	close(stop)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("messageLoop did not exit on stop signal")
+	}
+}
+
+// TestReconnectLoopNilContext verifies reconnectLoop does not panic when no run
+// context was assigned: the wait select must fall back to the backoff timer.
+func TestReconnectLoopNilContext(t *testing.T) {
+	client, transport, _, _ := newReconnectClient(t)
+	client.ctx = nil
+	client.reconnectAttempts = 1
+	client.reconnectWait = time.Millisecond
+
+	failedCh := make(chan struct{})
+	client.reconnectFailedHand = func() { close(failedCh) }
+
+	// The single attempt fails, exhausting the loop and closing the client.
+	transport.EXPECT().
+		Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(assertErr("dial failed"))
+	transport.EXPECT().Stop().Return(nil)
+
+	client.reconnectLoop(assertErr("connection dropped"))
+
+	select {
+	case <-failedCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reconnectLoop did not finish with a nil context")
+	}
+}
+
+// assertErr is a tiny error helper so this file does not need the errors import
+// solely for test fixtures.
+type assertErr string
+
+func (e assertErr) Error() string { return string(e) }

--- a/engine.io/v4/client/reconnect_test.go
+++ b/engine.io/v4/client/reconnect_test.go
@@ -1,0 +1,529 @@
+package engineio_v4_client
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	engineio_v4 "github.com/maldikhan/go.socket.io/engine.io/v4"
+	mocks "github.com/maldikhan/go.socket.io/engine.io/v4/client/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+// newReconnectClient builds a client wired for reconnect tests: short waits,
+// a single supported transport, and a logger that swallows all levels.
+func newReconnectClient(t *testing.T) (*Client, *mocks.MockTransport, *mocks.MockParser, *mocks.MockLogger) {
+	ctrl := gomock.NewController(t)
+	transport := mocks.NewMockTransport(ctrl)
+	parser := mocks.NewMockParser(ctrl)
+	logger := mocks.NewMockLogger(ctrl)
+	logger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+	logger.EXPECT().Infof(gomock.Any(), gomock.Any()).AnyTimes()
+	logger.EXPECT().Warnf(gomock.Any(), gomock.Any()).AnyTimes()
+	logger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
+
+	client := &Client{
+		url:               &url.URL{Scheme: "http", Host: "localhost:8080"},
+		transport:         transport,
+		parser:            parser,
+		log:               logger,
+		pingInterval:      time.NewTicker(time.Second),
+		reconnect:         true,
+		reconnectAttempts: 3,
+		reconnectWait:     time.Millisecond,
+		supportedTransports: map[engineio_v4.EngineIOTransport]Transport{
+			engineio_v4.TransportPolling: transport,
+		},
+		stopPooling:     make(chan struct{}, 1),
+		transportClosed: make(chan error, 1),
+	}
+	client.ctx = context.Background()
+	return client, transport, parser, logger
+}
+
+// TestSuperviseGracefulNilError verifies that a nil close value (graceful stop)
+// makes the supervisor exit without firing any reconnect logic.
+func TestSuperviseGracefulNilError(t *testing.T) {
+	client, _, _, _ := newReconnectClient(t)
+	closed := make(chan error, 1)
+	done := make(chan struct{})
+	closed <- nil
+
+	var reconnecting int32
+	client.reconnectingHandler = func() { atomic.AddInt32(&reconnecting, 1) }
+
+	client.supervise(closed, done)
+	<-done
+	assert.Equal(t, int32(0), atomic.LoadInt32(&reconnecting))
+}
+
+// TestSuperviseContextDone verifies that cancelling the parent context unblocks
+// the supervisor even when the transport never reports a close.
+func TestSuperviseContextDone(t *testing.T) {
+	client, _, _, _ := newReconnectClient(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel before supervising so the select deterministically takes the
+	// context-done arm (closed is never written).
+	cancel()
+	client.ctx = ctx
+	closed := make(chan error) // never written
+	done := make(chan struct{})
+
+	client.supervise(closed, done)
+	<-done
+}
+
+// TestSuperviseIntentionalClose verifies that a drop observed while closing==1
+// is treated as a graceful shutdown (no reconnect).
+func TestSuperviseIntentionalClose(t *testing.T) {
+	client, _, _, _ := newReconnectClient(t)
+	atomic.StoreUint32(&client.closing, 1)
+
+	var reconnecting int32
+	client.reconnectingHandler = func() { atomic.AddInt32(&reconnecting, 1) }
+
+	closed := make(chan error, 1)
+	done := make(chan struct{})
+	closed <- errors.New("drop")
+
+	client.supervise(closed, done)
+	<-done
+	assert.Equal(t, int32(0), atomic.LoadInt32(&reconnecting))
+}
+
+// TestSuperviseReconnectDisabled verifies that with reconnect disabled the close
+// handler is invoked instead of starting the reconnect loop.
+func TestSuperviseReconnectDisabled(t *testing.T) {
+	client, _, _, _ := newReconnectClient(t)
+	client.reconnect = false
+
+	var closed32 int32
+	// Register via On so the "close" handler closure is exercised too.
+	client.On("close", func([]byte) { atomic.AddInt32(&closed32, 1) })
+	var reconnecting int32
+	client.reconnectingHandler = func() { atomic.AddInt32(&reconnecting, 1) }
+
+	closed := make(chan error, 1)
+	done := make(chan struct{})
+	closed <- errors.New("drop")
+
+	client.supervise(closed, done)
+	<-done
+	assert.Equal(t, int32(1), atomic.LoadInt32(&closed32))
+	assert.Equal(t, int32(0), atomic.LoadInt32(&reconnecting))
+}
+
+// TestSuperviseReconnectDisabledNilHandler exercises the nil close-handler
+// branch of the reconnect-disabled path.
+func TestSuperviseReconnectDisabledNilHandler(t *testing.T) {
+	client, _, _, _ := newReconnectClient(t)
+	client.reconnect = false
+
+	closed := make(chan error, 1)
+	done := make(chan struct{})
+	closed <- errors.New("drop")
+
+	client.supervise(closed, done) // must not panic with nil closeHandler
+	<-done
+}
+
+// TestSuperviseNilDone confirms the supervisor tolerates a nil done channel
+// (the direct-handleHandshake unit-test path).
+func TestSuperviseNilDone(t *testing.T) {
+	client, _, _, _ := newReconnectClient(t)
+	closed := make(chan error, 1)
+	closed <- nil
+	client.supervise(closed, nil) // must not panic
+}
+
+// TestSuperviseTriggersReconnect drives the full supervisor path: a non-nil drop
+// with reconnect enabled must reach reconnectLoop and re-establish the
+// connection (covering the supervise -> reconnectLoop edge).
+func TestSuperviseTriggersReconnect(t *testing.T) {
+	client, transport, _, _ := newReconnectClient(t)
+
+	reconnected := make(chan struct{})
+	client.reconnectHandler = func() { close(reconnected) }
+
+	// reconnectLoop's first attempt re-runs the transport and handshakes.
+	transport.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	transport.EXPECT().RequestHandshake().Return(nil)
+
+	closed := make(chan error, 1)
+	done := make(chan struct{})
+	closed <- errors.New("connection dropped")
+
+	go client.supervise(closed, done)
+
+	select {
+	case <-reconnected:
+	case <-time.After(2 * time.Second):
+		t.Fatal("supervise did not drive a reconnect")
+	}
+	<-done
+
+	// Clean up the message loop spun up by the successful reconnect.
+	client.transportClosed <- nil
+	transport.EXPECT().Stop().Return(nil)
+	_ = client.Close()
+}
+
+// TestSuperviseNilContext confirms the supervisor doesn't panic when no run
+// context was assigned: it must fall back to watching only the close channel.
+func TestSuperviseNilContext(t *testing.T) {
+	client, _, _, _ := newReconnectClient(t)
+	client.ctx = nil
+	closed := make(chan error, 1)
+	done := make(chan struct{})
+	closed <- nil // graceful stop
+
+	client.supervise(closed, done) // must not panic on nil ctx
+	<-done
+}
+
+// TestStartSupervisorNilTransportClosed verifies startSupervisor is a no-op when
+// there is no transportClosed channel to watch (handshake exercised in isolation).
+func TestStartSupervisorNilTransportClosed(t *testing.T) {
+	client, _, _, _ := newReconnectClient(t)
+	client.transportClosed = nil
+	client.superviseOnce = sync.Once{}
+
+	client.startSupervisor()
+	assert.Equal(t, uint32(0), atomic.LoadUint32(&client.supervisorStarted),
+		"no supervisor should start without a transportClosed channel")
+}
+
+// TestReconnectLoopSuccess drives a full reconnect: a dropped connection, one
+// failed attempt, then a successful re-handshake that re-establishes the
+// supervisor and fires the "reconnect" hook.
+func TestReconnectLoopSuccess(t *testing.T) {
+	client, transport, _, _ := newReconnectClient(t)
+
+	var reconnecting, reconnected int32
+	client.reconnectingHandler = func() { atomic.AddInt32(&reconnecting, 1) }
+	reconnectedCh := make(chan struct{})
+	client.reconnectHandler = func() {
+		atomic.AddInt32(&reconnected, 1)
+		close(reconnectedCh)
+	}
+
+	// First attempt: Run fails. Second attempt: Run succeeds + handshake.
+	gomock.InOrder(
+		transport.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(errors.New("dial failed")),
+		transport.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil),
+	)
+	transport.EXPECT().RequestHandshake().Return(nil)
+
+	client.reconnectLoop(errors.New("connection dropped"))
+
+	select {
+	case <-reconnectedCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reconnect hook not fired")
+	}
+	assert.Equal(t, int32(1), atomic.LoadInt32(&reconnecting))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&reconnected))
+
+	// Clean up the message loop started by the successful reconnect.
+	client.transportClosed <- nil
+	transport.EXPECT().Stop().Return(nil)
+	_ = client.Close()
+}
+
+// TestReconnectLoopExhausted verifies that when every attempt fails the
+// "reconnect_failed" hook fires and the client is closed.
+func TestReconnectLoopExhausted(t *testing.T) {
+	client, transport, _, _ := newReconnectClient(t)
+	client.reconnectAttempts = 2
+
+	var failed int32
+	failedCh := make(chan struct{})
+	client.reconnectFailedHand = func() {
+		atomic.AddInt32(&failed, 1)
+		close(failedCh)
+	}
+
+	transport.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(errors.New("dial failed")).Times(2)
+	// reconnectLoop -> Close(): transport is non-nil, Stop() is called.
+	transport.EXPECT().Stop().Return(nil)
+
+	client.reconnectLoop(errors.New("connection dropped"))
+
+	select {
+	case <-failedCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reconnect_failed hook not fired")
+	}
+	assert.Equal(t, int32(1), atomic.LoadInt32(&failed))
+}
+
+// TestReconnectLoopStopRequestedBeforeWait verifies the loop aborts immediately
+// when the client is already closing.
+func TestReconnectLoopStopRequestedBeforeWait(t *testing.T) {
+	client, transport, _, _ := newReconnectClient(t)
+	atomic.StoreUint32(&client.closing, 1)
+
+	var failed int32
+	client.reconnectFailedHand = func() { atomic.AddInt32(&failed, 1) }
+
+	// No Run/Stop expected: the loop must bail before the first attempt.
+	client.reconnectLoop(errors.New("connection dropped"))
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(&failed))
+	_ = transport // unused expectations: none
+}
+
+// TestReconnectLoopContextCancelledDuringWait verifies the loop exits when the
+// context is cancelled while waiting for the backoff timer.
+func TestReconnectLoopContextCancelledDuringWait(t *testing.T) {
+	client, _, _, _ := newReconnectClient(t)
+	client.reconnectWait = time.Hour // ensure we are parked in the wait select
+	ctx, cancel := context.WithCancel(context.Background())
+	client.ctx = ctx
+
+	done := make(chan struct{})
+	go func() {
+		client.reconnectLoop(errors.New("connection dropped"))
+		close(done)
+	}()
+
+	// Give the loop a moment to reach the wait, then cancel.
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reconnectLoop did not exit on context cancel")
+	}
+}
+
+// TestReconnectLoopStopRequestedAfterWait verifies the post-wait stop check by
+// flipping closing to 1 from a concurrent goroutine during a short wait.
+func TestReconnectLoopStopRequestedAfterWait(t *testing.T) {
+	client, _, _, _ := newReconnectClient(t)
+	client.reconnectWait = 30 * time.Millisecond
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(10 * time.Millisecond)
+		atomic.StoreUint32(&client.closing, 1)
+	}()
+
+	var failed int32
+	client.reconnectFailedHand = func() { atomic.AddInt32(&failed, 1) }
+
+	client.reconnectLoop(errors.New("connection dropped"))
+	wg.Wait()
+	assert.Equal(t, int32(0), atomic.LoadInt32(&failed))
+}
+
+// TestReconnectLoopBackoffCap drives several failing attempts with a base wait
+// so that the doubling hits the 8x cap branch.
+func TestReconnectLoopBackoffCap(t *testing.T) {
+	client, transport, _, _ := newReconnectClient(t)
+	client.reconnectAttempts = 5
+	client.reconnectWait = time.Millisecond
+
+	var failed int32
+	failedCh := make(chan struct{})
+	client.reconnectFailedHand = func() {
+		atomic.AddInt32(&failed, 1)
+		close(failedCh)
+	}
+
+	transport.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(errors.New("dial failed")).Times(5)
+	transport.EXPECT().Stop().Return(nil)
+
+	client.reconnectLoop(errors.New("connection dropped"))
+
+	select {
+	case <-failedCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("reconnect_failed hook not fired")
+	}
+	assert.Equal(t, int32(1), atomic.LoadInt32(&failed))
+}
+
+// TestReconnectLoopZeroWaitDefault verifies the default base wait is used when
+// reconnectWait is zero (so backoff is well-defined).
+func TestReconnectLoopZeroWaitDefault(t *testing.T) {
+	client, transport, _, _ := newReconnectClient(t)
+	client.reconnectAttempts = 1
+	client.reconnectWait = 0
+	// Cancel quickly so the (default 1s) wait does not slow the test.
+	ctx, cancel := context.WithCancel(context.Background())
+	client.ctx = ctx
+
+	done := make(chan struct{})
+	go func() {
+		client.reconnectLoop(errors.New("connection dropped"))
+		close(done)
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reconnectLoop did not exit")
+	}
+	_ = transport
+}
+
+// TestStartConnectionTransportNil verifies a reconnect attempt that races with
+// Close (transport set to nil) returns errClientClosed instead of panicking.
+func TestStartConnectionTransportNil(t *testing.T) {
+	client, _, _, _ := newReconnectClient(t)
+	client.transport = nil
+	err := client.startConnection(context.Background())
+	assert.ErrorIs(t, err, errClientClosed)
+}
+
+// TestStartConnectionRunError covers the transport.Run failure cleanup path:
+// transportClosed and supervisorDone are both closed and the error is returned.
+func TestStartConnectionRunError(t *testing.T) {
+	client, transport, _, _ := newReconnectClient(t)
+	runErr := errors.New("dial failed")
+	transport.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(runErr)
+
+	err := client.startConnection(context.Background())
+	assert.Equal(t, runErr, err)
+
+	// supervisorDone must have been closed by the failure path.
+	select {
+	case <-client.supervisorDone:
+	default:
+		t.Fatal("supervisorDone was not closed on Run failure")
+	}
+}
+
+// TestStartConnectionHandshakeError covers the RequestHandshake failure cleanup
+// path: the transport is stopped, transportClosed/messages are drained and the
+// message loop is awaited before the error is returned.
+func TestStartConnectionHandshakeError(t *testing.T) {
+	client, transport, _, _ := newReconnectClient(t)
+	hsErr := errors.New("handshake failed")
+
+	transport.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *url.URL, _ string, _ chan<- []byte, onClose chan<- error) error {
+			// Simulate the transport reporting it has stopped once Stop() is
+			// called: deliver a value so the cleanup's <-transportClosed unblocks.
+			go func() { onClose <- nil }()
+			return nil
+		})
+	transport.EXPECT().RequestHandshake().Return(hsErr)
+	transport.EXPECT().Stop().Return(nil)
+
+	err := client.startConnection(context.Background())
+	assert.Equal(t, hsErr, err)
+
+	select {
+	case <-client.supervisorDone:
+	default:
+		t.Fatal("supervisorDone was not closed on handshake failure")
+	}
+}
+
+// TestStopRequested covers the three stopRequested outcomes.
+func TestStopRequested(t *testing.T) {
+	client, _, _, _ := newReconnectClient(t)
+
+	// Neither closing nor cancelled.
+	assert.False(t, client.stopRequested())
+
+	// Closing.
+	atomic.StoreUint32(&client.closing, 1)
+	assert.True(t, client.stopRequested())
+
+	// Cancelled context (closing reset).
+	atomic.StoreUint32(&client.closing, 0)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	client.ctx = ctx
+	assert.True(t, client.stopRequested())
+}
+
+// TestFireHooksNil ensures the fire helpers are no-ops when no handler is set.
+func TestFireHooksNil(t *testing.T) {
+	client, _, _, _ := newReconnectClient(t)
+	client.fireReconnecting()
+	client.fireReconnect()
+	client.fireReconnectFailed()
+}
+
+// TestOnReconnectEvents verifies On registers the reconnect lifecycle handlers
+// and that their closures are invoked when the corresponding event fires.
+func TestOnReconnectEvents(t *testing.T) {
+	client, _, _, _ := newReconnectClient(t)
+
+	var a, b, d int32
+	client.On("reconnecting", func([]byte) { atomic.AddInt32(&a, 1) })
+	client.On("reconnect", func([]byte) { atomic.AddInt32(&b, 1) })
+	client.On("reconnect_failed", func([]byte) { atomic.AddInt32(&d, 1) })
+
+	client.fireReconnecting()
+	client.fireReconnect()
+	client.fireReconnectFailed()
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&a))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&b))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&d))
+}
+
+// TestOnConnectMessageHandlers covers the "connect" and "message" branches of On
+// and the execution of their wrapping closures.
+func TestOnConnectMessageHandlers(t *testing.T) {
+	client, _, _, _ := newReconnectClient(t)
+
+	var connected, messaged int32
+	client.On("connect", func([]byte) { atomic.AddInt32(&connected, 1) })
+	client.On("message", func([]byte) { atomic.AddInt32(&messaged, 1) })
+
+	// Invoke the registered handlers via the stored fields.
+	client.handlerMu.RLock()
+	afterConnect := client.afterConnect
+	messageHandler := client.messageHandler
+	client.handlerMu.RUnlock()
+
+	if assert.NotNil(t, afterConnect) {
+		afterConnect()
+	}
+	if assert.NotNil(t, messageHandler) {
+		messageHandler(nil)
+	}
+	assert.Equal(t, int32(1), atomic.LoadInt32(&connected))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&messaged))
+}
+
+// TestStartSupervisorOnce verifies startSupervisor starts exactly one goroutine
+// per cycle and that the supervisor exits on a graceful (nil) close.
+func TestStartSupervisorOnce(t *testing.T) {
+	client, _, _, _ := newReconnectClient(t)
+	client.supervisorDone = make(chan struct{})
+	client.transportClosed = make(chan error, 1)
+
+	client.startSupervisor()
+	client.startSupervisor() // second call is a no-op (superviseOnce)
+
+	assert.Equal(t, uint32(1), atomic.LoadUint32(&client.supervisorStarted))
+
+	// Graceful close: supervisor exits and closes supervisorDone.
+	client.transportClosed <- nil
+	select {
+	case <-client.supervisorDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("supervisor did not exit on graceful close")
+	}
+}

--- a/engine.io/v4/client/reconnect_test.go
+++ b/engine.io/v4/client/reconnect_test.go
@@ -46,6 +46,16 @@ func newReconnectClient(t *testing.T) (*Client, *mocks.MockTransport, *mocks.Moc
 	return client, transport, parser, logger
 }
 
+// completeHandshake closes the cycle's waitHandshake gate the way
+// handleHandshake would, so reconnect success paths in tests are recognised by
+// awaitConnectionEstablished.
+func completeHandshake(client *Client) {
+	client.transportMu.RLock()
+	wh := client.waitHandshake
+	client.transportMu.RUnlock()
+	client.hadHandshake.Do(func() { close(wh) })
+}
+
 // TestSuperviseGracefulNilError verifies that a nil close value (graceful stop)
 // makes the supervisor exit without firing any reconnect logic.
 func TestSuperviseGracefulNilError(t *testing.T) {
@@ -150,9 +160,14 @@ func TestSuperviseTriggersReconnect(t *testing.T) {
 	reconnected := make(chan struct{})
 	client.reconnectHandler = func() { close(reconnected) }
 
-	// reconnectLoop's first attempt re-runs the transport and handshakes.
+	// reconnectLoop's first attempt re-runs the transport and handshakes. The
+	// handshake gate is completed the way handleHandshake would, since the
+	// reconnect is only reported once the handshake actually finished.
 	transport.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-	transport.EXPECT().RequestHandshake().Return(nil)
+	transport.EXPECT().RequestHandshake().DoAndReturn(func() error {
+		completeHandshake(client)
+		return nil
+	})
 
 	closed := make(chan error, 1)
 	done := make(chan struct{})
@@ -219,7 +234,10 @@ func TestReconnectLoopSuccess(t *testing.T) {
 		transport.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(nil),
 	)
-	transport.EXPECT().RequestHandshake().Return(nil)
+	transport.EXPECT().RequestHandshake().DoAndReturn(func() error {
+		completeHandshake(client)
+		return nil
+	})
 
 	client.reconnectLoop(errors.New("connection dropped"))
 

--- a/engine.io/v4/client/transport/polling/constructor.go
+++ b/engine.io/v4/client/transport/polling/constructor.go
@@ -19,11 +19,11 @@ const defaultHTTPTimeout = 30 * time.Second
 func NewTransport(options ...EngineTransportOption) (*Transport, error) {
 	// Create default client
 	client := &Transport{
-		log:            &utils.DefaultLogger{},
-		httpClient:     &http.Client{Timeout: defaultHTTPTimeout},
-		pinger:         time.NewTicker(10 * time.Second),
-		stopPooling:    make(chan struct{}, 1),
-		stopCh:         make(chan struct{}),
+		log:              &utils.DefaultLogger{},
+		httpClient:       &http.Client{Timeout: defaultHTTPTimeout},
+		pinger:           time.NewTicker(10 * time.Second),
+		stopPooling:      make(chan struct{}, 1),
+		stopCh:           make(chan struct{}),
 		maxPayloadSize:   4 * 1024 * 1024, // 4MB default, matches socket.io JS maxHttpBufferSize
 		redactPayload:    true,            // production-safe default; WithDebugPayload(true) opts out
 		pollErrorBackoff: defaultPollErrorBackoff,

--- a/engine.io/v4/client/transport/polling/transport.go
+++ b/engine.io/v4/client/transport/polling/transport.go
@@ -173,7 +173,9 @@ func (c *Transport) Run(
 		if err != nil {
 			c.log.Errorf("pollingLoop error: %s", err)
 		}
-		// TODO: reconnect
+		// Reconnection is handled at the engine.io Client level: finishPolling
+		// reports the drop via onClose, and the client's reconnect supervisor
+		// performs a fresh handshake. The transport does not reconnect itself.
 	}()
 
 	return nil

--- a/engine.io/v4/client/transport/polling/transport.go
+++ b/engine.io/v4/client/transport/polling/transport.go
@@ -24,6 +24,20 @@ import (
 // context.Canceled before it can reach public API callers.
 var errTransportStopped = errors.New("transport stopped")
 
+// pollStatusError reports a non-2xx polling response. Client-level (4xx)
+// rejections are fatal: the server refused the session itself (e.g. a 400
+// "Session ID unknown" after a server restart), so retrying with the same sid
+// can never succeed — the loop must stop and surface the drop to the engine
+// client's reconnect supervisor instead of polling the dead session forever.
+// Server-level (5xx) responses are treated as transient and retried.
+type pollStatusError struct{ status int }
+
+func (e *pollStatusError) Error() string {
+	return fmt.Sprintf("unexpected polling response status %d", e.status)
+}
+
+func (e *pollStatusError) fatal() bool { return e.status >= 400 && e.status < 500 }
+
 type Transport struct {
 	log        Logger
 	httpClient HttpClient
@@ -257,6 +271,20 @@ func (c *Transport) pollingLoop() error {
 			if c.ctx.Err() != nil {
 				return c.finishPolling(false, c.ctx.Err())
 			}
+			// A 4xx response means the server rejected the session itself (e.g.
+			// "Session ID unknown" after a restart): retrying the same sid can
+			// never succeed. Stop the loop and report the drop with the actual
+			// error so the engine client's reconnect supervisor starts a fresh
+			// session instead of this loop polling a dead sid forever.
+			var statusErr *pollStatusError
+			if errors.As(err, &statusErr) && statusErr.fatal() {
+				c.log.Errorf("fatal poll error, stopping transport: %s", err)
+				atomic.StoreUint32(&c.stopped, 1)
+				if c.onClose != nil {
+					c.onClose <- err
+				}
+				return err
+			}
 			// Genuine transient error (network blip, server hiccup): log and back
 			// off briefly, but stay responsive to stop/cancel during the pause.
 			c.log.Errorf("poll error: %s", err)
@@ -340,7 +368,7 @@ func (c *Transport) poll() error {
 	// forwarding the error body as an engine.io packet and hot-spinning.
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1024))
-		return fmt.Errorf("unexpected polling response status %d", resp.StatusCode)
+		return &pollStatusError{status: resp.StatusCode}
 	}
 
 	// Limit payload size to guard against OOM from a malicious/buggy server.

--- a/engine.io/v4/client/transport/polling/transport_test.go
+++ b/engine.io/v4/client/transport/polling/transport_test.go
@@ -308,17 +308,21 @@ func TestPollingLoop(t *testing.T) {
 		defer cancel()
 
 		errExpected := errors.New("expected error")
-		pingCalled := make(chan struct{})
+		// errLogged is closed once the loop has logged the poll error. Triggering
+		// Stop() off this (rather than off the Do call) makes the test
+		// deterministic: Stop() runs only after pollingLoop has already passed its
+		// stopped-check and logged, so the "poll error" Errorf is always observed.
+		// Stopping earlier raced the loop's stopped-check and could make it exit
+		// before logging, flaking the MinTimes(1) expectation.
+		errLogged := make(chan struct{})
 
 		mockLogger := mocks.NewMockLogger(ctrl)
 		mockHttpClient := mocks.NewMockHttpClient(ctrl)
 		mockLogger.EXPECT().Debugf("run polling").MinTimes(1)
 		mockLogger.EXPECT().Debugf("stop polling").MinTimes(1)
-		mockLogger.EXPECT().Errorf("poll error: %s", errExpected).MinTimes(1)
-		mockHttpClient.EXPECT().Do(gomock.Any()).DoAndReturn(func(_ *http.Request) (*http.Response, error) {
-			close(pingCalled)
-			return nil, errExpected
-		})
+		mockLogger.EXPECT().Errorf("poll error: %s", errExpected).
+			Do(func(string, ...interface{}) { close(errLogged) }).Times(1)
+		mockHttpClient.EXPECT().Do(gomock.Any()).Return(nil, errExpected).Times(1)
 
 		onClose := make(chan error, 1)
 		client := &Transport{
@@ -336,9 +340,10 @@ func TestPollingLoop(t *testing.T) {
 
 		go func() {
 			select {
-			case <-pingCalled:
-			case <-time.After(100 * time.Millisecond):
-				assert.Fail(t, "expected ping to be called")
+			case <-errLogged:
+			case <-time.After(2 * time.Second):
+				assert.Fail(t, "expected poll error to be logged")
+				return
 			}
 
 			assert.NoError(t, client.Stop())
@@ -1636,4 +1641,101 @@ func TestHandshakeGateUpgradeToPolling(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("expected onClose after Stop")
 	}
+}
+
+// TestPollingLoopFatalStatus verifies that a 4xx poll response (e.g. 400
+// "Session ID unknown" after a server restart) stops the loop and reports the
+// error on onClose, so the engine client's reconnect supervisor can start a
+// fresh session instead of the loop retrying a dead sid forever.
+func TestPollingLoopFatalStatus(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := mocks.NewMockLogger(ctrl)
+	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
+	mockHTTPClient := mocks.NewMockHttpClient(ctrl)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	onClose := make(chan error, 1)
+	client := &Transport{
+		log:         mockLogger,
+		httpClient:  mockHTTPClient,
+		url:         &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
+		sid:         "dead-sid",
+		ctx:         ctx,
+		messages:    make(chan []byte, 1),
+		onClose:     onClose,
+		stopPooling: make(chan struct{}, 1),
+	}
+
+	mockHTTPClient.EXPECT().Do(gomock.Any()).Return(&http.Response{
+		StatusCode: 400,
+		Body:       io.NopCloser(strings.NewReader(`{"code":1,"message":"Session ID unknown"}`)),
+	}, nil)
+
+	err := client.pollingLoop()
+	assert.ErrorContains(t, err, "unexpected polling response status 400")
+
+	select {
+	case reported := <-onClose:
+		assert.ErrorContains(t, reported, "unexpected polling response status 400",
+			"onClose must carry the fatal error so the supervisor reconnects")
+	default:
+		t.Fatal("fatal poll error was not reported on onClose")
+	}
+	assert.Equal(t, uint32(1), atomic.LoadUint32(&client.stopped), "transport must be marked stopped")
+}
+
+// TestPollingLoopTransientServerError verifies that a 5xx response stays on
+// the transient path: the loop backs off and retries instead of stopping.
+func TestPollingLoopTransientServerError(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockLogger := mocks.NewMockLogger(ctrl)
+	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
+	mockHTTPClient := mocks.NewMockHttpClient(ctrl)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	onClose := make(chan error, 1)
+	client := &Transport{
+		log:              mockLogger,
+		httpClient:       mockHTTPClient,
+		url:              &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
+		sid:              "test-sid",
+		ctx:              ctx,
+		messages:         make(chan []byte, 1),
+		onClose:          onClose,
+		stopPooling:      make(chan struct{}, 1),
+		pollErrorBackoff: time.Millisecond,
+	}
+
+	calls := 0
+	mockHTTPClient.EXPECT().Do(gomock.Any()).DoAndReturn(func(*http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			return &http.Response{
+				StatusCode: 503,
+				Body:       io.NopCloser(strings.NewReader("busy")),
+			}, nil
+		}
+		// Second poll: stop the loop cleanly.
+		client.stopPooling <- struct{}{}
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader("2")),
+		}, nil
+	}).AnyTimes()
+
+	err := client.pollingLoop()
+	assert.NoError(t, err, "a 5xx response must be retried, not treated as fatal")
+	assert.GreaterOrEqual(t, calls, 2, "the loop must retry after a 5xx response")
 }

--- a/engine.io/v4/client/transport/websocket/transport.go
+++ b/engine.io/v4/client/transport/websocket/transport.go
@@ -133,7 +133,10 @@ func (c *Transport) connectWebSocket() error {
 		if err != nil {
 			c.log.Errorf("wsClose: %s", err)
 		}
-		// TODO: Reconnect
+		// Reconnection is handled at the engine.io Client level: wsReadLoop
+		// reports the drop (with its error) via onClose, and the client's
+		// reconnect supervisor performs a fresh handshake / transport
+		// re-selection. The transport intentionally does not reconnect itself.
 	}()
 
 	return nil

--- a/socket.io/v5/client/client.go
+++ b/socket.io/v5/client/client.go
@@ -47,8 +47,53 @@ type namespace struct {
 	handlers    map[string][]func([]interface{})
 	anyHandlers []func(string, []interface{})
 
+	// waitConnected gates Emit until the server acknowledged the namespace
+	// CONNECT: open (blocking) while a CONNECT is outstanding, closed once the
+	// ack arrived. It is re-armed by resetConnectionGate when a reconnect cycle
+	// starts, so post-reconnect emits wait for the re-sent CONNECT to be
+	// acknowledged. Guarded by mu.
 	waitConnected chan struct{}
-	hadConnected  sync.Once
+}
+
+// connectionGate returns the current waitConnected channel (which may be nil
+// for namespaces built without the constructor in tests).
+func (n *namespace) connectionGate() chan struct{} {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return n.waitConnected
+}
+
+// resetConnectionGate re-arms waitConnected before a reconnect attempt so Emit
+// blocks until the server acknowledges the re-sent CONNECT. Only a closed gate
+// is replaced: replacing an open one would orphan emitters already waiting on
+// it (their CONNECT ack is still the next one to arrive).
+func (n *namespace) resetConnectionGate() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.waitConnected == nil {
+		n.waitConnected = make(chan struct{})
+		return
+	}
+	select {
+	case <-n.waitConnected:
+		n.waitConnected = make(chan struct{})
+	default:
+	}
+}
+
+// openConnectionGate marks the namespace connected, releasing every emitter
+// blocked on the gate. Closing is idempotent so duplicate CONNECT acks are safe.
+func (n *namespace) openConnectionGate() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.waitConnected == nil {
+		return
+	}
+	select {
+	case <-n.waitConnected:
+	default:
+		close(n.waitConnected)
+	}
 }
 
 // SetHandshakeData stores a shallow copy of the provided map as the handshake
@@ -104,7 +149,6 @@ func (c *Client) namespace(name string) *namespace {
 		name:          name,
 		handlers:      make(map[string][]func([]interface{})),
 		waitConnected: make(chan struct{}),
-		hadConnected:  sync.Once{},
 	}
 	c.namespaces[name] = ns
 	return ns

--- a/socket.io/v5/client/client.go
+++ b/socket.io/v5/client/client.go
@@ -118,6 +118,7 @@ func (c *Client) connectSocketIO(_ []byte) {
 
 	err := c.sendPacket(&socketio_v5.Message{
 		Type:    socketio_v5.PacketConnect,
+		NS:      c.defaultNs.name,
 		Payload: handshakeData,
 	})
 

--- a/socket.io/v5/client/client_test.go
+++ b/socket.io/v5/client/client_test.go
@@ -45,10 +45,12 @@ func TestConnectSocketIO(t *testing.T) {
 		parser:        mockParser,
 		logger:        mockLogger,
 		handshakeData: map[string]interface{}{"foo": "bar"},
+		defaultNs:     &namespace{name: "/"},
 	}
 
 	expectedPacket := &socketio_v5.Message{
 		Type:    socketio_v5.PacketConnect,
+		NS:      "/",
 		Payload: client.handshakeData,
 	}
 
@@ -62,6 +64,18 @@ func TestConnectSocketIO(t *testing.T) {
 		str := fmt.Sprintf(format, v...)
 		assert.Contains(t, str, "send error")
 	})
+
+	client.connectSocketIO(nil)
+
+	// The CONNECT packet must target the configured default namespace, not "/".
+	client.defaultNs = &namespace{name: "/admin"}
+	adminPacket := &socketio_v5.Message{
+		Type:    socketio_v5.PacketConnect,
+		NS:      "/admin",
+		Payload: client.handshakeData,
+	}
+	mockParser.EXPECT().Serialize(gomock.Eq(adminPacket)).Return([]byte("encoded_packet"), nil)
+	mockEngineIO.EXPECT().Send(gomock.Any()).Return(nil)
 
 	client.connectSocketIO(nil)
 }
@@ -286,6 +300,7 @@ func TestConcurrentSetHandshakeDataAndConnect(t *testing.T) {
 		engineio:      mockEngineIO,
 		handshakeData: make(map[string]interface{}),
 		mutex:         sync.RWMutex{},
+		defaultNs:     &namespace{name: "/"},
 	}
 
 	mockParser.EXPECT().Serialize(gomock.Any()).Return([]byte("packet"), nil).AnyTimes()

--- a/socket.io/v5/client/constructor.go
+++ b/socket.io/v5/client/constructor.go
@@ -78,13 +78,15 @@ func NewClient(options ...ClientOption) (*Client, error) {
 	client.engineio.On("connect", client.connectSocketIO)
 	client.engineio.On("message", client.onMessage)
 
-	// Reconnect wiring. On a successful engine.io reconnect we must re-send the
-	// socket.io CONNECT packet so the namespace re-joins the server (mirrors the
-	// initial "connect" handling above). The reconnect lifecycle events are also
-	// surfaced to socket.io-level handlers so users can react with
-	// client.On("reconnect"/"reconnecting"/"reconnect_failed", ...).
+	// Reconnect wiring. A successful engine.io reconnect performs a fresh
+	// handshake, which fires the engine-level "connect" event registered above
+	// and therefore already re-sends the socket.io CONNECT packet exactly once.
+	// The "reconnect" handler must NOT send CONNECT again, otherwise two CONNECT
+	// packets would be emitted for the same namespace per reconnect (duplicate
+	// server-side connect handling / protocol errors). It only surfaces the
+	// reconnect lifecycle events to socket.io-level handlers so users can react
+	// with client.On("reconnect"/"reconnecting"/"reconnect_failed", ...).
 	client.engineio.On("reconnect", func(_ []byte) {
-		client.connectSocketIO(nil)
 		client.emitReserved("reconnect")
 	})
 	client.engineio.On("reconnecting", func(_ []byte) {

--- a/socket.io/v5/client/constructor.go
+++ b/socket.io/v5/client/constructor.go
@@ -78,6 +78,22 @@ func NewClient(options ...ClientOption) (*Client, error) {
 	client.engineio.On("connect", client.connectSocketIO)
 	client.engineio.On("message", client.onMessage)
 
+	// Reconnect wiring. On a successful engine.io reconnect we must re-send the
+	// socket.io CONNECT packet so the namespace re-joins the server (mirrors the
+	// initial "connect" handling above). The reconnect lifecycle events are also
+	// surfaced to socket.io-level handlers so users can react with
+	// client.On("reconnect"/"reconnecting"/"reconnect_failed", ...).
+	client.engineio.On("reconnect", func(_ []byte) {
+		client.connectSocketIO(nil)
+		client.emitReserved("reconnect")
+	})
+	client.engineio.On("reconnecting", func(_ []byte) {
+		client.emitReserved("reconnecting")
+	})
+	client.engineio.On("reconnect_failed", func(_ []byte) {
+		client.emitReserved("reconnect_failed")
+	})
+
 	return client.Client, nil
 }
 

--- a/socket.io/v5/client/constructor.go
+++ b/socket.io/v5/client/constructor.go
@@ -90,9 +90,21 @@ func NewClient(options ...ClientOption) (*Client, error) {
 		client.emitReserved("reconnect")
 	})
 	client.engineio.On("reconnecting", func(_ []byte) {
+		// Re-arm the namespace CONNECT gate before any reconnect attempt is
+		// made: the engine-level "connect" hook above runs asynchronously after
+		// a successful attempt and re-sends the socket.io CONNECT, and emits
+		// (including ones fired from a "reconnect" handler) must block until
+		// the server acknowledges it (handleConnect re-opens the gate).
+		// "reconnecting" fires before a new connection can exist, so the reset
+		// cannot race with that ack.
+		client.defaultNs.resetConnectionGate()
 		client.emitReserved("reconnecting")
 	})
 	client.engineio.On("reconnect_failed", func(_ []byte) {
+		// All attempts failed and the engine client closes: release pending
+		// emitters so they fail fast at the transport instead of hanging on a
+		// gate no CONNECT ack will ever close.
+		client.defaultNs.openConnectionGate()
 		client.emitReserved("reconnect_failed")
 	})
 

--- a/socket.io/v5/client/constructor_test.go
+++ b/socket.io/v5/client/constructor_test.go
@@ -149,6 +149,9 @@ func TestNewClient(t *testing.T) {
 			if !tt.wantErr {
 				mockEngineIOClient.EXPECT().On("connect", gomock.Any()).AnyTimes()
 				mockEngineIOClient.EXPECT().On("message", gomock.Any()).AnyTimes()
+				mockEngineIOClient.EXPECT().On("reconnect", gomock.Any()).AnyTimes()
+				mockEngineIOClient.EXPECT().On("reconnecting", gomock.Any()).AnyTimes()
+				mockEngineIOClient.EXPECT().On("reconnect_failed", gomock.Any()).AnyTimes()
 			}
 
 			got, err := NewClient(tt.options...)

--- a/socket.io/v5/client/emitters.go
+++ b/socket.io/v5/client/emitters.go
@@ -75,6 +75,7 @@ func (n *namespace) Emit(event interface{}, args ...interface{}) error {
 
 	return n.client.sendPacketWithAckTimeout(
 		&socketio_v5.Message{
+			NS:    n.name,
 			Type:  socketio_v5.PacketEvent,
 			Event: emitEvent,
 		},

--- a/socket.io/v5/client/emitters.go
+++ b/socket.io/v5/client/emitters.go
@@ -15,14 +15,16 @@ func (c *Client) Emit(event interface{}, args ...interface{}) error {
 
 func (n *namespace) Emit(event interface{}, args ...interface{}) error {
 
-	if n.waitConnected != nil {
+	// Snapshot the gate under the namespace lock: resetConnectionGate replaces
+	// the channel when a reconnect cycle starts.
+	if waitConnected := n.connectionGate(); waitConnected != nil {
 		// Snapshot ctx under lock to prevent data race
 		n.client.mutex.RLock()
 		ctx := n.client.ctx
 		n.client.mutex.RUnlock()
 
 		select {
-		case <-n.waitConnected:
+		case <-waitConnected:
 		case <-ctx.Done():
 			return ctx.Err()
 		}

--- a/socket.io/v5/client/emitters_test.go
+++ b/socket.io/v5/client/emitters_test.go
@@ -194,6 +194,54 @@ func TestNamespaceEmit(t *testing.T) {
 	}
 }
 
+// TestNamespaceEmitCarriesNamespace is a regression guard: emits from a
+// non-default namespace must serialize with that namespace set, both for plain
+// events and for events with an ack callback (the ack path previously dropped
+// the namespace, so the server received the packet on "/").
+func TestNamespaceEmitCarriesNamespace(t *testing.T) {
+	for _, withAck := range []bool{false, true} {
+		name := "plain event"
+		if withAck {
+			name = "event with ack"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockEngineIO := mocks.NewMockEngineIOClient(ctrl)
+			mockParser := mocks.NewMockParser(ctrl)
+			mockLogger := mocks.NewMockLogger(ctrl)
+
+			client := &Client{
+				engineio:     mockEngineIO,
+				parser:       mockParser,
+				ackCallbacks: make(map[int]func([]interface{})),
+				logger:       mockLogger,
+				ctx:          context.Background(),
+			}
+			ns := &namespace{client: client, name: "/admin"}
+
+			mockParser.EXPECT().Serialize(gomock.Any()).DoAndReturn(func(msg *socketio_v5.Message) ([]byte, error) {
+				assert.Equal(t, "/admin", msg.NS, "emit must target the namespace")
+				assert.Equal(t, socketio_v5.PacketEvent, msg.Type)
+				if withAck {
+					assert.NotNil(t, msg.AckId, "ack emit must carry an ack id")
+				}
+				return []byte{}, nil
+			})
+			mockEngineIO.EXPECT().Send(gomock.Any()).Return(nil)
+
+			var args []interface{}
+			if withAck {
+				mockParser.EXPECT().WrapCallback(gomock.Any()).Return(func(in []interface{}) {})
+				args = []interface{}{emit.WithAck(func() {})}
+			}
+
+			assert.NoError(t, ns.Emit("echo", args...))
+		})
+	}
+}
+
 func TestSendPacketWithAckTimeout(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/socket.io/v5/client/handlers.go
+++ b/socket.io/v5/client/handlers.go
@@ -24,6 +24,33 @@ func (n *namespace) OnAny(handler func(string, []interface{})) {
 	n.mu.Unlock()
 }
 
+// emitReserved dispatches a reserved client-lifecycle event (e.g. "reconnect",
+// "reconnecting", "reconnect_failed") to handlers registered on the default
+// namespace. These events originate from the engine.io layer rather than from a
+// server packet, so they carry no payload. Handlers run on safeGo goroutines,
+// matching the dispatch style of the packet-driven handlers below.
+func (c *Client) emitReserved(event string) {
+	ns := c.defaultNs
+	if ns == nil {
+		return
+	}
+
+	ns.mu.RLock()
+	handlers := ns.handlers[event]
+	anyHandlers := ns.anyHandlers
+	ns.mu.RUnlock()
+
+	for _, handler := range anyHandlers {
+		h := handler
+		c.safeGo(func() { h(event, nil) })
+	}
+
+	for _, handler := range handlers {
+		h := handler
+		c.safeGo(func() { h(nil) })
+	}
+}
+
 func (c *Client) onMessage(data []byte) {
 	c.logger.Debugf("socketio receive %s", c.payload(data))
 

--- a/socket.io/v5/client/handlers.go
+++ b/socket.io/v5/client/handlers.go
@@ -147,11 +147,7 @@ func (c *Client) handleDisconnect(ns *namespace, payload interface{}) {
 
 func (c *Client) handleConnect(ns *namespace, payload interface{}) {
 	c.logger.Infof("Connected to namespace: %s", ns.name)
-	ns.hadConnected.Do(func() {
-		if ns.waitConnected != nil {
-			close(ns.waitConnected)
-		}
-	})
+	ns.openConnectionGate()
 
 	ns.mu.RLock()
 	handlers, ok := ns.handlers["connect"]

--- a/socket.io/v5/client/handlers_test.go
+++ b/socket.io/v5/client/handlers_test.go
@@ -416,7 +416,6 @@ func TestClientHandleConnect(t *testing.T) {
 
 	t.Run("With channel notify", func(t *testing.T) {
 		mockLogger.EXPECT().Infof(gomock.Any(), gomock.Any())
-		client.defaultNs.hadConnected = sync.Once{}
 		client.defaultNs.waitConnected = make(chan struct{})
 		client.handleConnect(ns, "test")
 

--- a/socket.io/v5/client/reconnect_test.go
+++ b/socket.io/v5/client/reconnect_test.go
@@ -65,13 +65,66 @@ func TestConstructorRegistersReconnectHandlers(t *testing.T) {
 	}
 }
 
-// TestReconnectResendsConnectAndEmits verifies that the engine "reconnect" event
-// (1) re-sends the socket.io CONNECT packet so the namespace re-joins, and
-// (2) emits the socket.io-level "reconnect" event to user handlers.
-func TestReconnectResendsConnectAndEmits(t *testing.T) {
+// TestExactlyOneConnectPerReconnect is the issue-A regression test. A real
+// engine.io reconnect performs a fresh handshake, which fires the engine-level
+// "connect" event and re-sends the socket.io CONNECT packet exactly once. The
+// engine-level "reconnect" event must NOT send a second CONNECT, otherwise two
+// CONNECT packets would be emitted for the same namespace per reconnect. This
+// test counts the CONNECT packets the client serializes and asserts exactly one
+// per (re)connect cycle.
+func TestExactlyOneConnectPerReconnect(t *testing.T) {
+	_, handlers, mockEngine, mockParser := captureEngineHandlers(t)
+
+	var mu sync.Mutex
+	connectCount := 0
+	mockParser.EXPECT().Serialize(gomock.Any()).DoAndReturn(func(msg *socketio_v5.Message) ([]byte, error) {
+		mu.Lock()
+		if msg.Type == socketio_v5.PacketConnect {
+			connectCount++
+		}
+		mu.Unlock()
+		return []byte("0"), nil
+	}).AnyTimes()
+	mockEngine.EXPECT().Send(gomock.Any()).Return(nil).AnyTimes()
+	mockParser.EXPECT().WrapCallback(gomock.Any()).DoAndReturn(passthroughWrap).AnyTimes()
+
+	count := func() int {
+		mu.Lock()
+		defer mu.Unlock()
+		return connectCount
+	}
+
+	connectH := handlers["connect"]
+	reconnectH := handlers["reconnect"]
+	require.NotNil(t, connectH, "engine.io \"connect\" handler must be registered")
+	require.NotNil(t, reconnectH, "engine.io \"reconnect\" handler must be registered")
+
+	// Initial connect handshake: exactly one CONNECT.
+	connectH(nil)
+	assert.Equal(t, 1, count(), "initial connect must send exactly one CONNECT")
+
+	// A real reconnect: the fresh handshake fires "connect" (sending the single
+	// CONNECT), then the engine fires "reconnect". The "reconnect" handler must
+	// not add a second CONNECT for this cycle.
+	connectH(nil)
+	reconnectH(nil)
+	assert.Equal(t, 2, count(),
+		"each (re)connect must send exactly one CONNECT; \"reconnect\" must not duplicate it")
+
+	// A second reconnect cycle: again exactly one more CONNECT.
+	connectH(nil)
+	reconnectH(nil)
+	assert.Equal(t, 3, count(),
+		"each (re)connect must send exactly one CONNECT; \"reconnect\" must not duplicate it")
+}
+
+// TestReconnectEmitsButDoesNotResendConnect verifies that the engine "reconnect"
+// event surfaces the socket.io-level "reconnect" event to user handlers WITHOUT
+// serializing its own CONNECT packet (the fresh handshake's "connect" event owns
+// that — see issue A).
+func TestReconnectEmitsButDoesNotResendConnect(t *testing.T) {
 	client, handlers, mockEngine, mockParser := captureEngineHandlers(t)
 
-	// connectSocketIO serializes a CONNECT packet and sends it over the engine.
 	var mu sync.Mutex
 	var sentConnect bool
 	mockParser.EXPECT().Serialize(gomock.Any()).DoAndReturn(func(msg *socketio_v5.Message) ([]byte, error) {
@@ -98,7 +151,7 @@ func TestReconnectResendsConnectAndEmits(t *testing.T) {
 	}
 
 	mu.Lock()
-	assert.True(t, sentConnect, "reconnect must re-send the CONNECT packet")
+	assert.False(t, sentConnect, "the \"reconnect\" handler must not re-send CONNECT on its own")
 	mu.Unlock()
 }
 

--- a/socket.io/v5/client/reconnect_test.go
+++ b/socket.io/v5/client/reconnect_test.go
@@ -1,0 +1,161 @@
+package socketio_v5_client
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	socketio_v5 "github.com/maldikhan/go.socket.io/socket.io/v5"
+	mocks "github.com/maldikhan/go.socket.io/socket.io/v5/client/mocks"
+)
+
+// passthroughWrap returns a WrapCallback stub that adapts a func(...interface{})
+// user handler into the func([]interface{}) form the namespace stores, matching
+// what the default parser does at runtime.
+func passthroughWrap(cb interface{}) func([]interface{}) {
+	return func(args []interface{}) {
+		if f, ok := cb.(func(...interface{})); ok {
+			f(args...)
+		}
+	}
+}
+
+// captureEngineHandlers builds a socket.io client backed by a mock engine.io
+// client and records every handler the constructor registers via engineio.On,
+// keyed by event name. This lets the tests invoke the engine-level callbacks
+// (connect, message, reconnect, reconnecting, reconnect_failed) directly and
+// assert the socket.io-level reaction.
+func captureEngineHandlers(t *testing.T) (*Client, map[string]func([]byte), *mocks.MockEngineIOClient, *mocks.MockParser) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+
+	mockEngine := mocks.NewMockEngineIOClient(ctrl)
+	mockParser := mocks.NewMockParser(ctrl)
+	mockLogger := mocks.NewMockLogger(ctrl)
+	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+	mockLogger.EXPECT().Infof(gomock.Any(), gomock.Any()).AnyTimes()
+	mockLogger.EXPECT().Warnf(gomock.Any(), gomock.Any()).AnyTimes()
+	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
+
+	handlers := make(map[string]func([]byte))
+	mockEngine.EXPECT().On(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(event string, handler func([]byte)) {
+			handlers[event] = handler
+		}).AnyTimes()
+
+	client, err := NewClient(
+		WithEngineIOClient(mockEngine),
+		WithLogger(mockLogger),
+		WithParser(mockParser),
+	)
+	require.NoError(t, err)
+	return client, handlers, mockEngine, mockParser
+}
+
+// TestConstructorRegistersReconnectHandlers verifies the constructor wires all
+// engine.io lifecycle events the reconnect feature relies on.
+func TestConstructorRegistersReconnectHandlers(t *testing.T) {
+	_, handlers, _, _ := captureEngineHandlers(t)
+	for _, event := range []string{"connect", "message", "reconnect", "reconnecting", "reconnect_failed"} {
+		assert.NotNil(t, handlers[event], "constructor must register engine handler for %q", event)
+	}
+}
+
+// TestReconnectResendsConnectAndEmits verifies that the engine "reconnect" event
+// (1) re-sends the socket.io CONNECT packet so the namespace re-joins, and
+// (2) emits the socket.io-level "reconnect" event to user handlers.
+func TestReconnectResendsConnectAndEmits(t *testing.T) {
+	client, handlers, mockEngine, mockParser := captureEngineHandlers(t)
+
+	// connectSocketIO serializes a CONNECT packet and sends it over the engine.
+	var mu sync.Mutex
+	var sentConnect bool
+	mockParser.EXPECT().Serialize(gomock.Any()).DoAndReturn(func(msg *socketio_v5.Message) ([]byte, error) {
+		mu.Lock()
+		if msg.Type == socketio_v5.PacketConnect {
+			sentConnect = true
+		}
+		mu.Unlock()
+		return []byte("0"), nil
+	}).AnyTimes()
+	mockEngine.EXPECT().Send(gomock.Any()).Return(nil).AnyTimes()
+	mockParser.EXPECT().WrapCallback(gomock.Any()).DoAndReturn(passthroughWrap).AnyTimes()
+
+	reconnected := make(chan struct{})
+	client.On("reconnect", func(args ...interface{}) { close(reconnected) })
+
+	// Fire the engine-level reconnect event.
+	handlers["reconnect"](nil)
+
+	select {
+	case <-reconnected:
+	case <-time.After(time.Second):
+		t.Fatal("socket.io reconnect handler not invoked")
+	}
+
+	mu.Lock()
+	assert.True(t, sentConnect, "reconnect must re-send the CONNECT packet")
+	mu.Unlock()
+}
+
+// TestReconnectingAndFailedEmit verifies that the "reconnecting" and
+// "reconnect_failed" engine events reach socket.io-level handlers.
+func TestReconnectingAndFailedEmit(t *testing.T) {
+	client, handlers, _, mockParser := captureEngineHandlers(t)
+	mockParser.EXPECT().WrapCallback(gomock.Any()).DoAndReturn(passthroughWrap).AnyTimes()
+
+	reconnecting := make(chan struct{})
+	failed := make(chan struct{})
+	client.On("reconnecting", func(args ...interface{}) { close(reconnecting) })
+	client.On("reconnect_failed", func(args ...interface{}) { close(failed) })
+
+	handlers["reconnecting"](nil)
+	handlers["reconnect_failed"](nil)
+
+	select {
+	case <-reconnecting:
+	case <-time.After(time.Second):
+		t.Fatal("reconnecting handler not invoked")
+	}
+	select {
+	case <-failed:
+	case <-time.After(time.Second):
+		t.Fatal("reconnect_failed handler not invoked")
+	}
+}
+
+// TestEmitReservedNoHandlers exercises emitReserved when there are no handlers
+// registered for the event and when the default namespace is nil (both no-ops).
+func TestEmitReservedNoHandlers(t *testing.T) {
+	client, _, _, _ := captureEngineHandlers(t)
+	// No handlers registered for "reconnect" yet: must be a no-op, not a panic.
+	client.emitReserved("reconnect")
+
+	// Nil default namespace: must short-circuit safely.
+	client.defaultNs = nil
+	client.emitReserved("reconnect")
+}
+
+// TestEmitReservedAnyHandler verifies emitReserved also dispatches to OnAny
+// handlers with a nil payload.
+func TestEmitReservedAnyHandler(t *testing.T) {
+	client, _, _, _ := captureEngineHandlers(t)
+
+	got := make(chan string, 1)
+	client.OnAny(func(event string, args []interface{}) {
+		got <- event
+	})
+
+	client.emitReserved("reconnecting")
+
+	select {
+	case ev := <-got:
+		assert.Equal(t, "reconnecting", ev)
+	case <-time.After(time.Second):
+		t.Fatal("OnAny handler not invoked by emitReserved")
+	}
+}

--- a/socket.io/v5/client/reconnect_test.go
+++ b/socket.io/v5/client/reconnect_test.go
@@ -181,6 +181,121 @@ func TestReconnectingAndFailedEmit(t *testing.T) {
 	}
 }
 
+// TestReconnectingReArmsConnectGate is the regression test for emits racing the
+// re-sent CONNECT after a reconnect: "reconnecting" must re-arm the namespace
+// gate so an Emit (e.g. from a user's "reconnect" handler) blocks until the
+// server acknowledges the new CONNECT, instead of sailing through on the gate
+// closed by the FIRST connection's ack.
+func TestReconnectingReArmsConnectGate(t *testing.T) {
+	client, handlers, mockEngine, mockParser := captureEngineHandlers(t)
+	mockParser.EXPECT().Serialize(gomock.Any()).Return([]byte("2"), nil).AnyTimes()
+	mockEngine.EXPECT().Send(gomock.Any()).Return(nil).AnyTimes()
+
+	// First connection completed: the server's CONNECT ack closed the gate.
+	client.handleConnect(client.defaultNs, nil)
+
+	// Connection drops, reconnect cycle starts.
+	handlers["reconnecting"](nil)
+
+	// An emit issued now (the engine may already have fired "reconnect") must
+	// block until the re-sent CONNECT is acknowledged.
+	emitDone := make(chan error, 1)
+	go func() { emitDone <- client.Emit("hello") }()
+
+	select {
+	case <-emitDone:
+		t.Fatal("Emit must block until the re-sent CONNECT is acknowledged")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// The server acknowledges the re-sent CONNECT: the emit proceeds.
+	client.handleConnect(client.defaultNs, nil)
+	select {
+	case err := <-emitDone:
+		assert.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Emit must proceed once the CONNECT ack arrives")
+	}
+}
+
+// TestReconnectFailedReleasesEmitters verifies that when every reconnect
+// attempt failed (the engine client closes), pending emitters are released
+// instead of blocking forever on a gate no CONNECT ack will ever close.
+func TestReconnectFailedReleasesEmitters(t *testing.T) {
+	client, handlers, mockEngine, mockParser := captureEngineHandlers(t)
+	mockParser.EXPECT().Serialize(gomock.Any()).Return([]byte("2"), nil).AnyTimes()
+	mockEngine.EXPECT().Send(gomock.Any()).Return(nil).AnyTimes()
+
+	client.handleConnect(client.defaultNs, nil)
+	handlers["reconnecting"](nil)
+
+	emitDone := make(chan error, 1)
+	go func() { emitDone <- client.Emit("hello") }()
+	select {
+	case <-emitDone:
+		t.Fatal("Emit must block while the reconnect is in flight")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	handlers["reconnect_failed"](nil)
+	select {
+	case <-emitDone:
+	case <-time.After(time.Second):
+		t.Fatal("reconnect_failed must release pending emitters")
+	}
+}
+
+// TestConnectionGateHelpers covers the namespace gate primitives directly:
+// resetConnectionGate must create a gate when none exists, replace a closed
+// gate and leave an open gate (with potential waiters) untouched;
+// openConnectionGate must tolerate nil gates and duplicate CONNECT acks.
+func TestConnectionGateHelpers(t *testing.T) {
+	t.Run("reset creates gate when nil", func(t *testing.T) {
+		ns := &namespace{}
+		ns.resetConnectionGate()
+		assert.NotNil(t, ns.connectionGate())
+	})
+
+	t.Run("reset keeps an open gate", func(t *testing.T) {
+		ns := &namespace{waitConnected: make(chan struct{})}
+		before := ns.connectionGate()
+		ns.resetConnectionGate()
+		assert.Equal(t, before, ns.connectionGate(),
+			"an open gate has waiters bound to it and must not be replaced")
+	})
+
+	t.Run("reset replaces a closed gate", func(t *testing.T) {
+		ns := &namespace{waitConnected: make(chan struct{})}
+		ns.openConnectionGate()
+		before := ns.connectionGate()
+		ns.resetConnectionGate()
+		after := ns.connectionGate()
+		assert.NotEqual(t, before, after)
+		select {
+		case <-after:
+			t.Fatal("the re-armed gate must be open (blocking)")
+		default:
+		}
+	})
+
+	t.Run("open tolerates nil gate", func(t *testing.T) {
+		ns := &namespace{}
+		ns.openConnectionGate()
+		assert.Nil(t, ns.connectionGate())
+	})
+
+	t.Run("open is idempotent", func(t *testing.T) {
+		ns := &namespace{waitConnected: make(chan struct{})}
+		ns.openConnectionGate()
+		ns.openConnectionGate() // duplicate CONNECT ack must not panic
+		select {
+		case <-ns.connectionGate():
+		default:
+			t.Fatal("gate must be closed after openConnectionGate")
+		}
+	})
+}
+
 // TestEmitReservedNoHandlers exercises emitReserved when there are no handlers
 // registered for the event and when the default namespace is nil (both no-ops).
 func TestEmitReservedNoHandlers(t *testing.T) {

--- a/socket.io/v5/parser/default/callback.go
+++ b/socket.io/v5/parser/default/callback.go
@@ -25,13 +25,23 @@ func (p *SocketIOV5DefaultParser) WrapCallback(callback interface{}) func(in []i
 	}
 
 	return func(in []interface{}) {
-		if len(in) < callbackType.NumIn() {
+		// A variadic callback (e.g. func(args ...interface{})) only requires
+		// its fixed parameters: when exactly those are supplied, the variadic
+		// slot is omitted and reflect's Call invokes the function with an
+		// empty variadic list. Without this, a handler registered for a
+		// reserved lifecycle event ("reconnect", "reconnecting",
+		// "reconnect_failed") — which is dispatched with no payload — would be
+		// silently rejected by the arity check below.
+		numIn := callbackType.NumIn()
+		if callbackType.IsVariadic() && len(in) == numIn-1 {
+			numIn--
+		} else if len(in) < numIn {
 			p.logger.Errorf("Error: expected %d arguments, got %d\n", callbackType.NumIn(), len(in))
 			return
 		}
 
-		args := make([]reflect.Value, callbackType.NumIn())
-		for i := 0; i < callbackType.NumIn(); i++ {
+		args := make([]reflect.Value, numIn)
+		for i := 0; i < numIn; i++ {
 			argType := callbackType.In(i)
 			argValue := reflect.New(argType).Interface()
 			data, ok := in[i].(json.RawMessage)

--- a/socket.io/v5/parser/default/parser_test.go
+++ b/socket.io/v5/parser/default/parser_test.go
@@ -936,3 +936,45 @@ var typedEvent = []interface{}{
 	},
 	[]string{"a", "b", "c"},
 }
+
+// TestWrapCallback_VariadicNoPayload verifies that a variadic handler — the
+// natural shape for reserved lifecycle events ("reconnect", "reconnecting",
+// "reconnect_failed"), which are dispatched with no payload — is invoked with
+// an empty argument list instead of being rejected by the arity check.
+func TestWrapCallback_VariadicNoPayload(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	t.Run("variadic only, nil payload", func(t *testing.T) {
+		t.Parallel()
+		called := false
+		callback := parser.WrapCallback(func(args ...interface{}) {
+			assert.Empty(t, args)
+			called = true
+		})
+		callback(nil)
+		assert.True(t, called, "variadic handler must fire for a no-payload event")
+	})
+
+	t.Run("fixed plus variadic still requires the fixed args", func(t *testing.T) {
+		t.Parallel()
+		called := false
+		callback := parser.WrapCallback(func(_ string, _ ...interface{}) {
+			called = true
+		})
+		callback(nil)
+		assert.False(t, called, "missing fixed arguments must still be rejected")
+	})
+
+	t.Run("fixed plus variadic with exactly the fixed args", func(t *testing.T) {
+		t.Parallel()
+		called := false
+		callback := parser.WrapCallback(func(s string, rest ...interface{}) {
+			assert.Equal(t, "hello", s)
+			assert.Empty(t, rest)
+			called = true
+		})
+		callback([]interface{}{json.RawMessage(`"hello"`)})
+		assert.True(t, called)
+	})
+}

--- a/websocket/native/ws_test.go
+++ b/websocket/native/ws_test.go
@@ -40,22 +40,24 @@ func TestWebSocketConnection_Dial(t *testing.T) {
 	t.Run("Connection error", func(t *testing.T) {
 		t.Parallel()
 		ws := &WebSocketConnection{}
-		err = ws.Dial(ctx, &url.URL{
+		// Use a local error: parallel subtests must not write the shared
+		// variable from the parent scope (data race).
+		dialErr := ws.Dial(ctx, &url.URL{
 			Path:   "invalid-url",
 			Scheme: "ws",
 		}, origin)
-		assert.Error(t, err, "Dial should return an error for invalid URL")
+		assert.Error(t, dialErr, "Dial should return an error for invalid URL")
 		assert.Nil(t, ws.conn, "Connection should not be established")
 	})
 
 	t.Run("Config error", func(t *testing.T) {
 		t.Parallel()
 		ws := &WebSocketConnection{}
-		err = ws.Dial(ctx, &url.URL{
+		dialErr := ws.Dial(ctx, &url.URL{
 			Path:   "invalid-url",
 			Scheme: ";;;",
 		}, origin)
-		assert.Error(t, err, "Dial should return an error for invalid URL")
+		assert.Error(t, dialErr, "Dial should return an error for invalid URL")
 		assert.Nil(t, ws.conn, "Connection should not be established")
 	})
 }
@@ -256,18 +258,17 @@ func createTestServer(t *testing.T, receivedChan chan<- string) *httptest.Server
 			var msg string
 			err := websocket.Message.Receive(ws, &msg)
 			if err != nil {
-				// Игнорируем ошибку EOF, так как она ожидаема при закрытии соединения
-				if err.Error() != "EOF" {
-					t.Logf("Server received an error: %v", err)
-				}
+				// Receive errors (EOF, connection reset) are expected when the
+				// client side of a finished test tears the connection down. The
+				// handler goroutine may outlive the test, so it must not call
+				// t.Logf/t.Errorf here — logging after the test completes panics.
 				return
 			}
 			if receivedChan != nil {
 				receivedChan <- msg
 			}
-			// Echo the message back
+			// Echo the message back. Send errors are likewise teardown noise.
 			if err := websocket.Message.Send(ws, msg); err != nil {
-				t.Errorf("Server failed to send message: %v", err)
 				return
 			}
 		}


### PR DESCRIPTION
Implements #26. Closes #26.

## Summary
Adds an automatic reconnection supervisor at the **engine.io Client** level (reconnect needs a fresh handshake and possible transport re-selection, so it can't live in a single transport). The previously dead `reconnectAttempts` / `reconnectWait` config is now wired up.

## Reconnect state machine (`engine.io/v4/client/reconnect.go`)
1. After a successful handshake, a single supervisor goroutine is started (guarded by a per-cycle `sync.Once`) that owns that cycle's `transportClosed` channel (it snapshots the cycle's channels so a later reconnect can't close the wrong one).
2. The supervisor blocks on `transportClosed`: a **nil** value = graceful stop (Close / drained upgrade) → exit; a **non-nil error** = unexpected drop.
3. On a drop: if `Close()` was called → exit; if reconnection is disabled → run the existing close handler (exact pre-existing behavior) and exit; otherwise enter the reconnect loop.
4. **Reconnect loop**: fire `reconnecting`, then up to `reconnectAttempts` tries with exponential backoff (`reconnectWait` base, doubling, capped at 8×). Each attempt fully re-initialises every per-connection channel and `sync.Once` (messages, transportClosed, supervisorDone, hadUpgrade/waitUpgrade, hadHandshake/waitHandshake) before touching the transport. On success → fire `reconnect`; on exhaustion → fire `reconnect_failed` then `Close()`. The loop aborts promptly on context cancellation / `Close()`.
5. `Connect` now delegates to the shared connection setup; `Close` is idempotent (CAS guard) and defers `transportClosed` draining to the live supervisor.

## New public API
- Engine.io options: `WithReconnect(bool)` (default **true**), `WithOnReconnecting(func())`, `WithOnReconnect(func())`, `WithOnReconnectFailed(func())`.
- Synthetic events: `On("reconnecting" | "reconnect" | "reconnect_failed", func([]byte))` — surfaced to the socket.io client too (`client.On("reconnect", ...)`). On a successful reconnect the socket.io layer re-sends its CONNECT packet, re-joining the namespace.

## Notes / scope
- Reconnection is driven primarily off the **websocket** transport's read-error signal. The polling transport's loop reports `ctx.Err()` (nil on a transient blip) and backs off internally, so a pure-polling session retries inside the transport rather than via the Client supervisor — consistent with the existing transport design. Surfacing hard polling failures would be a separate change.
- README left unchanged (per maintainer's request to leave docs as-is for now).

## Validation (verified independently on the pushed tip)
- `go build ./...`, `go vet ./...`, `gofmt -l` — all clean.
- `go test ./...` — pass; `go test -race ./engine.io/... ./socket.io/...` — no races.
- Coverage: `engine.io/v4/client` **100%**, `socket.io/v5/client` **100%**.

https://claude.ai/code/session_01Gkv7LscaX5vY63HQFudXTi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gkv7LscaX5vY63HQFudXTi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reconnection enabled by default with exponential backoff and configurable hooks for reconnecting/reconnect/reconnect_failed.
  * Socket.IO now propagates engine-layer reconnect events and preserves namespace info on CONNECT and emitted messages.

* **Bug Fixes**
  * Reliable message-loop teardown across reconnects, prompt Close during backoff, and safer transport/upgrade handling (fatal poll errors stop transport).

* **Tests**
  * Broad unit and e2e coverage for reconnect, close races, backoff wake-ups, gating, and transport behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->