### PR TITLE
[4.3] Add binary event support (PacketBinaryEvent / PacketBinaryAck)

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -163,3 +163,85 @@ func TestE2E_PollingOnly(t *testing.T) {
 func TestE2E_WebsocketOnly(t *testing.T) {
 	runScenario(t, newClient(t, "websocket"))
 }
+
+// runBinaryScenario exercises the Socket.IO v5 binary attachment paths against
+// the real server: a binary ack round-trip ("binEcho") and a server-pushed
+// binary event ("binWelcome"), asserting the []byte survives both directions.
+func runBinaryScenario(t *testing.T, client *socketio.Client) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	binWelcome := make(chan []byte, 1)
+	client.On("binWelcome", func(buf []byte) {
+		select {
+		case binWelcome <- buf:
+		default:
+		}
+	})
+
+	connected := make(chan struct{}, 1)
+	client.On("connect", func() {
+		select {
+		case connected <- struct{}{}:
+		default:
+		}
+	})
+
+	if err := client.Connect(ctx); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer client.Close()
+
+	select {
+	case <-connected:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for connect event")
+	}
+
+	// Binary ack round-trip: send a Buffer, expect the same bytes back.
+	payload := []byte{0x00, 0x01, 0x02, 0xFF, 0x7F, 0x80}
+	ack := make(chan []byte, 1)
+	if err := client.Emit("binEcho", payload, emit.WithAck(func(buf []byte) {
+		select {
+		case ack <- buf:
+		default:
+		}
+	})); err != nil {
+		t.Fatalf("emit binEcho: %v", err)
+	}
+	select {
+	case got := <-ack:
+		if string(got) != string(payload) {
+			t.Fatalf("binEcho ack = %v, want %v", got, payload)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for binEcho ack")
+	}
+
+	// Server-pushed binary event: emit "binPush", expect a "binWelcome" Buffer.
+	if err := client.Emit("binPush", "world"); err != nil {
+		t.Fatalf("emit binPush: %v", err)
+	}
+	select {
+	case got := <-binWelcome:
+		if string(got) != "world" {
+			t.Fatalf("binWelcome payload = %q, want %q", got, "world")
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for binWelcome event")
+	}
+}
+
+func TestE2E_BinaryDefaultTransport(t *testing.T) {
+	runBinaryScenario(t, newClient(t, "default"))
+}
+
+func TestE2E_BinaryPollingOnly(t *testing.T) {
+	runBinaryScenario(t, newClient(t, "polling"))
+}
+
+func TestE2E_BinaryWebsocketOnly(t *testing.T) {
+	runBinaryScenario(t, newClient(t, "websocket"))
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -253,3 +253,103 @@ func TestE2E_BinaryWebsocketOnly(t *testing.T) {
 func TestE2E_Namespace(t *testing.T) {
 	runScenario(t, newClient(t, "default", socketio.WithDefaultNamespace("/admin")))
 }
+
+// runRichBinaryScenario exercises the harder corners of the binary protocol
+// against the real server: multiple attachments in one packet (both
+// directions) and a nested object mixing a Buffer, a null and a string —
+// asserting placeholder substitution at nested positions and that nil byte
+// slices stay JSON null rather than becoming empty attachments.
+func runRichBinaryScenario(t *testing.T, client *socketio.Client) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	connected := make(chan struct{}, 1)
+	client.On("connect", func() {
+		select {
+		case connected <- struct{}{}:
+		default:
+		}
+	})
+
+	if err := client.Connect(ctx); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer client.Close()
+
+	select {
+	case <-connected:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for connect event")
+	}
+
+	// Two attachments in one packet, echoed back as two attachments.
+	first := []byte{0x01, 0x02, 0x03}
+	second := []byte{0xFF, 0x00, 0x7F, 0x80}
+	multiAck := make(chan [2][]byte, 1)
+	if err := client.Emit("binMulti", first, second, emit.WithAck(func(a, b []byte) {
+		select {
+		case multiAck <- [2][]byte{a, b}:
+		default:
+		}
+	})); err != nil {
+		t.Fatalf("emit binMulti: %v", err)
+	}
+	select {
+	case got := <-multiAck:
+		if string(got[0]) != string(first) || string(got[1]) != string(second) {
+			t.Fatalf("binMulti ack = %v/%v, want %v/%v", got[0], got[1], first, second)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for binMulti ack")
+	}
+
+	// A nested object: Buffer at a key, an explicit null (sent as a nil byte
+	// slice, which must serialize as JSON null) and a plain string.
+	type nested struct {
+		File []byte  `json:"file"`
+		Note *string `json:"note"`
+		Name string  `json:"name"`
+	}
+	payload := map[string]interface{}{
+		"file": []byte("attachment-bytes"),
+		"note": []byte(nil), // nil []byte must arrive as null, not an empty Buffer
+		"name": "report.bin",
+	}
+	nestedAck := make(chan nested, 1)
+	if err := client.Emit("binNested", payload, emit.WithAck(func(obj nested) {
+		select {
+		case nestedAck <- obj:
+		default:
+		}
+	})); err != nil {
+		t.Fatalf("emit binNested: %v", err)
+	}
+	select {
+	case got := <-nestedAck:
+		if string(got.File) != "attachment-bytes" {
+			t.Fatalf("binNested file = %q, want %q", got.File, "attachment-bytes")
+		}
+		if got.Note != nil {
+			t.Fatalf("binNested note = %q, want JSON null (nil)", *got.Note)
+		}
+		if got.Name != "report.bin" {
+			t.Fatalf("binNested name = %q, want %q", got.Name, "report.bin")
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for binNested ack")
+	}
+}
+
+func TestE2E_BinaryRich_DefaultTransport(t *testing.T) {
+	runRichBinaryScenario(t, newClient(t, "default"))
+}
+
+func TestE2E_BinaryRich_PollingOnly(t *testing.T) {
+	runRichBinaryScenario(t, newClient(t, "polling"))
+}
+
+func TestE2E_BinaryRich_WebsocketOnly(t *testing.T) {
+	runRichBinaryScenario(t, newClient(t, "websocket"))
+}

--- a/e2e/server/index.js
+++ b/e2e/server/index.js
@@ -28,6 +28,20 @@ function wire(socket, ns) {
     socket.emit('welcome', 'hello ' + name);
   });
 
+  // "binEcho" echoes a binary Buffer back through the ack callback, exercising
+  // the socket.io binary attachment (PacketBinaryAck) path.
+  socket.on('binEcho', (buf, ack) => {
+    if (typeof ack === 'function') {
+      ack(buf);
+    }
+  });
+
+  // "binPush" triggers a server-pushed "binWelcome" event carrying a binary
+  // Buffer (PacketBinaryEvent), so the client receives []byte without an ack.
+  socket.on('binPush', (name) => {
+    socket.emit('binWelcome', Buffer.from(String(name)));
+  });
+
   // eslint-disable-next-line no-console
   console.log('client connected on namespace ' + ns + ': ' + socket.id);
 }

--- a/e2e/server/index.js
+++ b/e2e/server/index.js
@@ -36,6 +36,23 @@ function wire(socket, ns) {
     }
   });
 
+  // "binMulti" acks with BOTH buffers, exercising multi-attachment encoding in
+  // both directions (two placeholders in one packet).
+  socket.on('binMulti', (a, b, ack) => {
+    if (typeof ack === 'function') {
+      ack(a, b);
+    }
+  });
+
+  // "binNested" echoes an object that mixes a binary Buffer, a null and a
+  // plain string back through the ack, exercising placeholder substitution at
+  // nested positions and null handling next to real attachments.
+  socket.on('binNested', (obj, ack) => {
+    if (typeof ack === 'function') {
+      ack({ file: obj.file, note: obj.note, name: obj.name });
+    }
+  });
+
   // "binPush" triggers a server-pushed "binWelcome" event carrying a binary
   // Buffer (PacketBinaryEvent), so the client receives []byte without an ack.
   socket.on('binPush', (name) => {

--- a/engine.io/v4/client/binary_test.go
+++ b/engine.io/v4/client/binary_test.go
@@ -1,0 +1,252 @@
+package engineio_v4_client
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	engineio_v4 "github.com/maldikhan/go.socket.io/engine.io/v4"
+	mocks "github.com/maldikhan/go.socket.io/engine.io/v4/client/mocks"
+)
+
+// newBinaryTestClient builds a Client wired with fresh mocks for the binary
+// tests. Debugf is allowed any number of times since the binary paths log.
+func newBinaryTestClient(t *testing.T) (*Client, *mocks.MockTransport, *mocks.MockParser, *mocks.MockLogger) {
+	ctrl := gomock.NewController(t)
+	mockTransport := mocks.NewMockTransport(ctrl)
+	mockParser := mocks.NewMockParser(ctrl)
+	mockLogger := mocks.NewMockLogger(ctrl)
+	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+	mockLogger.EXPECT().Debugf(gomock.Any()).AnyTimes()
+	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
+
+	client := &Client{
+		log:       mockLogger,
+		transport: mockTransport,
+		parser:    mockParser,
+	}
+	return client, mockTransport, mockParser, mockLogger
+}
+
+func TestClient_splitRecords(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input []byte
+		want  [][]byte
+	}{
+		{
+			name:  "no separator yields single record",
+			input: []byte("4hello"),
+			want:  [][]byte{[]byte("4hello")},
+		},
+		{
+			name:  "two records",
+			input: []byte("4hello\x1e4world"),
+			want:  [][]byte{[]byte("4hello"), []byte("4world")},
+		},
+		{
+			name:  "trailing separator yields empty tail",
+			input: []byte("4a\x1e"),
+			want:  [][]byte{[]byte("4a"), {}},
+		},
+		{
+			name:  "empty input yields one empty record",
+			input: []byte{},
+			want:  [][]byte{{}},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, splitRecords(tt.input))
+		})
+	}
+}
+
+func TestClient_handleFrame_Binary(t *testing.T) {
+	client, _, _, _ := newBinaryTestClient(t)
+
+	got := make(chan []byte, 1)
+	client.On("binary", func(data []byte) {
+		got <- data
+	})
+
+	err := client.handleFrame(engineio_v4.Frame{Data: []byte{1, 2, 3}, IsBinary: true})
+	require.NoError(t, err)
+	assert.Equal(t, []byte{1, 2, 3}, <-got)
+}
+
+func TestClient_handleFrame_BinaryNoHandler(t *testing.T) {
+	client, _, _, _ := newBinaryTestClient(t)
+	// No binary handler registered: must not panic and returns nil.
+	err := client.handleFrame(engineio_v4.Frame{Data: []byte{1}, IsBinary: true})
+	assert.NoError(t, err)
+}
+
+func TestClient_handleFrame_EmptyRecordSkipped(t *testing.T) {
+	client, _, mockParser, _ := newBinaryTestClient(t)
+
+	// A trailing separator produces an empty record that must be skipped (only
+	// the non-empty "4a" record is parsed).
+	mockParser.EXPECT().Parse([]byte("4a")).Return(&engineio_v4.Message{
+		Type: engineio_v4.PacketMessage, Data: []byte("a"),
+	}, nil)
+
+	err := client.handleFrame(engineio_v4.Frame{Data: []byte("4a\x1e")})
+	require.NoError(t, err)
+}
+
+func TestClient_handleFrame_MultiRecord(t *testing.T) {
+	client, _, mockParser, _ := newBinaryTestClient(t)
+
+	got := make(chan []byte, 2)
+	client.On("message", func(data []byte) { got <- data })
+
+	mockParser.EXPECT().Parse([]byte("4a")).Return(&engineio_v4.Message{
+		Type: engineio_v4.PacketMessage, Data: []byte("a"),
+	}, nil)
+	mockParser.EXPECT().Parse([]byte("4b")).Return(&engineio_v4.Message{
+		Type: engineio_v4.PacketMessage, Data: []byte("b"),
+	}, nil)
+
+	err := client.handleFrame(engineio_v4.Frame{Data: []byte("4a\x1e4b")})
+	require.NoError(t, err)
+	assert.Equal(t, []byte("a"), <-got)
+	assert.Equal(t, []byte("b"), <-got)
+}
+
+func TestClient_handleFrame_RecordParseError(t *testing.T) {
+	client, _, mockParser, _ := newBinaryTestClient(t)
+
+	mockParser.EXPECT().Parse(gomock.Any()).Return(nil, assertErr())
+
+	err := client.handleFrame(engineio_v4.Frame{Data: []byte("bad")})
+	assert.Error(t, err)
+}
+
+func TestClient_handlePacket_BinaryMessage(t *testing.T) {
+	client, _, mockParser, _ := newBinaryTestClient(t)
+
+	got := make(chan []byte, 1)
+	client.On("binary", func(data []byte) { got <- data })
+
+	mockParser.EXPECT().Parse(gomock.Any()).Return(&engineio_v4.Message{
+		Type:   engineio_v4.PacketMessage,
+		Data:   []byte{9, 8, 7},
+		Binary: true,
+	}, nil)
+
+	err := client.handleFrame(engineio_v4.Frame{Data: []byte("bCQgH")})
+	require.NoError(t, err)
+	assert.Equal(t, []byte{9, 8, 7}, <-got)
+}
+
+func TestClient_handlePacket_BinaryMessageNoHandler(t *testing.T) {
+	client, _, mockParser, _ := newBinaryTestClient(t)
+
+	mockParser.EXPECT().Parse(gomock.Any()).Return(&engineio_v4.Message{
+		Type:   engineio_v4.PacketMessage,
+		Data:   []byte{1},
+		Binary: true,
+	}, nil)
+
+	// No binary handler registered: must not panic.
+	err := client.handleFrame(engineio_v4.Frame{Data: []byte("bAQ==")})
+	require.NoError(t, err)
+}
+
+func TestClient_On_BinaryHandlerRegistration(t *testing.T) {
+	client, _, _, _ := newBinaryTestClient(t)
+	// Registering the "binary" handler must set binaryHandler so binary frames
+	// are routed to it.
+	called := make(chan struct{}, 1)
+	client.On("binary", func([]byte) { called <- struct{}{} })
+
+	client.handlerMu.RLock()
+	h := client.binaryHandler
+	client.handlerMu.RUnlock()
+	require.NotNil(t, h)
+	h(nil)
+	<-called
+}
+
+// TestClient_On_AllEvents registers every supported event and invokes the
+// stored wrappers so each On case (including the connect/close zero-arg
+// adapters) is exercised.
+func TestClient_On_AllEvents(t *testing.T) {
+	client, _, _, _ := newBinaryTestClient(t)
+
+	hits := make(chan string, 4)
+	client.On("connect", func([]byte) { hits <- "connect" })
+	client.On("message", func([]byte) { hits <- "message" })
+	client.On("binary", func([]byte) { hits <- "binary" })
+	client.On("close", func([]byte) { hits <- "close" })
+
+	client.handlerMu.RLock()
+	connect := client.afterConnect
+	message := client.messageHandler
+	binary := client.binaryHandler
+	closeH := client.closeHandler
+	client.handlerMu.RUnlock()
+
+	require.NotNil(t, connect)
+	require.NotNil(t, message)
+	require.NotNil(t, binary)
+	require.NotNil(t, closeH)
+
+	connect()
+	message(nil)
+	binary(nil)
+	closeH()
+
+	got := map[string]bool{}
+	for i := 0; i < 4; i++ {
+		got[<-hits] = true
+	}
+	assert.Equal(t, map[string]bool{"connect": true, "message": true, "binary": true, "close": true}, got)
+}
+
+func TestClient_SendBinary(t *testing.T) {
+	t.Run("delivers to transport", func(t *testing.T) {
+		client, mockTransport, _, _ := newBinaryTestClient(t)
+		mockTransport.EXPECT().SendBinary([]byte{1, 2, 3}).Return(nil)
+		assert.NoError(t, client.SendBinary([]byte{1, 2, 3}))
+	})
+
+	t.Run("waits on handshake and upgrade gates", func(t *testing.T) {
+		client, mockTransport, _, _ := newBinaryTestClient(t)
+		wh := make(chan struct{})
+		wu := make(chan struct{})
+		client.waitHandshake = wh
+		client.waitUpgrade = wu
+		close(wh)
+		close(wu)
+		mockTransport.EXPECT().SendBinary(gomock.Any()).Return(nil)
+		assert.NoError(t, client.SendBinary([]byte{4}))
+	})
+
+	t.Run("closed client", func(t *testing.T) {
+		client, _, _, _ := newBinaryTestClient(t)
+		client.transport = nil
+		err := client.SendBinary([]byte{1})
+		assert.Error(t, err)
+	})
+}
+
+// assertErr is a small helper returning a deterministic error for the binary
+// tests.
+func assertErr() error {
+	return errBinaryTest
+}
+
+var errBinaryTest = &binaryTestError{}
+
+type binaryTestError struct{}
+
+func (e *binaryTestError) Error() string { return "binary test error" }

--- a/engine.io/v4/client/binary_test.go
+++ b/engine.io/v4/client/binary_test.go
@@ -30,45 +30,6 @@ func newBinaryTestClient(t *testing.T) (*Client, *mocks.MockTransport, *mocks.Mo
 	return client, mockTransport, mockParser, mockLogger
 }
 
-func TestClient_splitRecords(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name  string
-		input []byte
-		want  [][]byte
-	}{
-		{
-			name:  "no separator yields single record",
-			input: []byte("4hello"),
-			want:  [][]byte{[]byte("4hello")},
-		},
-		{
-			name:  "two records",
-			input: []byte("4hello\x1e4world"),
-			want:  [][]byte{[]byte("4hello"), []byte("4world")},
-		},
-		{
-			name:  "trailing separator yields empty tail",
-			input: []byte("4a\x1e"),
-			want:  [][]byte{[]byte("4a"), {}},
-		},
-		{
-			name:  "empty input yields one empty record",
-			input: []byte{},
-			want:  [][]byte{{}},
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			assert.Equal(t, tt.want, splitRecords(tt.input))
-		})
-	}
-}
-
 func TestClient_handleFrame_Binary(t *testing.T) {
 	client, _, _, _ := newBinaryTestClient(t)
 
@@ -89,36 +50,33 @@ func TestClient_handleFrame_BinaryNoHandler(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestClient_handleFrame_EmptyRecordSkipped(t *testing.T) {
+func TestClient_handleFrame_EmptyFrameSkipped(t *testing.T) {
 	client, _, mockParser, _ := newBinaryTestClient(t)
 
-	// A trailing separator produces an empty record that must be skipped (only
-	// the non-empty "4a" record is parsed).
-	mockParser.EXPECT().Parse([]byte("4a")).Return(&engineio_v4.Message{
-		Type: engineio_v4.PacketMessage, Data: []byte("a"),
-	}, nil)
+	// An empty text frame carries no packet: handleFrame must skip it without
+	// ever invoking the parser. Record splitting now lives in the polling
+	// transport, so the engine.io client only ever sees single-packet frames.
+	mockParser.EXPECT().Parse(gomock.Any()).Times(0)
 
-	err := client.handleFrame(engineio_v4.Frame{Data: []byte("4a\x1e")})
+	err := client.handleFrame(engineio_v4.Frame{Data: []byte{}})
 	require.NoError(t, err)
 }
 
-func TestClient_handleFrame_MultiRecord(t *testing.T) {
+func TestClient_handleFrame_SingleRecord(t *testing.T) {
 	client, _, mockParser, _ := newBinaryTestClient(t)
 
-	got := make(chan []byte, 2)
+	got := make(chan []byte, 1)
 	client.On("message", func(data []byte) { got <- data })
 
+	// A text frame carries exactly one packet (the transports deliver one
+	// record per frame), so the whole frame is parsed as a single packet.
 	mockParser.EXPECT().Parse([]byte("4a")).Return(&engineio_v4.Message{
 		Type: engineio_v4.PacketMessage, Data: []byte("a"),
 	}, nil)
-	mockParser.EXPECT().Parse([]byte("4b")).Return(&engineio_v4.Message{
-		Type: engineio_v4.PacketMessage, Data: []byte("b"),
-	}, nil)
 
-	err := client.handleFrame(engineio_v4.Frame{Data: []byte("4a\x1e4b")})
+	err := client.handleFrame(engineio_v4.Frame{Data: []byte("4a")})
 	require.NoError(t, err)
 	assert.Equal(t, []byte("a"), <-got)
-	assert.Equal(t, []byte("b"), <-got)
 }
 
 func TestClient_handleFrame_RecordParseError(t *testing.T) {

--- a/engine.io/v4/client/client.go
+++ b/engine.io/v4/client/client.go
@@ -23,6 +23,7 @@ type Client struct {
 	pingTimeout         time.Duration
 	parser              Parser
 	messageHandler      func([]byte)
+	binaryHandler       func([]byte)
 	closeHandler        func()
 	reconnectAttempts   int
 	reconnectWait       time.Duration
@@ -33,7 +34,7 @@ type Client struct {
 	stopPooling         chan struct{}
 	transportClosed     chan error
 	afterConnect        func()
-	messages            chan []byte
+	messages            chan engineio_v4.Frame
 	messagesDone        chan struct{} // closed when messageLoop exits
 
 	// transportMu serializes access to the transport field and
@@ -67,7 +68,7 @@ func (c *Client) payload(data []byte) string {
 func (c *Client) Connect(ctx context.Context) error {
 	c.ctx = ctx
 
-	c.messages = make(chan []byte, 100)
+	c.messages = make(chan engineio_v4.Frame, 100)
 
 	// Run transport before starting the message loop so that a Run()
 	// failure doesn't leak a goroutine.
@@ -103,7 +104,7 @@ func (c *Client) Connect(ctx context.Context) error {
 	return nil
 }
 
-func (c *Client) messageLoop(ctx context.Context, messages <-chan []byte) {
+func (c *Client) messageLoop(ctx context.Context, messages <-chan engineio_v4.Frame) {
 	if c.messagesDone != nil {
 		defer close(c.messagesDone)
 	}
@@ -113,11 +114,11 @@ func (c *Client) messageLoop(ctx context.Context, messages <-chan []byte) {
 	}
 	for {
 		select {
-		case message, ok := <-messages:
+		case frame, ok := <-messages:
 			if !ok {
 				return
 			}
-			err := c.handlePacket(message)
+			err := c.handleFrame(frame)
 			if err != nil {
 				c.log.Errorf("handle packet error: %s", err)
 			}
@@ -259,6 +260,53 @@ func (c *Client) handleHandshake(data []byte) error {
 	return nil
 }
 
+// recordSeparator is the engine.io v4 payload delimiter (U+001E) that joins
+// multiple packets inside a single HTTP long-polling body.
+const recordSeparator = '\x1e'
+
+// handleFrame dispatches one transport frame. A binary frame is delivered as a
+// single attachment to the binary handler. A text frame may carry several
+// engine.io packets joined by the record separator (HTTP long-polling), so it
+// is split and each record handled in order. WebSocket frames carry exactly one
+// record, so splitting is a no-op there.
+func (c *Client) handleFrame(frame engineio_v4.Frame) error {
+	if frame.IsBinary {
+		c.log.Debugf("handle binary frame: %s", c.payload(frame.Data))
+		c.handlerMu.RLock()
+		handler := c.binaryHandler
+		c.handlerMu.RUnlock()
+		if handler != nil {
+			handler(frame.Data)
+		}
+		return nil
+	}
+
+	for _, record := range splitRecords(frame.Data) {
+		if len(record) == 0 {
+			continue
+		}
+		if err := c.handlePacket(record); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// splitRecords splits a text payload on the engine.io record separator. A
+// payload without separators yields a single record, so single-packet frames
+// (and every WebSocket frame) flow through unchanged.
+func splitRecords(data []byte) [][]byte {
+	var out [][]byte
+	start := 0
+	for i := 0; i < len(data); i++ {
+		if data[i] == recordSeparator {
+			out = append(out, data[start:i])
+			start = i + 1
+		}
+	}
+	return append(out, data[start:])
+}
+
 func (c *Client) handlePacket(packetData []byte) error {
 	c.log.Debugf("handle packet: %s", c.payload(packetData))
 	packet, err := c.parser.Parse(packetData)
@@ -311,8 +359,15 @@ func (c *Client) handlePacket(packetData []byte) error {
 	case engineio_v4.PacketMessage:
 		c.handlerMu.RLock()
 		handler := c.messageHandler
+		binaryHandler := c.binaryHandler
 		c.handlerMu.RUnlock()
-		if handler != nil {
+		// A base64 "b"-prefixed record decodes to a binary attachment; route it
+		// to the binary handler so socket.io can reassemble binary events.
+		if packet.Binary {
+			if binaryHandler != nil {
+				binaryHandler(packet.Data)
+			}
+		} else if handler != nil {
 			handler(packet.Data)
 		}
 	}
@@ -368,6 +423,38 @@ func (c *Client) Send(message []byte) error {
 	return t.SendMessage(msg)
 }
 
+// SendBinary delivers a raw binary attachment after waiting on the same
+// handshake/upgrade gates as Send(), so binary frames are never written on a
+// transport that is mid-upgrade or closed. The transport encodes the bytes for
+// the active transport (raw binary frame for websocket, base64 record for
+// long-polling).
+func (c *Client) SendBinary(message []byte) error {
+	c.transportMu.RLock()
+	wh := c.waitHandshake
+	wu := c.waitUpgrade
+	c.transportMu.RUnlock()
+
+	if wh != nil {
+		<-wh
+	}
+	if wu != nil {
+		<-wu
+	}
+
+	c.transportMu.RLock()
+	t := c.transport
+	c.transportMu.RUnlock()
+
+	if t == nil {
+		return errors.New("client is closed")
+	}
+
+	// Pass the raw attachment bytes to the transport; each transport applies its
+	// own wire encoding (raw binary frame over websocket, base64 "b"-record over
+	// HTTP long-polling).
+	return t.SendBinary(message)
+}
+
 func (c *Client) On(event string, handler func([]byte)) {
 	c.handlerMu.Lock()
 	defer c.handlerMu.Unlock()
@@ -377,6 +464,8 @@ func (c *Client) On(event string, handler func([]byte)) {
 		c.afterConnect = func() { handler(nil) }
 	case "message":
 		c.messageHandler = handler
+	case "binary":
+		c.binaryHandler = handler
 	case "close":
 		c.closeHandler = func() { handler(nil) }
 	}

--- a/engine.io/v4/client/client.go
+++ b/engine.io/v4/client/client.go
@@ -260,15 +260,12 @@ func (c *Client) handleHandshake(data []byte) error {
 	return nil
 }
 
-// recordSeparator is the engine.io v4 payload delimiter (U+001E) that joins
-// multiple packets inside a single HTTP long-polling body.
-const recordSeparator = '\x1e'
-
-// handleFrame dispatches one transport frame. A binary frame is delivered as a
-// single attachment to the binary handler. A text frame may carry several
-// engine.io packets joined by the record separator (HTTP long-polling), so it
-// is split and each record handled in order. WebSocket frames carry exactly one
-// record, so splitting is a no-op there.
+// handleFrame dispatches one transport frame, which always carries exactly one
+// engine.io packet. A binary frame is delivered as a single attachment to the
+// binary handler. A text frame carries one packet record: the polling transport
+// splits a multi-packet long-polling body into individual record frames before
+// delivery, and the WebSocket transport already frames each packet on its own,
+// so the record separator (U+001E) never reaches this layer.
 func (c *Client) handleFrame(frame engineio_v4.Frame) error {
 	if frame.IsBinary {
 		c.log.Debugf("handle binary frame: %s", c.payload(frame.Data))
@@ -281,30 +278,11 @@ func (c *Client) handleFrame(frame engineio_v4.Frame) error {
 		return nil
 	}
 
-	for _, record := range splitRecords(frame.Data) {
-		if len(record) == 0 {
-			continue
-		}
-		if err := c.handlePacket(record); err != nil {
-			return err
-		}
+	// Defensively skip an empty text frame: it carries no packet to parse.
+	if len(frame.Data) == 0 {
+		return nil
 	}
-	return nil
-}
-
-// splitRecords splits a text payload on the engine.io record separator. A
-// payload without separators yields a single record, so single-packet frames
-// (and every WebSocket frame) flow through unchanged.
-func splitRecords(data []byte) [][]byte {
-	var out [][]byte
-	start := 0
-	for i := 0; i < len(data); i++ {
-		if data[i] == recordSeparator {
-			out = append(out, data[start:i])
-			start = i + 1
-		}
-	}
-	return append(out, data[start:])
+	return c.handlePacket(frame.Data)
 }
 
 func (c *Client) handlePacket(packetData []byte) error {

--- a/engine.io/v4/client/client_test.go
+++ b/engine.io/v4/client/client_test.go
@@ -37,7 +37,7 @@ func TestClient_Connect(t *testing.T) {
 		parser:              mockParser,
 		supportedTransports: map[engineio_v4.EngineIOTransport]Transport{engineio_v4.TransportPolling: mockTransport},
 		transport:           mockTransport,
-		messages:            make(chan []byte, 100),
+		messages:            make(chan engineio_v4.Frame, 100),
 		transportClosed:     make(chan error, 1),
 		ctx:                 ctx,
 	}
@@ -61,7 +61,7 @@ func TestClient_Connect(t *testing.T) {
 		mockTransport.EXPECT().Run(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 		mockTransport.EXPECT().RequestHandshake().DoAndReturn(func() error {
 			go func() {
-				client.messages <- append([]byte{'0'}, respData...)
+				client.messages <- engineio_v4.Frame{Data: append([]byte{'0'}, respData...)}
 			}()
 			return nil
 		})
@@ -152,7 +152,7 @@ func TestClient_messageLoop(t *testing.T) {
 	client := &Client{
 		log:      mockLogger,
 		parser:   mockParser,
-		messages: make(chan []byte, 100),
+		messages: make(chan engineio_v4.Frame, 100),
 		ctx:      ctx,
 	}
 
@@ -162,7 +162,7 @@ func TestClient_messageLoop(t *testing.T) {
 		mockParser.EXPECT().Parse([]byte("test")).Return(&engineio_v4.Message{Type: engineio_v4.PacketMessage}, nil)
 
 		go client.messageLoop(ctx, client.messages)
-		client.messages <- []byte("test")
+		client.messages <- engineio_v4.Frame{Data: []byte("test")}
 		time.Sleep(10 * time.Millisecond)
 	})
 
@@ -171,13 +171,13 @@ func TestClient_messageLoop(t *testing.T) {
 		mockParser.EXPECT().Parse([]byte("error")).Return(nil, errors.New("parse error"))
 
 		go client.messageLoop(ctx, client.messages)
-		client.messages <- []byte("error")
+		client.messages <- engineio_v4.Frame{Data: []byte("error")}
 		time.Sleep(10 * time.Millisecond)
 	})
 
 	t.Run("Context done", func(t *testing.T) {
 		mockLogger.EXPECT().Warnf("context done, engine.io client stopped processing messages").AnyTimes()
-		messages := make(chan []byte, 1)
+		messages := make(chan engineio_v4.Frame, 1)
 		go client.messageLoop(ctx, messages)
 		cancel()
 		time.Sleep(10 * time.Millisecond)
@@ -205,7 +205,7 @@ func TestClient_transportUpgrade(t *testing.T) {
 		parser:          mockParser,
 		transport:       mockOldTransport,
 		transportClosed: make(chan error, 1),
-		messages:        make(chan []byte, 100),
+		messages:        make(chan engineio_v4.Frame, 100),
 	}
 
 	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
@@ -949,7 +949,7 @@ func TestClient_Close_stops_ticker(t *testing.T) {
 		log:       mockLogger,
 		parser:    mockParser,
 		transport: mockTransport,
-		messages:  make(chan []byte, 1),
+		messages:  make(chan engineio_v4.Frame, 1),
 	}
 
 	// Create a ticker that we'll verify gets stopped

--- a/engine.io/v4/client/dep.go
+++ b/engine.io/v4/client/dep.go
@@ -26,13 +26,17 @@ type Transport interface {
 		ctx context.Context,
 		url *url.URL,
 		sid string,
-		messagesChan chan<- []byte,
+		messagesChan chan<- engineio_v4.Frame,
 		onClose chan<- error,
 	) error
 	SetHandshake(handshake *engineio_v4.HandshakeResponse)
 	RequestHandshake() error
 	Stop() error
 	SendMessage(message []byte) error
+	// SendBinary delivers a raw binary attachment over the transport. Over
+	// websocket this is a binary frame; over HTTP long-polling it is encoded
+	// as a base64 "b"-prefixed record by the transport.
+	SendBinary(message []byte) error
 }
 
 // Logger представляет интерфейс для логирования

--- a/engine.io/v4/client/mocks/deps.go
+++ b/engine.io/v4/client/mocks/deps.go
@@ -104,7 +104,7 @@ func (mr *MockTransportMockRecorder) RequestHandshake() *gomock.Call {
 }
 
 // Run mocks base method.
-func (m *MockTransport) Run(ctx context.Context, url *url.URL, sid string, messagesChan chan<- []byte, onClose chan<- error) error {
+func (m *MockTransport) Run(ctx context.Context, url *url.URL, sid string, messagesChan chan<- engineio_v4.Frame, onClose chan<- error) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Run", ctx, url, sid, messagesChan, onClose)
 	ret0, _ := ret[0].(error)
@@ -115,6 +115,20 @@ func (m *MockTransport) Run(ctx context.Context, url *url.URL, sid string, messa
 func (mr *MockTransportMockRecorder) Run(ctx, url, sid, messagesChan, onClose interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockTransport)(nil).Run), ctx, url, sid, messagesChan, onClose)
+}
+
+// SendBinary mocks base method.
+func (m *MockTransport) SendBinary(message []byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendBinary", message)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendBinary indicates an expected call of SendBinary.
+func (mr *MockTransportMockRecorder) SendBinary(message interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendBinary", reflect.TypeOf((*MockTransport)(nil).SendBinary), message)
 }
 
 // SendMessage mocks base method.

--- a/engine.io/v4/client/transport/polling/constructor.go
+++ b/engine.io/v4/client/transport/polling/constructor.go
@@ -19,11 +19,11 @@ const defaultHTTPTimeout = 30 * time.Second
 func NewTransport(options ...EngineTransportOption) (*Transport, error) {
 	// Create default client
 	client := &Transport{
-		log:            &utils.DefaultLogger{},
-		httpClient:     &http.Client{Timeout: defaultHTTPTimeout},
-		pinger:         time.NewTicker(10 * time.Second),
-		stopPooling:    make(chan struct{}, 1),
-		stopCh:         make(chan struct{}),
+		log:              &utils.DefaultLogger{},
+		httpClient:       &http.Client{Timeout: defaultHTTPTimeout},
+		pinger:           time.NewTicker(10 * time.Second),
+		stopPooling:      make(chan struct{}, 1),
+		stopCh:           make(chan struct{}),
 		maxPayloadSize:   4 * 1024 * 1024, // 4MB default, matches socket.io JS maxHttpBufferSize
 		redactPayload:    true,            // production-safe default; WithDebugPayload(true) opts out
 		pollErrorBackoff: defaultPollErrorBackoff,

--- a/engine.io/v4/client/transport/polling/transport.go
+++ b/engine.io/v4/client/transport/polling/transport.go
@@ -3,6 +3,7 @@ package engineio_v4_client_transport
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -33,7 +34,7 @@ type Transport struct {
 	sid string
 	ctx context.Context
 
-	messages    chan<- []byte
+	messages    chan<- engineio_v4.Frame
 	onClose     chan<- error
 	stopPooling chan struct{}
 
@@ -136,7 +137,7 @@ func (c *Transport) Run(
 	ctx context.Context,
 	url *url.URL,
 	sid string,
-	messagesChan chan<- []byte,
+	messagesChan chan<- engineio_v4.Frame,
 	onClose chan<- error,
 ) error {
 	c.ctx = ctx
@@ -367,7 +368,7 @@ func (c *Transport) poll() error {
 	c.log.Debugf("receiveHttp: %s", c.payload(body))
 
 	select {
-	case c.messages <- body:
+	case c.messages <- engineio_v4.Frame{Data: body}:
 	case <-c.ctx.Done():
 		return c.ctx.Err()
 	case <-c.stopCh:
@@ -380,7 +381,20 @@ func (c *Transport) poll() error {
 }
 
 func (c *Transport) SendMessage(msg []byte) error {
+	return c.post(msg)
+}
 
+// SendBinary POSTs a raw binary attachment encoded as the engine.io v4 base64
+// "b"-record. Over HTTP long-polling binary cannot travel as its own frame, so
+// it is sent as a base64 text record the server decodes back to bytes.
+func (c *Transport) SendBinary(msg []byte) error {
+	encoded := make([]byte, 1, base64.StdEncoding.EncodedLen(len(msg))+1)
+	encoded[0] = 'b'
+	encoded = append(encoded, []byte(base64.StdEncoding.EncodeToString(msg))...)
+	return c.post(encoded)
+}
+
+func (c *Transport) post(msg []byte) error {
 	c.log.Debugf("sendHttp: %s", c.payload(msg))
 	req, err := http.NewRequestWithContext(c.ctx, "POST", c.buildHttpUrl().String(), bytes.NewReader(msg))
 	if err != nil {

--- a/engine.io/v4/client/transport/polling/transport.go
+++ b/engine.io/v4/client/transport/polling/transport.go
@@ -367,17 +367,46 @@ func (c *Transport) poll() error {
 
 	c.log.Debugf("receiveHttp: %s", c.payload(body))
 
-	select {
-	case c.messages <- engineio_v4.Frame{Data: body}:
-	case <-c.ctx.Done():
-		return c.ctx.Err()
-	case <-c.stopCh:
-		// Stop() was called while we were blocked sending. stopCh is a closed
-		// channel (broadcast), so pollingLoop's own stopPooling case remains
-		// intact — it will still exit cleanly via the value Stop() enqueued.
-		return errTransportStopped
+	// A long-polling body may carry several engine.io packets joined by the
+	// record separator (U+001E). Split here, at the transport that owns the
+	// long-polling framing, and deliver one packet per frame. The WebSocket
+	// transport already frames each packet on its own, so the separator never
+	// leaks into the engine.io client.
+	for _, record := range splitRecords(body) {
+		if len(record) == 0 {
+			continue
+		}
+		select {
+		case c.messages <- engineio_v4.Frame{Data: record}:
+		case <-c.ctx.Done():
+			return c.ctx.Err()
+		case <-c.stopCh:
+			// Stop() was called while we were blocked sending. stopCh is a closed
+			// channel (broadcast), so pollingLoop's own stopPooling case remains
+			// intact — it will still exit cleanly via the value Stop() enqueued.
+			return errTransportStopped
+		}
 	}
 	return nil
+}
+
+// recordSeparator is the engine.io v4 payload delimiter (U+001E) that joins
+// multiple packets inside a single HTTP long-polling body.
+const recordSeparator = '\x1e'
+
+// splitRecords splits a long-polling body on the engine.io record separator. A
+// body without separators yields a single record, so single-packet responses
+// (including every handshake) flow through unchanged.
+func splitRecords(data []byte) [][]byte {
+	var out [][]byte
+	start := 0
+	for i := 0; i < len(data); i++ {
+		if data[i] == recordSeparator {
+			out = append(out, data[start:i])
+			start = i + 1
+		}
+	}
+	return append(out, data[start:])
 }
 
 func (c *Transport) SendMessage(msg []byte) error {

--- a/engine.io/v4/client/transport/polling/transport_test.go
+++ b/engine.io/v4/client/transport/polling/transport_test.go
@@ -70,7 +70,7 @@ func TestRequestHandshake(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	messages := make(chan []byte, 1)
+	messages := make(chan engineio_v4.Frame, 1)
 	client := &Transport{
 		log:        mockLogger,
 		httpClient: mockHttpClient,
@@ -133,7 +133,7 @@ func TestRequestHandshake_StopDuringHandshake(t *testing.T) {
 		httpClient:  mockHTTPClient,
 		url:         &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
 		ctx:         ctx,
-		messages:    make(chan []byte), // unbuffered: send will block
+		messages:    make(chan engineio_v4.Frame), // unbuffered: send will block
 		stopPooling: make(chan struct{}, 1),
 		stopCh:      stopCh,
 	}
@@ -178,7 +178,7 @@ func TestRun(t *testing.T) {
 	defer cancel()
 
 	url, _ := url.Parse("http://example.com")
-	messagesChan := make(chan []byte, 1)
+	messagesChan := make(chan engineio_v4.Frame, 1)
 	onCloseChan := make(chan error, 1)
 
 	client := &Transport{
@@ -330,7 +330,7 @@ func TestPollingLoop(t *testing.T) {
 			stopCh:           make(chan struct{}),
 			ctx:              ctx,
 			onClose:          onClose,
-			messages:         make(chan []byte, 1),
+			messages:         make(chan engineio_v4.Frame, 1),
 			pollErrorBackoff: time.Second, // long enough that Stop() interrupts the backoff
 		}
 
@@ -397,7 +397,7 @@ func TestPollingLoop(t *testing.T) {
 			stopCh:      make(chan struct{}),
 			ctx:         ctx,
 			onClose:     onClose,
-			messages:    make(chan []byte, 1),
+			messages:    make(chan engineio_v4.Frame, 1),
 		}
 		// Run() normally wires these; set them up directly for the unit test.
 		client.reqCtx, client.pollCancel = context.WithCancel(ctx)
@@ -448,7 +448,7 @@ func TestPollingLoop(t *testing.T) {
 			stopCh:        make(chan struct{}),
 			ctx:           ctx,
 			onClose:       make(chan error, 1),
-			messages:      make(chan []byte, 1),
+			messages:      make(chan engineio_v4.Frame, 1),
 			handshakeDone: make(chan struct{}),
 		}
 		client.reqCtx, client.pollCancel = context.WithCancel(ctx)
@@ -562,7 +562,7 @@ func TestPollingLoop(t *testing.T) {
 			stopCh:      make(chan struct{}),
 			ctx:         ctx,
 			onClose:     make(chan error, 1),
-			messages:    make(chan []byte, 1),
+			messages:    make(chan engineio_v4.Frame, 1),
 		}
 		client.reqCtx, client.pollCancel = context.WithCancel(ctx)
 
@@ -603,7 +603,7 @@ func TestPollingLoop(t *testing.T) {
 			stopCh:           make(chan struct{}),
 			ctx:              ctx,
 			onClose:          make(chan error, 1),
-			messages:         make(chan []byte, 1),
+			messages:         make(chan engineio_v4.Frame, 1),
 			pollErrorBackoff: 5 * time.Millisecond,
 		}
 		client.reqCtx, client.pollCancel = context.WithCancel(ctx)
@@ -641,7 +641,7 @@ func TestPollingLoop(t *testing.T) {
 			stopCh:           make(chan struct{}),
 			ctx:              ctx,
 			onClose:          make(chan error, 1),
-			messages:         make(chan []byte, 1),
+			messages:         make(chan engineio_v4.Frame, 1),
 			pollErrorBackoff: time.Second, // long, so the context cancel wins
 		}
 		client.reqCtx, client.pollCancel = context.WithCancel(ctx)
@@ -728,7 +728,7 @@ func TestPoll(t *testing.T) {
 		defer cancel()
 
 		// Create a buffered channel to avoid blocking
-		messagesChan := make(chan []byte, 1)
+		messagesChan := make(chan engineio_v4.Frame, 1)
 
 		client := &Transport{
 			log:        mockLogger,
@@ -784,7 +784,7 @@ func TestPoll(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		messagesChan := make(chan []byte, 1)
+		messagesChan := make(chan engineio_v4.Frame, 1)
 		client := &Transport{
 			log:        mockLogger,
 			httpClient: mockHTTPClient,
@@ -818,7 +818,7 @@ func TestPoll(t *testing.T) {
 			log:      mockLogger,
 			url:      &url.URL{Scheme: "http", Host: "example.com"},
 			ctx:      nil, // Intentionally set to nil to cause an error
-			messages: make(chan<- []byte),
+			messages: make(chan<- engineio_v4.Frame),
 		}
 
 		mockLogger.EXPECT().Debugf("run polling")
@@ -843,7 +843,7 @@ func TestPoll(t *testing.T) {
 			url:        &url.URL{Scheme: "http", Host: "example.com"},
 			sid:        "test-sid",
 			ctx:        context.Background(),
-			messages:   make(chan<- []byte),
+			messages:   make(chan<- engineio_v4.Frame),
 		}
 
 		mockLogger.EXPECT().Debugf("run polling")
@@ -874,7 +874,7 @@ func TestPoll(t *testing.T) {
 			url:        &url.URL{Scheme: "http", Host: "example.com"},
 			sid:        "test-sid",
 			ctx:        context.Background(),
-			messages:   make(chan<- []byte),
+			messages:   make(chan<- engineio_v4.Frame),
 		}
 
 		mockLogger.EXPECT().Debugf("run polling")
@@ -922,7 +922,7 @@ func TestPoll(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 
 		// Unbuffered channel: poll() must not block forever
-		messagesChan := make(chan []byte)
+		messagesChan := make(chan engineio_v4.Frame)
 
 		client := &Transport{
 			log:         mockLogger,
@@ -979,7 +979,7 @@ func TestPoll(t *testing.T) {
 			url:         &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
 			sid:         "test-sid",
 			ctx:         context.Background(),
-			messages:    make(chan []byte), // unbuffered: send will block
+			messages:    make(chan engineio_v4.Frame), // unbuffered: send will block
 			stopPooling: make(chan struct{}, 1),
 			stopCh:      stopCh,
 		}
@@ -1175,7 +1175,7 @@ func TestPollOversizedPayload(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		messagesChan := make(chan []byte, 1)
+		messagesChan := make(chan engineio_v4.Frame, 1)
 		maxPayloadSize := int64(100)
 		oversizedBody := strings.Repeat("x", 101)
 
@@ -1222,7 +1222,7 @@ func TestPollOversizedPayload(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		messagesChan := make(chan []byte, 1)
+		messagesChan := make(chan engineio_v4.Frame, 1)
 		maxPayloadSize := int64(100)
 		validBody := strings.Repeat("x", 50)
 
@@ -1276,7 +1276,7 @@ func TestPollOversizedPayload(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		messagesChan := make(chan []byte, 1)
+		messagesChan := make(chan engineio_v4.Frame, 1)
 		// Set maxPayloadSize to a value that would overflow when incremented
 		maxPayloadSize := int64(9223372036854775807) // math.MaxInt64
 
@@ -1336,7 +1336,7 @@ func TestRun_stopped_flag_reset(t *testing.T) {
 	defer cancel()
 
 	url, _ := url.Parse("http://example.com")
-	messagesChan := make(chan []byte, 1)
+	messagesChan := make(chan engineio_v4.Frame, 1)
 	onCloseChan := make(chan error, 1)
 
 	client := &Transport{
@@ -1489,7 +1489,7 @@ func TestRequestHandshake_StopWithCancelledContext(t *testing.T) {
 		httpClient:  mockHTTPClient,
 		url:         &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
 		ctx:         ctxCanceledDoneNever{Context: context.Background(), err: context.DeadlineExceeded},
-		messages:    make(chan []byte), // unbuffered: the send blocks
+		messages:    make(chan engineio_v4.Frame), // unbuffered: the send blocks
 		stopPooling: make(chan struct{}, 1),
 		stopCh:      stopCh,
 	}
@@ -1531,7 +1531,7 @@ func TestPollingLoop_StopDuringPoll(t *testing.T) {
 		pinger:      time.NewTicker(time.Millisecond),
 		url:         &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
 		ctx:         context.Background(),
-		messages:    make(chan []byte), // unbuffered: poll's send blocks
+		messages:    make(chan engineio_v4.Frame), // unbuffered: poll's send blocks
 		stopPooling: make(chan struct{}, 1),
 		stopCh:      stopCh,
 		onClose:     onClose,
@@ -1620,7 +1620,7 @@ func TestHandshakeGateUpgradeToPolling(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	onClose := make(chan error, 1)
-	err := transport.Run(ctx, &url.URL{Scheme: "http", Host: "localhost", Path: "/socket.io/"}, "known-sid", make(chan []byte, 1), onClose)
+	err := transport.Run(ctx, &url.URL{Scheme: "http", Host: "localhost", Path: "/socket.io/"}, "known-sid", make(chan engineio_v4.Frame, 1), onClose)
 	assert.NoError(t, err)
 
 	// pollingLoop must reach poll() instead of blocking on the gate.
@@ -1636,4 +1636,62 @@ func TestHandshakeGateUpgradeToPolling(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("expected onClose after Stop")
 	}
+}
+
+// TestSendBinary verifies that a binary attachment is POSTed as the engine.io
+// v4 base64 "b"-record, and that send errors surface.
+func TestSendBinary(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Successful binary send is base64 b-record", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockHttpClient := mocks.NewMockHttpClient(ctrl)
+
+		transport := &Transport{
+			log:        mockLogger,
+			httpClient: mockHttpClient,
+			url:        &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
+			ctx:        context.Background(),
+		}
+
+		mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+		mockResp := &http.Response{
+			StatusCode: 200,
+			Status:     "200 OK",
+			Body:       io.NopCloser(strings.NewReader("")),
+		}
+		// {1,2,3,4} base64-encodes to "AQIDBA==", prefixed with 'b'.
+		mockHttpClient.EXPECT().Do(gomock.Any()).DoAndReturn(func(req *http.Request) (*http.Response, error) {
+			body, _ := io.ReadAll(req.Body)
+			assert.Equal(t, "bAQIDBA==", string(body))
+			return mockResp, nil
+		})
+
+		err := transport.SendBinary([]byte{1, 2, 3, 4})
+		assert.NoError(t, err)
+	})
+
+	t.Run("Binary send error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockHttpClient := mocks.NewMockHttpClient(ctrl)
+
+		transport := &Transport{
+			log:        mockLogger,
+			httpClient: mockHttpClient,
+			url:        &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
+			ctx:        context.Background(),
+		}
+
+		mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+		mockHttpClient.EXPECT().Do(gomock.Any()).Return(nil, errors.New("send error"))
+
+		err := transport.SendBinary([]byte{1})
+		assert.Error(t, err)
+	})
 }

--- a/engine.io/v4/client/transport/polling/transport_test.go
+++ b/engine.io/v4/client/transport/polling/transport_test.go
@@ -305,21 +305,25 @@ func TestPollingLoop(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
 		errExpected := errors.New("expected error")
-		pingCalled := make(chan struct{})
+		// errLogged is closed once the loop has logged the poll error. Triggering
+		// Stop() off this (rather than off the Do call) makes the test
+		// deterministic: Stop() runs only after pollingLoop has already passed its
+		// stopped-check and logged, so the "poll error" Errorf is always observed.
+		// Stopping earlier raced the loop's stopped-check and could make it exit
+		// before logging, flaking the MinTimes(1) expectation.
+		errLogged := make(chan struct{})
 
 		mockLogger := mocks.NewMockLogger(ctrl)
 		mockHttpClient := mocks.NewMockHttpClient(ctrl)
 		mockLogger.EXPECT().Debugf("run polling").MinTimes(1)
 		mockLogger.EXPECT().Debugf("stop polling").MinTimes(1)
-		mockLogger.EXPECT().Errorf("poll error: %s", errExpected).MinTimes(1)
-		mockHttpClient.EXPECT().Do(gomock.Any()).DoAndReturn(func(_ *http.Request) (*http.Response, error) {
-			close(pingCalled)
-			return nil, errExpected
-		})
+		mockLogger.EXPECT().Errorf("poll error: %s", errExpected).
+			Do(func(string, ...interface{}) { close(errLogged) }).Times(1)
+		mockHttpClient.EXPECT().Do(gomock.Any()).Return(nil, errExpected).Times(1)
 
 		onClose := make(chan error, 1)
 		client := &Transport{
@@ -337,9 +341,10 @@ func TestPollingLoop(t *testing.T) {
 
 		go func() {
 			select {
-			case <-pingCalled:
-			case <-time.After(100 * time.Millisecond):
-				assert.Fail(t, "expected ping to be called")
+			case <-errLogged:
+			case <-time.After(2 * time.Second):
+				assert.Fail(t, "expected poll error to be logged")
+				return
 			}
 
 			assert.NoError(t, client.Stop())
@@ -354,14 +359,14 @@ func TestPollingLoop(t *testing.T) {
 
 		select {
 		case <-exitChan:
-		case <-time.After(100 * time.Millisecond):
+		case <-time.After(2 * time.Second):
 			assert.Fail(t, "expected pollingLoop to exit")
 		}
 
 		select {
 		case err := <-onClose:
 			assert.NoError(t, err)
-		case <-time.After(100 * time.Millisecond):
+		case <-time.After(2 * time.Second):
 			assert.Fail(t, "expected pollingLoop to exit and emit onClose")
 		}
 

--- a/engine.io/v4/client/transport/polling/transport_test.go
+++ b/engine.io/v4/client/transport/polling/transport_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	engineio_v4 "github.com/maldikhan/go.socket.io/engine.io/v4"
 	mocks "github.com/maldikhan/go.socket.io/engine.io/v4/client/transport/polling/mocks"
@@ -714,6 +715,45 @@ func TestStop(t *testing.T) {
 	})
 }
 
+func TestSplitRecords(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input []byte
+		want  [][]byte
+	}{
+		{
+			name:  "no separator yields single record",
+			input: []byte("4hello"),
+			want:  [][]byte{[]byte("4hello")},
+		},
+		{
+			name:  "two records",
+			input: []byte("4hello\x1e4world"),
+			want:  [][]byte{[]byte("4hello"), []byte("4world")},
+		},
+		{
+			name:  "trailing separator yields empty tail",
+			input: []byte("4a\x1e"),
+			want:  [][]byte{[]byte("4a"), {}},
+		},
+		{
+			name:  "empty input yields one empty record",
+			input: []byte{},
+			want:  [][]byte{{}},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, splitRecords(tt.input))
+		})
+	}
+}
+
 func TestPoll(t *testing.T) {
 
 	t.Run("Successful poll", func(t *testing.T) {
@@ -771,6 +811,46 @@ func TestPoll(t *testing.T) {
 		case <-time.After(time.Second):
 			t.Fatal("Timeout waiting for poll to complete")
 		}
+	})
+
+	t.Run("Multi-record body split into separate frames", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockLogger := mocks.NewMockLogger(ctrl)
+		mockHTTPClient := mocks.NewMockHttpClient(ctrl)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		// A trailing separator yields an empty tail record that must be dropped:
+		// only the two non-empty packets are delivered.
+		body := "4hello\x1e4world\x1e"
+		messagesChan := make(chan engineio_v4.Frame, 4)
+
+		client := &Transport{
+			log:        mockLogger,
+			httpClient: mockHTTPClient,
+			url:        &url.URL{Scheme: "http", Host: "example.com", Path: "/socket.io/"},
+			sid:        "test-sid",
+			ctx:        ctx,
+			messages:   messagesChan,
+		}
+
+		mockLogger.EXPECT().Debugf("run polling")
+		mockLogger.EXPECT().Debugf("receiveHttp: %s", body)
+
+		mockHTTPClient.EXPECT().Do(gomock.Any()).Return(&http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(body)),
+		}, nil)
+
+		err := client.poll()
+		require.NoError(t, err)
+		require.Equal(t, 2, len(messagesChan), "expected two packet frames")
+		assert.Equal(t, engineio_v4.Frame{Data: []byte("4hello")}, <-messagesChan)
+		assert.Equal(t, engineio_v4.Frame{Data: []byte("4world")}, <-messagesChan)
 	})
 
 	t.Run("Non-2xx response status", func(t *testing.T) {

--- a/engine.io/v4/client/transport/websocket/dep.go
+++ b/engine.io/v4/client/transport/websocket/dep.go
@@ -17,6 +17,8 @@ type Logger interface {
 type WebSocket interface {
 	Dial(ctx context.Context, url *url.URL, origin *url.URL) (err error)
 	Send(v []byte) (err error)
+	SendBinary(v []byte) (err error)
 	Receive(v *[]byte) (err error)
+	ReceiveFrame(v *[]byte) (isBinary bool, err error)
 	Close() error
 }

--- a/engine.io/v4/client/transport/websocket/mocks/deps.go
+++ b/engine.io/v4/client/transport/websocket/mocks/deps.go
@@ -168,6 +168,21 @@ func (mr *MockWebSocketMockRecorder) Receive(v interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Receive", reflect.TypeOf((*MockWebSocket)(nil).Receive), v)
 }
 
+// ReceiveFrame mocks base method.
+func (m *MockWebSocket) ReceiveFrame(v *[]byte) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReceiveFrame", v)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReceiveFrame indicates an expected call of ReceiveFrame.
+func (mr *MockWebSocketMockRecorder) ReceiveFrame(v interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReceiveFrame", reflect.TypeOf((*MockWebSocket)(nil).ReceiveFrame), v)
+}
+
 // Send mocks base method.
 func (m *MockWebSocket) Send(v []byte) error {
 	m.ctrl.T.Helper()
@@ -180,4 +195,18 @@ func (m *MockWebSocket) Send(v []byte) error {
 func (mr *MockWebSocketMockRecorder) Send(v interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockWebSocket)(nil).Send), v)
+}
+
+// SendBinary mocks base method.
+func (m *MockWebSocket) SendBinary(v []byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendBinary", v)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendBinary indicates an expected call of SendBinary.
+func (mr *MockWebSocketMockRecorder) SendBinary(v interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendBinary", reflect.TypeOf((*MockWebSocket)(nil).SendBinary), v)
 }

--- a/engine.io/v4/client/transport/websocket/transport.go
+++ b/engine.io/v4/client/transport/websocket/transport.go
@@ -18,7 +18,7 @@ type Transport struct {
 	origin *url.URL
 	ctx    context.Context
 
-	messages    chan<- []byte
+	messages    chan<- engineio_v4.Frame
 	onClose     chan<- error
 	stopPooling chan struct{}
 	mu          sync.RWMutex
@@ -55,7 +55,7 @@ func (c *Transport) Run(
 	ctx context.Context,
 	url *url.URL,
 	sid string,
-	messagesChan chan<- []byte,
+	messagesChan chan<- engineio_v4.Frame,
 	onClose chan<- error,
 ) error {
 	c.ctx = ctx
@@ -149,18 +149,18 @@ func (c *Transport) wsReadLoop() error {
 	// then delivers that error into the buffer (no reader required) and exits.
 	// Only one reader goroutine is ever in flight at a time, so a capacity of 1
 	// is sufficient.
-	messageCh := make(chan []byte, 1)
+	messageCh := make(chan engineio_v4.Frame, 1)
 	errorCh := make(chan error, 1)
 	for {
 		// Run ws read in goroutine
 		go func() {
 			var message []byte
-			err := c.ws.Receive(&message)
+			isBinary, err := c.ws.ReceiveFrame(&message)
 			if err != nil {
 				errorCh <- err
 				return
 			}
-			messageCh <- message
+			messageCh <- engineio_v4.Frame{Data: message, IsBinary: isBinary}
 		}()
 
 		select {
@@ -181,11 +181,11 @@ func (c *Transport) wsReadLoop() error {
 			}
 			return c.ctx.Err()
 
-		case message := <-messageCh:
+		case frame := <-messageCh:
 			// New message received
-			c.log.Debugf("receiveWs: %s", c.payload(message))
+			c.log.Debugf("receiveWs: %s", c.payload(frame.Data))
 			select {
-			case c.messages <- message:
+			case c.messages <- frame:
 			case <-c.stopPooling:
 				c.log.Debugf("Stop signal received, exiting ws read loop")
 				select {
@@ -217,4 +217,12 @@ func (c *Transport) wsReadLoop() error {
 func (c *Transport) SendMessage(msg []byte) error {
 	c.log.Debugf("sendWs: %s", c.payload(msg))
 	return c.ws.Send(msg)
+}
+
+// SendBinary writes a raw binary attachment as a WebSocket binary frame. The
+// engine.io binary marker / base64 encoding is not applied over websocket:
+// binary travels in its own frame type.
+func (c *Transport) SendBinary(msg []byte) error {
+	c.log.Debugf("sendWsBinary: %s", c.payload(msg))
+	return c.ws.SendBinary(msg)
 }

--- a/engine.io/v4/client/transport/websocket/transport_test.go
+++ b/engine.io/v4/client/transport/websocket/transport_test.go
@@ -74,7 +74,7 @@ func TestTransport_Run(t *testing.T) {
 
 	u, _ := url.Parse("http://example.com")
 	sid := "test-sid"
-	messagesChan := make(chan []byte, 1)
+	messagesChan := make(chan engineio_v4.Frame, 1)
 	onClose := make(chan error, 1)
 
 	transport := &Transport{
@@ -84,9 +84,9 @@ func TestTransport_Run(t *testing.T) {
 	}
 
 	mockWS.EXPECT().Dial(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-	mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(message *[]byte) error {
+	mockWS.EXPECT().ReceiveFrame(gomock.Any()).DoAndReturn(func(message *[]byte) (bool, error) {
 		*message = []byte("test message")
-		return nil
+		return false, nil
 	}).AnyTimes()
 	mockWS.EXPECT().Close().Return(nil).AnyTimes()
 
@@ -106,7 +106,7 @@ func TestTransport_Run(t *testing.T) {
 	// Check message received
 	select {
 	case msg := <-messagesChan:
-		assert.Equal(t, []byte("test message"), msg)
+		assert.Equal(t, []byte("test message"), msg.Data)
 	case <-time.After(time.Second):
 		t.Fatal("Timeout waiting for message")
 	}
@@ -232,7 +232,7 @@ func TestTransport_wsCloseError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	messages := make(chan []byte, 1)
+	messages := make(chan engineio_v4.Frame, 1)
 	onClose := make(chan error, 1)
 	transport := &Transport{
 		log:         mockLogger,
@@ -254,15 +254,15 @@ func TestTransport_wsCloseError(t *testing.T) {
 	}).AnyTimes()
 	mockWS.EXPECT().Dial(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	callCount := 0
-	mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(message *[]byte) error {
+	mockWS.EXPECT().ReceiveFrame(gomock.Any()).DoAndReturn(func(message *[]byte) (bool, error) {
 		callCount++
 		if callCount == 1 {
 			*message = []byte("test message")
-			return nil
+			return false, nil
 		}
 		// After first message, block until context is done
 		<-ctx.Done()
-		return context.Canceled
+		return false, context.Canceled
 	}).AnyTimes()
 	mockWS.EXPECT().Close().Return(errors.New("close error expected")).AnyTimes()
 
@@ -275,7 +275,7 @@ func TestTransport_wsCloseError(t *testing.T) {
 	// Check message received
 	select {
 	case msg := <-messages:
-		assert.Equal(t, []byte("test message"), msg)
+		assert.Equal(t, []byte("test message"), msg.Data)
 	case <-time.After(time.Second):
 		t.Fatal("Timeout waiting for message")
 	}
@@ -312,7 +312,7 @@ func TestTransport_connectWebSocket(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	messages := make(chan []byte, 1)
+	messages := make(chan engineio_v4.Frame, 1)
 	onClose := make(chan error, 1)
 	transport := &Transport{
 		log:         mockLogger,
@@ -328,9 +328,9 @@ func TestTransport_connectWebSocket(t *testing.T) {
 	mockLogger.EXPECT().Debugf(gomock.Any()).AnyTimes()
 	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
 	mockWS.EXPECT().Dial(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-	mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(message *[]byte) error {
+	mockWS.EXPECT().ReceiveFrame(gomock.Any()).DoAndReturn(func(message *[]byte) (bool, error) {
 		*message = []byte("test message")
-		return nil
+		return false, nil
 	}).AnyTimes()
 	mockWS.EXPECT().Close().Return(nil).AnyTimes()
 
@@ -343,7 +343,7 @@ func TestTransport_connectWebSocket(t *testing.T) {
 	// Check message received
 	select {
 	case msg := <-messages:
-		assert.Equal(t, []byte("test message"), msg)
+		assert.Equal(t, []byte("test message"), msg.Data)
 	case <-time.After(time.Second):
 		t.Fatal("Timeout waiting for message")
 	}
@@ -372,7 +372,7 @@ func TestTransport_wsReadLoop(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		messages := make(chan []byte, 1)
+		messages := make(chan engineio_v4.Frame, 1)
 		onClose := make(chan error, 1)
 		transport := &Transport{
 			log:         mockLogger,
@@ -387,15 +387,15 @@ func TestTransport_wsReadLoop(t *testing.T) {
 		mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
 
 		callCount := 0
-		mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(message *[]byte) error {
+		mockWS.EXPECT().ReceiveFrame(gomock.Any()).DoAndReturn(func(message *[]byte) (bool, error) {
 			callCount++
 			if callCount == 1 {
 				*message = []byte("test message")
-				return nil
+				return false, nil
 			}
 			// After first message, block until context is done
 			<-ctx.Done()
-			return context.Canceled
+			return false, context.Canceled
 		}).AnyTimes()
 
 		go func() {
@@ -406,7 +406,7 @@ func TestTransport_wsReadLoop(t *testing.T) {
 		// Check message is received
 		select {
 		case msg := <-messages:
-			assert.Equal(t, []byte("test message"), msg)
+			assert.Equal(t, []byte("test message"), msg.Data)
 		case <-time.After(time.Second):
 			t.Fatal("Timeout waiting for message")
 		}
@@ -434,7 +434,7 @@ func TestTransport_wsReadLoop(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		messages := make(chan []byte, 1)
+		messages := make(chan engineio_v4.Frame, 1)
 		onClose := make(chan error, 1)
 		transport := &Transport{
 			log:         mockLogger,
@@ -449,7 +449,7 @@ func TestTransport_wsReadLoop(t *testing.T) {
 		mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
 
 		ErrExpected := errors.New("test error")
-		mockWS.EXPECT().Receive(gomock.Any()).Return(ErrExpected).AnyTimes()
+		mockWS.EXPECT().ReceiveFrame(gomock.Any()).Return(false, ErrExpected).AnyTimes()
 		mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
 
 		go func() {
@@ -479,7 +479,7 @@ func TestTransport_wsReadLoop(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		messages := make(chan []byte, 1)
+		messages := make(chan engineio_v4.Frame, 1)
 		onClose := make(chan error, 1)
 		transport := &Transport{
 			log:         mockLogger,
@@ -493,9 +493,9 @@ func TestTransport_wsReadLoop(t *testing.T) {
 		mockLogger.EXPECT().Debugf(gomock.Any()).AnyTimes()
 		mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
 
-		mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(message *[]byte) error {
+		mockWS.EXPECT().ReceiveFrame(gomock.Any()).DoAndReturn(func(message *[]byte) (bool, error) {
 			<-ctx.Done()
-			return context.Canceled
+			return false, context.Canceled
 		}).AnyTimes()
 
 		go func() {
@@ -531,7 +531,7 @@ func TestTransport_wsReadLoop(t *testing.T) {
 		defer cancel()
 
 		// Use buffered channel to allow message delivery
-		messages := make(chan []byte, 10)
+		messages := make(chan engineio_v4.Frame, 10)
 		onClose := make(chan error, 1)
 		transport := &Transport{
 			log:         mockLogger,
@@ -546,19 +546,19 @@ func TestTransport_wsReadLoop(t *testing.T) {
 		mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
 
 		callCount := 0
-		mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(message *[]byte) error {
+		mockWS.EXPECT().ReceiveFrame(gomock.Any()).DoAndReturn(func(message *[]byte) (bool, error) {
 			callCount++
 			if callCount == 1 {
 				*message = []byte("test message 1")
-				return nil
+				return false, nil
 			}
 			if callCount == 2 {
 				*message = []byte("test message 2")
-				return nil
+				return false, nil
 			}
 			// Block until context is done
 			<-ctx.Done()
-			return context.Canceled
+			return false, context.Canceled
 		}).AnyTimes()
 
 		go func() {
@@ -572,14 +572,14 @@ func TestTransport_wsReadLoop(t *testing.T) {
 		// Receive multiple messages
 		select {
 		case msg := <-messages:
-			assert.Equal(t, []byte("test message 1"), msg)
+			assert.Equal(t, []byte("test message 1"), msg.Data)
 		case <-time.After(time.Second):
 			t.Fatal("Timeout waiting for first message")
 		}
 
 		select {
 		case msg := <-messages:
-			assert.Equal(t, []byte("test message 2"), msg)
+			assert.Equal(t, []byte("test message 2"), msg.Data)
 		case <-time.After(time.Second):
 			t.Fatal("Timeout waiting for second message")
 		}
@@ -608,7 +608,7 @@ func TestTransport_wsReadLoop(t *testing.T) {
 		defer cancel()
 
 		// Use unbuffered channel so send blocks
-		messages := make(chan []byte)
+		messages := make(chan engineio_v4.Frame)
 		onClose := make(chan error, 1)
 		transport := &Transport{
 			log:         mockLogger,
@@ -623,15 +623,15 @@ func TestTransport_wsReadLoop(t *testing.T) {
 		mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
 
 		delivered := false
-		mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(message *[]byte) error {
+		mockWS.EXPECT().ReceiveFrame(gomock.Any()).DoAndReturn(func(message *[]byte) (bool, error) {
 			if !delivered {
 				delivered = true
 				*message = []byte("blocked message")
-				return nil
+				return false, nil
 			}
 			// Subsequent calls block until context is done
 			<-ctx.Done()
-			return context.Canceled
+			return false, context.Canceled
 		}).AnyTimes()
 
 		mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
@@ -671,7 +671,7 @@ func TestTransport_wsReadLoop(t *testing.T) {
 		defer cancel()
 
 		// Use unbuffered channel so send blocks
-		messages := make(chan []byte)
+		messages := make(chan engineio_v4.Frame)
 		onClose := make(chan error, 1)
 		stopPooling := make(chan struct{}, 1)
 		transport := &Transport{
@@ -687,14 +687,14 @@ func TestTransport_wsReadLoop(t *testing.T) {
 		mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
 
 		delivered := false
-		mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(message *[]byte) error {
+		mockWS.EXPECT().ReceiveFrame(gomock.Any()).DoAndReturn(func(message *[]byte) (bool, error) {
 			if !delivered {
 				delivered = true
 				*message = []byte("blocked message")
-				return nil
+				return false, nil
 			}
 			<-ctx.Done()
-			return context.Canceled
+			return false, context.Canceled
 		}).AnyTimes()
 
 		mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
@@ -740,7 +740,7 @@ func TestTransport_wsReadLoop(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		messages := make(chan []byte)
+		messages := make(chan engineio_v4.Frame)
 		// Pre-fill onClose so the default branch is taken
 		onClose := make(chan error, 1)
 		onClose <- errors.New("pre-filled")
@@ -759,14 +759,14 @@ func TestTransport_wsReadLoop(t *testing.T) {
 		mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
 
 		delivered := false
-		mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(message *[]byte) error {
+		mockWS.EXPECT().ReceiveFrame(gomock.Any()).DoAndReturn(func(message *[]byte) (bool, error) {
 			if !delivered {
 				delivered = true
 				*message = []byte("blocked message")
-				return nil
+				return false, nil
 			}
 			<-ctx.Done()
-			return context.Canceled
+			return false, context.Canceled
 		}).AnyTimes()
 
 		done := make(chan error, 1)
@@ -797,7 +797,7 @@ func TestTransport_wsReadLoop(t *testing.T) {
 
 		ctx, cancel := context.WithCancel(context.Background())
 
-		messages := make(chan []byte)
+		messages := make(chan engineio_v4.Frame)
 		// Pre-fill onClose so the default branch is taken
 		onClose := make(chan error, 1)
 		onClose <- errors.New("pre-filled")
@@ -815,14 +815,14 @@ func TestTransport_wsReadLoop(t *testing.T) {
 		mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
 
 		delivered := false
-		mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(message *[]byte) error {
+		mockWS.EXPECT().ReceiveFrame(gomock.Any()).DoAndReturn(func(message *[]byte) (bool, error) {
 			if !delivered {
 				delivered = true
 				*message = []byte("blocked message")
-				return nil
+				return false, nil
 			}
 			<-ctx.Done()
-			return context.Canceled
+			return false, context.Canceled
 		}).AnyTimes()
 
 		done := make(chan error, 1)
@@ -854,7 +854,7 @@ func TestTransport_wsReadLoop(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		messages := make(chan []byte, 10)
+		messages := make(chan engineio_v4.Frame, 10)
 		onClose := make(chan error, 1)
 		transport := &Transport{
 			log:         mockLogger,
@@ -871,15 +871,15 @@ func TestTransport_wsReadLoop(t *testing.T) {
 
 		readCalls := 0
 		ErrExpected := errors.New("ws read error")
-		mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(message *[]byte) error {
+		mockWS.EXPECT().ReceiveFrame(gomock.Any()).DoAndReturn(func(message *[]byte) (bool, error) {
 			readCalls++
 			if readCalls == 1 {
 				// First call returns a message
 				*message = []byte("message before error")
-				return nil
+				return false, nil
 			}
 			// Second call returns error immediately
-			return ErrExpected
+			return false, ErrExpected
 		}).AnyTimes()
 
 		go func() {
@@ -890,7 +890,7 @@ func TestTransport_wsReadLoop(t *testing.T) {
 		// Wait for first message to be received
 		select {
 		case msg := <-messages:
-			assert.Equal(t, []byte("message before error"), msg)
+			assert.Equal(t, []byte("message before error"), msg.Data)
 		case <-time.After(time.Second):
 			t.Fatal("Timeout waiting for message")
 		}
@@ -918,7 +918,7 @@ func TestTransport_wsReadLoop(t *testing.T) {
 		defer cancel()
 
 		// Use non-buffered onClose so we can see if send blocks
-		messages := make(chan []byte, 1)
+		messages := make(chan engineio_v4.Frame, 1)
 		onClose := make(chan error) // unbuffered - non-blocking send will not block
 		transport := &Transport{
 			log:         mockLogger,
@@ -934,7 +934,7 @@ func TestTransport_wsReadLoop(t *testing.T) {
 		mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
 
 		ErrExpected := errors.New("ws read error")
-		mockWS.EXPECT().Receive(gomock.Any()).Return(ErrExpected).AnyTimes()
+		mockWS.EXPECT().ReceiveFrame(gomock.Any()).Return(false, ErrExpected).AnyTimes()
 
 		// wsReadLoop should not block even though onClose is unbuffered
 		// because the send is non-blocking (select with default)
@@ -966,7 +966,7 @@ func TestTransport_wsReadLoop(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 
 		// Use unbuffered onClose
-		messages := make(chan []byte, 1)
+		messages := make(chan engineio_v4.Frame, 1)
 		onClose := make(chan error) // unbuffered - non-blocking send will skip
 		transport := &Transport{
 			log:         mockLogger,
@@ -980,9 +980,9 @@ func TestTransport_wsReadLoop(t *testing.T) {
 		mockLogger.EXPECT().Debugf(gomock.Any()).AnyTimes()
 		mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
 
-		mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(message *[]byte) error {
+		mockWS.EXPECT().ReceiveFrame(gomock.Any()).DoAndReturn(func(message *[]byte) (bool, error) {
 			<-ctx.Done()
-			return context.Canceled
+			return false, context.Canceled
 		}).AnyTimes()
 
 		done := make(chan error, 1)
@@ -1020,7 +1020,7 @@ func TestTransport_wsReadLoop(t *testing.T) {
 		defer cancel()
 
 		// Use unbuffered onClose
-		messages := make(chan []byte, 1)
+		messages := make(chan engineio_v4.Frame, 1)
 		onClose := make(chan error) // unbuffered - non-blocking send will skip
 		transport := &Transport{
 			log:         mockLogger,
@@ -1034,10 +1034,10 @@ func TestTransport_wsReadLoop(t *testing.T) {
 		mockLogger.EXPECT().Debugf(gomock.Any()).AnyTimes()
 		mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
 
-		mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(message *[]byte) error {
+		mockWS.EXPECT().ReceiveFrame(gomock.Any()).DoAndReturn(func(message *[]byte) (bool, error) {
 			// Block until context is done
 			<-ctx.Done()
-			return context.Canceled
+			return false, context.Canceled
 		}).AnyTimes()
 
 		done := make(chan error, 1)
@@ -1094,7 +1094,7 @@ func TestTransport_wsReadLoop_FullChannel(t *testing.T) {
 		receiveWsLogged := make(chan struct{})
 
 		// Unbuffered messages channel ensures the inner select blocks.
-		messages := make(chan []byte)
+		messages := make(chan engineio_v4.Frame)
 		onClose := make(chan error, 1)
 		transport := &Transport{
 			log:         mockLogger,
@@ -1112,14 +1112,14 @@ func TestTransport_wsReadLoop_FullChannel(t *testing.T) {
 		).Times(1)
 		mockLogger.EXPECT().Debugf(gomock.Any()).AnyTimes()
 
-		mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(msg *[]byte) error {
+		mockWS.EXPECT().ReceiveFrame(gomock.Any()).DoAndReturn(func(msg *[]byte) (bool, error) {
 			*msg = []byte("msg")
-			return nil
+			return false, nil
 		}).Times(1)
 		// A background goroutine may still be in Receive after the loop exits.
-		mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(msg *[]byte) error {
+		mockWS.EXPECT().ReceiveFrame(gomock.Any()).DoAndReturn(func(msg *[]byte) (bool, error) {
 			<-ctx.Done()
-			return ctx.Err()
+			return false, ctx.Err()
 		}).AnyTimes()
 		mockWS.EXPECT().Close().Return(nil).AnyTimes()
 
@@ -1152,7 +1152,7 @@ func TestTransport_wsReadLoop_FullChannel(t *testing.T) {
 
 		receiveWsLogged := make(chan struct{})
 
-		messages := make(chan []byte)
+		messages := make(chan engineio_v4.Frame)
 		onClose := make(chan error, 1)
 		stopPooling := make(chan struct{}, 1)
 		transport := &Transport{
@@ -1169,9 +1169,9 @@ func TestTransport_wsReadLoop_FullChannel(t *testing.T) {
 		).Times(1)
 		mockLogger.EXPECT().Debugf(gomock.Any()).AnyTimes()
 
-		mockWS.EXPECT().Receive(gomock.Any()).DoAndReturn(func(msg *[]byte) error {
+		mockWS.EXPECT().ReceiveFrame(gomock.Any()).DoAndReturn(func(msg *[]byte) (bool, error) {
 			*msg = []byte("msg")
-			return nil
+			return false, nil
 		}).Times(1)
 		mockWS.EXPECT().Close().Return(nil).AnyTimes()
 
@@ -1235,6 +1235,39 @@ func TestTransport_SendMessage_Error(t *testing.T) {
 	err := transport.SendMessage([]byte("test message"))
 	assert.Error(t, err)
 	assert.Equal(t, "send error", err.Error())
+}
+
+// TestTransport_SendBinary verifies that binary attachments are written as
+// WebSocket binary frames and that send errors surface.
+func TestTransport_SendBinary(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockWS := mock_engineio_v4_client_transport.NewMockWebSocket(ctrl)
+	mockLogger := mock_engineio_v4_client_transport.NewMockLogger(ctrl)
+
+	transport := &Transport{
+		log: mockLogger,
+		ws:  mockWS,
+	}
+
+	mockLogger.EXPECT().Debugf(gomock.Any()).AnyTimes()
+	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+
+	t.Run("Successful binary send", func(t *testing.T) {
+		mockWS.EXPECT().SendBinary([]byte{0x1, 0x2, 0x3}).Return(nil)
+		err := transport.SendBinary([]byte{0x1, 0x2, 0x3})
+		assert.NoError(t, err)
+	})
+
+	t.Run("Binary send error", func(t *testing.T) {
+		mockWS.EXPECT().SendBinary(gomock.Any()).Return(errors.New("send error"))
+		err := transport.SendBinary([]byte{0x1})
+		assert.Error(t, err)
+		assert.Equal(t, "send error", err.Error())
+	})
 }
 
 func TestConcurrentSetHandshakeAndBuildUrl(t *testing.T) {

--- a/engine.io/v4/defs.go
+++ b/engine.io/v4/defs.go
@@ -23,6 +23,20 @@ type Message struct {
 	Force *bool
 	Type  EngineIOPacket
 	Data  []byte
+	// Binary marks a PacketMessage whose Data is a raw binary attachment
+	// (engine.io v4 binary payload). Text packets leave it false, preserving
+	// the previous behavior for every non-binary frame.
+	Binary bool
+}
+
+// Frame is a single engine.io frame as delivered from a transport to the
+// engine.io client. IsBinary distinguishes a binary attachment (websocket
+// binary frame, or a base64 "b"-prefixed record over HTTP long-polling) from a
+// regular UTF-8 text frame. The zero value (IsBinary == false) is a text frame,
+// which keeps existing transports backward compatible.
+type Frame struct {
+	Data     []byte
+	IsBinary bool
 }
 
 type HandshakeResponse struct {

--- a/engine.io/v4/parser/parser.go
+++ b/engine.io/v4/parser/parser.go
@@ -1,11 +1,16 @@
 package engineio_v4_parser
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
 
 	engineio_v4 "github.com/maldikhan/go.socket.io/engine.io/v4"
 )
+
+// binaryPrefix is the engine.io v4 marker that introduces a base64-encoded
+// binary attachment inside a (text) payload record, e.g. "bAQIDBA==".
+const binaryPrefix = 'b'
 
 // defaultMaxSerializeSize is the outbound payload limit applied when none is
 // configured. It mirrors the inbound default and guards against accidentally
@@ -50,6 +55,20 @@ func (p *EngineIOV4Parser) Parse(data []byte) (*engineio_v4.Message, error) {
 	if len(data) == 0 {
 		return nil, errors.New("empty message")
 	}
+	// A leading 'b' marks a base64-encoded binary attachment (engine.io v4
+	// represents binary inside a text record this way over HTTP long-polling).
+	// Decode it into a binary PacketMessage so callers receive the raw bytes.
+	if data[0] == binaryPrefix {
+		raw, err := base64.StdEncoding.DecodeString(string(data[1:]))
+		if err != nil {
+			return nil, fmt.Errorf("decode binary attachment: %w", err)
+		}
+		return &engineio_v4.Message{
+			Type:   engineio_v4.PacketMessage,
+			Data:   raw,
+			Binary: true,
+		}, nil
+	}
 	// data[0] is an ASCII digit '0'..'6' (0x30..0x36). Subtracting 0x30 maps it
 	// to the packet type. Any other byte yields a value greater than PacketNoop
 	// (bytes below '0' wrap around in the unsigned subtraction), so a single
@@ -72,6 +91,15 @@ func (p *EngineIOV4Parser) Serialize(msg *engineio_v4.Message) ([]byte, error) {
 	}
 	if int64(len(msg.Data)) > limit {
 		return nil, errors.New("message data too large")
+	}
+	// A binary attachment is serialized as 'b' followed by the base64 encoding
+	// of the raw bytes — the engine.io v4 text-payload representation used over
+	// HTTP long-polling.
+	if msg.Binary {
+		encoded := base64.StdEncoding.EncodeToString(msg.Data)
+		packet := make([]byte, 1, len(encoded)+1)
+		packet[0] = binaryPrefix
+		return append(packet, encoded...), nil
 	}
 	packet := make([]byte, 1, len(msg.Data)+1)
 	packet[0] = byte(msg.Type) + 0x30

--- a/engine.io/v4/parser/parser.go
+++ b/engine.io/v4/parser/parser.go
@@ -95,13 +95,13 @@ func (p *EngineIOV4Parser) Serialize(msg *engineio_v4.Message) ([]byte, error) {
 	// A binary attachment is serialized as 'b' followed by the base64 encoding
 	// of the raw bytes — the engine.io v4 text-payload representation used over
 	// HTTP long-polling.
+	//
+	// Both packets are built with append from a 1-byte literal rather than
+	// make(..., len+1): append grows the buffer itself, so there is no explicit
+	// size computation that could overflow on untrusted input lengths.
 	if msg.Binary {
 		encoded := base64.StdEncoding.EncodeToString(msg.Data)
-		packet := make([]byte, 1, len(encoded)+1)
-		packet[0] = binaryPrefix
-		return append(packet, encoded...), nil
+		return append([]byte{binaryPrefix}, encoded...), nil
 	}
-	packet := make([]byte, 1, len(msg.Data)+1)
-	packet[0] = byte(msg.Type) + 0x30
-	return append(packet, msg.Data...), nil
+	return append([]byte{byte(msg.Type) + 0x30}, msg.Data...), nil
 }

--- a/engine.io/v4/parser/parser_test.go
+++ b/engine.io/v4/parser/parser_test.go
@@ -191,3 +191,72 @@ func TestEngineIOV4Parser_Serialize_CustomLimit(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "message data too large", err.Error())
 }
+
+func TestEngineIOV4Parser_ParseBinary(t *testing.T) {
+	parser := &EngineIOV4Parser{}
+
+	t.Run("base64 binary attachment", func(t *testing.T) {
+		// "bAQIDBA==" decodes to {1,2,3,4}.
+		got, err := parser.Parse([]byte("bAQIDBA=="))
+		assert.NoError(t, err)
+		assert.Equal(t, &engineio_v4.Message{
+			Type:   engineio_v4.PacketMessage,
+			Data:   []byte{1, 2, 3, 4},
+			Binary: true,
+		}, got)
+	})
+
+	t.Run("empty base64 attachment", func(t *testing.T) {
+		got, err := parser.Parse([]byte("b"))
+		assert.NoError(t, err)
+		assert.Equal(t, &engineio_v4.Message{
+			Type:   engineio_v4.PacketMessage,
+			Data:   []byte{},
+			Binary: true,
+		}, got)
+	})
+
+	t.Run("invalid base64", func(t *testing.T) {
+		_, err := parser.Parse([]byte("b!!!notbase64"))
+		assert.Error(t, err)
+	})
+}
+
+func TestEngineIOV4Parser_SerializeBinary(t *testing.T) {
+	parser := &EngineIOV4Parser{}
+
+	got, err := parser.Serialize(&engineio_v4.Message{
+		Type:   engineio_v4.PacketMessage,
+		Data:   []byte{1, 2, 3, 4},
+		Binary: true,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("bAQIDBA=="), got)
+
+	// Oversized binary still hits the size guard.
+	_, err = parser.Serialize(&engineio_v4.Message{
+		Type:   engineio_v4.PacketMessage,
+		Data:   make([]byte, 65*1024*1024),
+		Binary: true,
+	})
+	assert.Error(t, err)
+}
+
+// TestEngineIOV4Parser_BinaryRoundTrip ensures Serialize/Parse are inverse for
+// binary attachments over the base64 long-polling representation.
+func TestEngineIOV4Parser_BinaryRoundTrip(t *testing.T) {
+	parser := &EngineIOV4Parser{}
+	original := []byte{0x00, 0x10, 0xFF, 0x42, 0x7F}
+
+	wire, err := parser.Serialize(&engineio_v4.Message{
+		Type:   engineio_v4.PacketMessage,
+		Data:   original,
+		Binary: true,
+	})
+	assert.NoError(t, err)
+
+	got, err := parser.Parse(wire)
+	assert.NoError(t, err)
+	assert.True(t, got.Binary)
+	assert.Equal(t, original, got.Data)
+}

--- a/socket.io/v5/client/binary_test.go
+++ b/socket.io/v5/client/binary_test.go
@@ -1,0 +1,257 @@
+package socketio_v5_client
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	socketio_v5 "github.com/maldikhan/go.socket.io/socket.io/v5"
+	mocks "github.com/maldikhan/go.socket.io/socket.io/v5/client/mocks"
+	parser "github.com/maldikhan/go.socket.io/socket.io/v5/parser/default"
+	"github.com/maldikhan/go.socket.io/utils"
+)
+
+// newBinaryClient builds a client backed by the real default parser (so the
+// binary serialize/reconstruct logic runs for real) and a mock engine.io client
+// used to capture or inject frames.
+func newBinaryClient(t *testing.T) (*Client, *mocks.MockEngineIOClient) {
+	ctrl := gomock.NewController(t)
+	mockEngine := mocks.NewMockEngineIOClient(ctrl)
+
+	client := &Client{
+		parser:        parser.NewParser(parser.WithLogger(&utils.DefaultLogger{Level: utils.NONE})),
+		engineio:      mockEngine,
+		logger:        &utils.DefaultLogger{Level: utils.NONE},
+		timer:         mocks.NewMockTimer(ctrl),
+		ctx:           context.Background(),
+		namespaces:    make(map[string]*namespace),
+		ackCallbacks:  make(map[int]func([]interface{})),
+		handshakeData: make(map[string]interface{}),
+	}
+	client.defaultNs = client.namespace("/")
+	// Mark default namespace as connected so Emit does not block.
+	client.defaultNs.hadConnected.Do(func() { close(client.defaultNs.waitConnected) })
+	return client, mockEngine
+}
+
+func TestClient_Emit_Binary(t *testing.T) {
+	client, mockEngine := newBinaryClient(t)
+
+	var sent []byte
+	var binaries [][]byte
+	var mu sync.Mutex
+
+	mockEngine.EXPECT().Send(gomock.Any()).DoAndReturn(func(data []byte) error {
+		mu.Lock()
+		sent = append([]byte{}, data...)
+		mu.Unlock()
+		return nil
+	})
+	mockEngine.EXPECT().SendBinary(gomock.Any()).DoAndReturn(func(data []byte) error {
+		mu.Lock()
+		binaries = append(binaries, append([]byte{}, data...))
+		mu.Unlock()
+		return nil
+	}).Times(2)
+
+	require.NoError(t, client.Emit("binEvent", []byte("first"), "text", []byte("second")))
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []byte(`52-["binEvent",{"_placeholder":true,"num":0},"text",{"_placeholder":true,"num":1}]`), sent)
+	require.Len(t, binaries, 2)
+	assert.Equal(t, []byte("first"), binaries[0])
+	assert.Equal(t, []byte("second"), binaries[1])
+}
+
+func TestClient_Emit_TextStillSingleSend(t *testing.T) {
+	client, mockEngine := newBinaryClient(t)
+
+	// A text-only event must use the regular Send path (no SendBinary calls).
+	mockEngine.EXPECT().Send([]byte(`2["textEvent","hello"]`)).Return(nil)
+
+	require.NoError(t, client.Emit("textEvent", "hello"))
+}
+
+func TestClient_ReceiveBinaryEvent(t *testing.T) {
+	client, _ := newBinaryClient(t)
+
+	got := make(chan []byte, 1)
+	client.On("binEvent", func(data []byte) {
+		got <- data
+	})
+
+	// Header announces one attachment; the attachment frame follows.
+	client.onMessage([]byte(`51-["binEvent",{"_placeholder":true,"num":0}]`))
+	client.onBinaryAttachment([]byte{0xAA, 0xBB, 0xCC})
+
+	assert.Equal(t, []byte{0xAA, 0xBB, 0xCC}, <-got)
+}
+
+func TestClient_ReceiveBinaryEvent_MultiAttachment(t *testing.T) {
+	client, _ := newBinaryClient(t)
+
+	got := make(chan []interface{}, 1)
+	client.OnAny(func(_ string, payloads []interface{}) {
+		got <- payloads
+	})
+
+	client.onMessage([]byte(`52-["multi",{"_placeholder":true,"num":0},"text",{"_placeholder":true,"num":1}]`))
+	client.onBinaryAttachment([]byte("aaa"))
+	client.onBinaryAttachment([]byte("bbb"))
+
+	payloads := <-got
+	require.Len(t, payloads, 3)
+	assert.Equal(t, []byte("aaa"), payloads[0])
+	assert.Equal(t, "text", payloads[1])
+	assert.Equal(t, []byte("bbb"), payloads[2])
+}
+
+func TestClient_ReceiveBinaryAck(t *testing.T) {
+	client, _ := newBinaryClient(t)
+
+	got := make(chan []interface{}, 1)
+	client.mutex.Lock()
+	client.ackCallbacks[5] = func(args []interface{}) { got <- args }
+	client.mutex.Unlock()
+
+	client.onMessage([]byte(`61-5[{"_placeholder":true,"num":0}]`))
+	client.onBinaryAttachment([]byte("ackdata"))
+
+	payloads := <-got
+	require.Len(t, payloads, 1)
+	assert.Equal(t, []byte("ackdata"), payloads[0])
+}
+
+func TestClient_ReceiveBinaryZeroAttachments(t *testing.T) {
+	client, _ := newBinaryClient(t)
+
+	got := make(chan []interface{}, 1)
+	client.On("noAttach", func(payloads []interface{}) {
+		got <- payloads
+	})
+
+	// Zero attachments: the message is complete immediately.
+	client.onMessage([]byte(`50-["noAttach","plain"]`))
+
+	payloads := <-got
+	require.Len(t, payloads, 1)
+}
+
+func TestClient_ReceiveBinary_ReconstructError(t *testing.T) {
+	// A binary header that declares a placeholder index out of range fails
+	// reconstruction; the message is dropped without panic.
+	client, _ := newBinaryClient(t)
+	client.onMessage([]byte(`51-["ev",{"_placeholder":true,"num":9}]`))
+	client.onBinaryAttachment([]byte{1})
+}
+
+func TestClient_ReceiveBinary_ZeroAttachmentReconstructError(t *testing.T) {
+	// Zero-attachment header whose placeholder points past the (empty)
+	// attachment list: reconstruction fails immediately and is dropped.
+	client, _ := newBinaryClient(t)
+	client.onMessage([]byte(`50-["ev",{"_placeholder":true,"num":0}]`))
+}
+
+func TestClient_BinaryAttachmentWithoutPending(t *testing.T) {
+	client, _ := newBinaryClient(t)
+	// No pending binary header: the stray attachment is dropped without panic.
+	client.onBinaryAttachment([]byte{1, 2, 3})
+}
+
+func TestClient_RoundTrip_EmitToReceive(t *testing.T) {
+	// Emit a binary event, capture the wire frames, then feed them back into a
+	// receiving client and assert the []byte survives the full path.
+	sender, senderEngine := newBinaryClient(t)
+
+	var header []byte
+	var attachments [][]byte
+	var mu sync.Mutex
+	senderEngine.EXPECT().Send(gomock.Any()).DoAndReturn(func(d []byte) error {
+		mu.Lock()
+		header = append([]byte{}, d...)
+		mu.Unlock()
+		return nil
+	})
+	senderEngine.EXPECT().SendBinary(gomock.Any()).DoAndReturn(func(d []byte) error {
+		mu.Lock()
+		attachments = append(attachments, append([]byte{}, d...))
+		mu.Unlock()
+		return nil
+	}).AnyTimes()
+
+	require.NoError(t, sender.Emit("roundtrip", []byte{0xDE, 0xAD, 0xBE, 0xEF}))
+
+	receiver, _ := newBinaryClient(t)
+	got := make(chan []byte, 1)
+	receiver.On("roundtrip", func(data []byte) { got <- data })
+
+	mu.Lock()
+	h := header
+	a := attachments
+	mu.Unlock()
+
+	receiver.onMessage(h)
+	for _, attachment := range a {
+		receiver.onBinaryAttachment(attachment)
+	}
+
+	assert.Equal(t, []byte{0xDE, 0xAD, 0xBE, 0xEF}, <-got)
+}
+
+// TestClient_sendPacket_BinarySendError covers the error branches when the
+// engine.io client fails to deliver a binary header or attachment.
+func TestClient_sendPacket_BinarySendError(t *testing.T) {
+	t.Run("header send fails", func(t *testing.T) {
+		client, mockEngine := newBinaryClient(t)
+		mockEngine.EXPECT().Send(gomock.Any()).Return(errBinaryTestClient)
+		err := client.sendPacket(&socketio_v5.Message{
+			Type: socketio_v5.PacketEvent,
+			NS:   "/",
+			Event: &socketio_v5.Event{
+				Name:     "ev",
+				Payloads: []interface{}{[]byte{1}},
+			},
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("attachment send fails", func(t *testing.T) {
+		client, mockEngine := newBinaryClient(t)
+		mockEngine.EXPECT().Send(gomock.Any()).Return(nil)
+		mockEngine.EXPECT().SendBinary(gomock.Any()).Return(errBinaryTestClient)
+		err := client.sendPacket(&socketio_v5.Message{
+			Type: socketio_v5.PacketEvent,
+			NS:   "/",
+			Event: &socketio_v5.Event{
+				Name:     "ev",
+				Payloads: []interface{}{[]byte{1}},
+			},
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("serialize binary fails", func(t *testing.T) {
+		client, _ := newBinaryClient(t)
+		// An unserializable payload alongside binary triggers SerializeBinary error.
+		err := client.sendPacket(&socketio_v5.Message{
+			Type: socketio_v5.PacketEvent,
+			NS:   "/",
+			Event: &socketio_v5.Event{
+				Name:     "ev",
+				Payloads: []interface{}{[]byte{1}, make(chan int)},
+			},
+		})
+		assert.Error(t, err)
+	})
+}
+
+var errBinaryTestClient = &binaryClientError{}
+
+type binaryClientError struct{}
+
+func (e *binaryClientError) Error() string { return "binary client error" }

--- a/socket.io/v5/client/binary_test.go
+++ b/socket.io/v5/client/binary_test.go
@@ -157,6 +157,22 @@ func TestClient_ReceiveBinary_ZeroAttachmentReconstructError(t *testing.T) {
 	client.onMessage([]byte(`50-["ev",{"_placeholder":true,"num":0}]`))
 }
 
+func TestClient_ReceiveBinary_HugeAttachmentCountNoPanic(t *testing.T) {
+	// A malformed/hostile header declares an enormous attachment count (the
+	// parser accepts up to 18 digits). Staging must not use it directly as a
+	// slice capacity — make([][]byte, 0, hugeCount) would panic ("cap out of
+	// range"). The clamped preallocation keeps this a no-op crash-wise: the
+	// header stages and simply waits for attachments that never complete.
+	client, _ := newBinaryClient(t)
+	client.On("ev", func(data []byte) {})
+
+	client.onMessage([]byte(`5999999999999999-["ev",{"_placeholder":true,"num":0}]`))
+
+	// A subsequent real attachment is appended (slice grew via append, not the
+	// huge declared capacity) without completing or panicking.
+	client.onBinaryAttachment([]byte{0x01})
+}
+
 func TestClient_BinaryAttachmentWithoutPending(t *testing.T) {
 	client, _ := newBinaryClient(t)
 	// No pending binary header: the stray attachment is dropped without panic.

--- a/socket.io/v5/client/binary_test.go
+++ b/socket.io/v5/client/binary_test.go
@@ -157,19 +157,36 @@ func TestClient_ReceiveBinary_ZeroAttachmentReconstructError(t *testing.T) {
 	client.onMessage([]byte(`50-["ev",{"_placeholder":true,"num":0}]`))
 }
 
-func TestClient_ReceiveBinary_HugeAttachmentCountNoPanic(t *testing.T) {
-	// A malformed/hostile header declares an enormous attachment count (the
-	// parser accepts up to 18 digits). Staging must not use it directly as a
-	// slice capacity — make([][]byte, 0, hugeCount) would panic ("cap out of
-	// range"). The clamped preallocation keeps this a no-op crash-wise: the
-	// header stages and simply waits for attachments that never complete.
+func TestClient_ReceiveBinary_HugeAttachmentCountRejected(t *testing.T) {
+	// A malformed/hostile header declares an enormous attachment count (the parser
+	// accepts up to 18 digits). It must be rejected outright, not staged: it can't
+	// be a slice capacity (make([][]byte, 0, hugeCount) panics) and must not become
+	// the completion target either, or a peer could pin unbounded memory streaming
+	// frames toward it. The message is dropped and never dispatched.
 	client, _ := newBinaryClient(t)
-	client.On("ev", func(data []byte) {})
+	dispatched := make(chan struct{}, 1)
+	client.On("ev", func(data []byte) { dispatched <- struct{}{} })
 
 	client.onMessage([]byte(`5999999999999999-["ev",{"_placeholder":true,"num":0}]`))
 
-	// A subsequent real attachment is appended (slice grew via append, not the
-	// huge declared capacity) without completing or panicking.
+	// A stray attachment now has no pending header to attach to; both are dropped
+	// without panicking, and the event is never delivered.
+	client.onBinaryAttachment([]byte{0x01})
+	select {
+	case <-dispatched:
+		t.Fatal("message with an unrealistic attachment count must not be dispatched")
+	default:
+	}
+}
+
+func TestClient_ReceiveBinary_AttachmentCountWithinLimitStages(t *testing.T) {
+	// A large-but-within-limit count (above the preallocation cap, below the
+	// attachment maximum) is staged with a clamped preallocation and grows via
+	// append; it neither panics nor over-allocates while waiting to complete.
+	client, _ := newBinaryClient(t)
+	client.On("ev", func(data []byte) {})
+
+	client.onMessage([]byte(`5100-["ev",{"_placeholder":true,"num":0}]`))
 	client.onBinaryAttachment([]byte{0x01})
 }
 

--- a/socket.io/v5/client/client.go
+++ b/socket.io/v5/client/client.go
@@ -25,6 +25,16 @@ type Client struct {
 	ackCallbacks map[int]func([]interface{})
 	ackCounter   int
 
+	// pendingBinary holds a binary event/ack header whose attachment frames have
+	// not all arrived yet. Binary attachments are accumulated in
+	// pendingAttachments and, once the expected count is reached, reassembled
+	// into the message before dispatch. Guarded by binaryMu so staging and the
+	// attachment callbacks never race.
+	binaryMu           sync.Mutex
+	pendingBinary      *socketio_v5.Message
+	pendingNeeded      int
+	pendingAttachments [][]byte
+
 	// redactPayload, when true, replaces raw payloads in debug logs with a
 	// size marker. Zero value is verbose; NewClient sets the safe default.
 	redactPayload bool

--- a/socket.io/v5/client/client.go
+++ b/socket.io/v5/client/client.go
@@ -25,6 +25,16 @@ type Client struct {
 	ackCallbacks map[int]func([]interface{})
 	ackCounter   int
 
+	// sendMu serializes the transport writes that make up a single logical
+	// socket.io packet. A binary event/ack is written as a text header frame
+	// followed by one or more binary attachment frames; without serialization
+	// two concurrent Emit calls could interleave their frames on the wire and
+	// the receiver would associate an attachment with the wrong header. The
+	// lock is held only around the frame writes (see sendPacket), never while
+	// an Emit is blocked waiting for the connection, so it does not serialize
+	// callers that are merely waiting to connect.
+	sendMu sync.Mutex
+
 	// pendingBinary holds a binary event/ack header whose attachment frames have
 	// not all arrived yet. Binary attachments are accumulated in
 	// pendingAttachments and, once the expected count is reached, reassembled

--- a/socket.io/v5/client/client_test.go
+++ b/socket.io/v5/client/client_test.go
@@ -220,6 +220,7 @@ func TestConcurrentConnectAndEmit(t *testing.T) {
 	}
 
 	mockEngineIO.EXPECT().Connect(ctx).Return(nil).AnyTimes()
+	mockParser.EXPECT().HasBinary(gomock.Any()).Return(false).AnyTimes()
 	mockParser.EXPECT().Serialize(gomock.Any()).Return([]byte("packet"), nil).AnyTimes()
 	mockEngineIO.EXPECT().Send(gomock.Any()).Return(nil).AnyTimes()
 

--- a/socket.io/v5/client/constructor.go
+++ b/socket.io/v5/client/constructor.go
@@ -77,6 +77,7 @@ func NewClient(options ...ClientOption) (*Client, error) {
 
 	client.engineio.On("connect", client.connectSocketIO)
 	client.engineio.On("message", client.onMessage)
+	client.engineio.On("binary", client.onBinaryAttachment)
 
 	return client.Client, nil
 }

--- a/socket.io/v5/client/constructor_test.go
+++ b/socket.io/v5/client/constructor_test.go
@@ -149,6 +149,7 @@ func TestNewClient(t *testing.T) {
 			if !tt.wantErr {
 				mockEngineIOClient.EXPECT().On("connect", gomock.Any()).AnyTimes()
 				mockEngineIOClient.EXPECT().On("message", gomock.Any()).AnyTimes()
+				mockEngineIOClient.EXPECT().On("binary", gomock.Any()).AnyTimes()
 			}
 
 			got, err := NewClient(tt.options...)

--- a/socket.io/v5/client/dep.go
+++ b/socket.io/v5/client/dep.go
@@ -13,12 +13,24 @@ type Parser interface {
 	WrapCallback(callback interface{}) func(in []interface{})
 	Parse([]byte) (*socketio_v5.Message, error)
 	Serialize(*socketio_v5.Message) ([]byte, error)
+	// HasBinary reports whether an event carries []byte payloads that must be
+	// sent as a binary packet (PacketBinaryEvent/PacketBinaryAck).
+	HasBinary(event *socketio_v5.Event) bool
+	// SerializeBinary encodes an event with binary payloads into a header packet
+	// plus the ordered binary attachments that follow it on the wire.
+	SerializeBinary(*socketio_v5.Message) (header []byte, attachments [][]byte, err error)
+	// ReconstructBinary substitutes collected binary attachments back into the
+	// placeholders of a parsed binary packet, exposing them as []byte.
+	ReconstructBinary(msg *socketio_v5.Message, attachments [][]byte) error
 }
 
 // EngineIOClient представляет интерфейс для клиента Engine.IO
 type EngineIOClient interface {
 	Connect(ctx context.Context) error
 	Send(message []byte) error
+	// SendBinary delivers a raw binary attachment frame (the buffers that follow
+	// a binary event/ack header).
+	SendBinary(message []byte) error
 	On(event string, handler func([]byte))
 	Close() error
 }

--- a/socket.io/v5/client/emitters.go
+++ b/socket.io/v5/client/emitters.go
@@ -147,6 +147,24 @@ func (c *Client) sendPacketWithAckTimeout(
 }
 
 func (c *Client) sendPacket(packet *socketio_v5.Message) error {
+	// Events carrying []byte payloads are sent as a binary packet: a text header
+	// with {"_placeholder"} markers followed by the raw attachment frames.
+	if packet.Event != nil && c.parser.HasBinary(packet.Event) {
+		header, attachments, err := c.parser.SerializeBinary(packet)
+		if err != nil {
+			return err
+		}
+		if err := c.engineio.Send(header); err != nil {
+			return err
+		}
+		for _, attachment := range attachments {
+			if err := c.engineio.SendBinary(attachment); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
 	packetData, err := c.parser.Serialize(packet)
 	if err != nil {
 		return err

--- a/socket.io/v5/client/emitters.go
+++ b/socket.io/v5/client/emitters.go
@@ -154,6 +154,11 @@ func (c *Client) sendPacket(packet *socketio_v5.Message) error {
 		if err != nil {
 			return err
 		}
+		// Serialization happens outside the lock; only the transport writes are
+		// serialized so the header and all of its attachment frames are emitted
+		// contiguously, with no foreign frame interleaved by a concurrent emit.
+		c.sendMu.Lock()
+		defer c.sendMu.Unlock()
 		if err := c.engineio.Send(header); err != nil {
 			return err
 		}
@@ -169,5 +174,9 @@ func (c *Client) sendPacket(packet *socketio_v5.Message) error {
 	if err != nil {
 		return err
 	}
+	// Hold sendMu so a single-frame packet cannot slip between a binary
+	// header and its attachment frames emitted by a concurrent binary send.
+	c.sendMu.Lock()
+	defer c.sendMu.Unlock()
 	return c.engineio.Send(packetData)
 }

--- a/socket.io/v5/client/emitters_concurrency_test.go
+++ b/socket.io/v5/client/emitters_concurrency_test.go
@@ -1,0 +1,203 @@
+package socketio_v5_client
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	socketio_v5 "github.com/maldikhan/go.socket.io/socket.io/v5"
+)
+
+// recordingEngineIO records the global order in which transport frames are
+// written. Each recorded entry is tagged so the test can verify that the frames
+// of one logical packet are emitted contiguously, with no foreign frame
+// interleaved by a concurrent emit.
+type recordingEngineIO struct {
+	mu     sync.Mutex
+	frames []string
+}
+
+func (e *recordingEngineIO) record(tag string) {
+	e.mu.Lock()
+	e.frames = append(e.frames, tag)
+	e.mu.Unlock()
+}
+
+func (e *recordingEngineIO) Connect(_ context.Context) error { return nil }
+
+func (e *recordingEngineIO) Send(message []byte) error {
+	// A text frame: either a binary packet header ("H:<id>") or a plain text
+	// event frame ("T").
+	e.record(string(message))
+	return nil
+}
+
+func (e *recordingEngineIO) SendBinary(message []byte) error {
+	e.record(string(message))
+	return nil
+}
+
+func (e *recordingEngineIO) On(_ string, _ func([]byte)) {}
+func (e *recordingEngineIO) Close() error                { return nil }
+
+// recordingParser produces deterministic, identifiable frames. Binary events
+// (whose payload list contains a []byte) yield a header tagged "H:<id>" and a
+// fixed number of attachment frames tagged "A:<id>:<n>". Text events yield a
+// single "T" frame.
+type recordingParser struct {
+	attachments int
+}
+
+func (p *recordingParser) WrapCallback(_ interface{}) func(in []interface{}) { return nil }
+func (p *recordingParser) Parse(_ []byte) (*socketio_v5.Message, error)      { return nil, nil }
+func (p *recordingParser) ReconstructBinary(_ *socketio_v5.Message, _ [][]byte) error {
+	return nil
+}
+
+func (p *recordingParser) HasBinary(event *socketio_v5.Event) bool {
+	for _, payload := range event.Payloads {
+		if _, ok := payload.([]byte); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *recordingParser) Serialize(msg *socketio_v5.Message) ([]byte, error) {
+	return []byte("T"), nil
+}
+
+func (p *recordingParser) SerializeBinary(msg *socketio_v5.Message) ([]byte, [][]byte, error) {
+	id := msg.Event.Name
+	header := []byte("H:" + id)
+	attachments := make([][]byte, p.attachments)
+	for i := range attachments {
+		attachments[i] = []byte("A:" + id + ":" + itoa(i))
+	}
+	return header, attachments, nil
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b [20]byte
+	pos := len(b)
+	for i > 0 {
+		pos--
+		b[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	return string(b[pos:])
+}
+
+// TestSendPacketBinaryFramesAreContiguousUnderConcurrency drives many concurrent
+// binary and text emits through a single Client and asserts that every binary
+// header frame is immediately followed by exactly its own attachment frames,
+// with no frame from another logical packet interleaved. Without the send mutex
+// around the whole multi-frame write, concurrent emits interleave and this
+// assertion fails (and -race reports a data race on the transport ordering).
+func TestSendPacketBinaryFramesAreContiguousUnderConcurrency(t *testing.T) {
+	const attachments = 3
+	engine := &recordingEngineIO{}
+	parser := &recordingParser{attachments: attachments}
+
+	client := &Client{
+		engineio:     engine,
+		parser:       parser,
+		logger:       &concNopLogger{},
+		timer:        concNopTimer{},
+		ctx:          context.Background(),
+		namespaces:   map[string]*namespace{},
+		ackCallbacks: map[int]func([]interface{}){},
+	}
+
+	const goroutines = 50
+	const iterations = 20
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for it := 0; it < iterations; it++ {
+				if (g+it)%2 == 0 {
+					// Binary emit: event with a []byte payload. The event name
+					// is the unique id used to tag header/attachment frames.
+					id := itoa(g) + "-" + itoa(it)
+					_ = client.sendPacket(&socketio_v5.Message{
+						Type: socketio_v5.PacketBinaryEvent,
+						Event: &socketio_v5.Event{
+							Name:     id,
+							Payloads: []interface{}{[]byte("blob")},
+						},
+					})
+				} else {
+					// Text emit: single text frame, no attachments.
+					_ = client.sendPacket(&socketio_v5.Message{
+						Type: socketio_v5.PacketEvent,
+						Event: &socketio_v5.Event{
+							Name:     "text",
+							Payloads: []interface{}{"hello"},
+						},
+					})
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	frames := engine.frames
+	headers := 0
+	for i := 0; i < len(frames); i++ {
+		f := frames[i]
+		switch {
+		case strings.HasPrefix(f, "H:"):
+			headers++
+			id := strings.TrimPrefix(f, "H:")
+			// The next `attachments` frames must be exactly this header's
+			// attachments, in order, with nothing foreign in between.
+			for n := 0; n < attachments; n++ {
+				idx := i + 1 + n
+				if idx >= len(frames) {
+					t.Fatalf("binary header %q at %d is missing attachment %d (only %d frames)", f, i, n, len(frames))
+				}
+				want := "A:" + id + ":" + itoa(n)
+				if frames[idx] != want {
+					t.Fatalf("binary header %q at %d: frame %d = %q, want %q (foreign frame interleaved)", f, i, idx, frames[idx], want)
+				}
+			}
+			i += attachments
+		case strings.HasPrefix(f, "A:"):
+			t.Fatalf("orphan attachment frame %q at %d (not preceded by its header)", f, i)
+		case f == "T":
+			// Standalone text frame is fine anywhere.
+		default:
+			t.Fatalf("unexpected frame %q at %d", f, i)
+		}
+	}
+
+	// Sanity: we actually exercised the binary path.
+	if headers == 0 {
+		t.Fatal("expected at least one binary header to be emitted")
+	}
+	expectedFrames := headers*(1+attachments) + (len(frames) - headers*(1+attachments))
+	if len(frames) != expectedFrames {
+		t.Fatalf("frame accounting mismatch: got %d frames", len(frames))
+	}
+}
+
+type concNopLogger struct{}
+
+func (concNopLogger) Debugf(string, ...any) {}
+func (concNopLogger) Infof(string, ...any)  {}
+func (concNopLogger) Warnf(string, ...any)  {}
+func (concNopLogger) Errorf(string, ...any) {}
+
+type concNopTimer struct{}
+
+func (concNopTimer) After(d time.Duration) <-chan time.Time {
+	return make(chan time.Time)
+}

--- a/socket.io/v5/client/emitters_concurrency_test.go
+++ b/socket.io/v5/client/emitters_concurrency_test.go
@@ -151,6 +151,7 @@ func TestSendPacketBinaryFramesAreContiguousUnderConcurrency(t *testing.T) {
 
 	frames := engine.frames
 	headers := 0
+	texts := 0
 	for i := 0; i < len(frames); i++ {
 		f := frames[i]
 		switch {
@@ -174,6 +175,7 @@ func TestSendPacketBinaryFramesAreContiguousUnderConcurrency(t *testing.T) {
 			t.Fatalf("orphan attachment frame %q at %d (not preceded by its header)", f, i)
 		case f == "T":
 			// Standalone text frame is fine anywhere.
+			texts++
 		default:
 			t.Fatalf("unexpected frame %q at %d", f, i)
 		}
@@ -183,9 +185,14 @@ func TestSendPacketBinaryFramesAreContiguousUnderConcurrency(t *testing.T) {
 	if headers == 0 {
 		t.Fatal("expected at least one binary header to be emitted")
 	}
-	expectedFrames := headers*(1+attachments) + (len(frames) - headers*(1+attachments))
+	// Independent reconciliation: every frame is either a binary header, one of
+	// its `attachments` attachment frames, or a standalone text frame. Counting
+	// texts separately makes this a real check (the previous formula reduced to
+	// len(frames) and could never fail).
+	expectedFrames := headers*(1+attachments) + texts
 	if len(frames) != expectedFrames {
-		t.Fatalf("frame accounting mismatch: got %d frames", len(frames))
+		t.Fatalf("frame accounting mismatch: got %d frames, want %d (%d headers x (1+%d attachments) + %d texts)",
+			len(frames), expectedFrames, headers, attachments, texts)
 	}
 }
 

--- a/socket.io/v5/client/emitters_test.go
+++ b/socket.io/v5/client/emitters_test.go
@@ -38,6 +38,7 @@ func TestEmitBeforeConnected(t *testing.T) {
 	}
 
 	t.Run("wait ok", func(t *testing.T) {
+		mockParser.EXPECT().HasBinary(gomock.Any()).Return(false).AnyTimes()
 		mockParser.EXPECT().Serialize(gomock.Any()).Return([]byte{}, nil)
 		mockEngineIO.EXPECT().Send(gomock.Any()).Return(nil)
 
@@ -121,6 +122,7 @@ func TestClientEmit(t *testing.T) {
 		},
 	}
 
+	mockParser.EXPECT().HasBinary(gomock.Any()).Return(false).AnyTimes()
 	mockParser.EXPECT().Serialize(gomock.Any()).Return([]byte{}, nil)
 	mockEngineIO.EXPECT().Send(gomock.Any()).Return(nil)
 
@@ -180,6 +182,7 @@ func TestNamespaceEmit(t *testing.T) {
 			ns := &namespace{client: client}
 
 			if tt.expectedError == nil {
+				mockParser.EXPECT().HasBinary(gomock.Any()).Return(false).AnyTimes()
 				mockParser.EXPECT().Serialize(gomock.Any()).Return([]byte{}, nil)
 				mockEngineIO.EXPECT().Send(gomock.Any()).Return(nil)
 			}
@@ -227,6 +230,7 @@ func TestSendPacketWithAckTimeout(t *testing.T) {
 				logger:       mockLogger,
 			}
 
+			mockParser.EXPECT().HasBinary(gomock.Any()).Return(false).AnyTimes()
 			mockParser.EXPECT().Serialize(gomock.Any()).Return([]byte{}, nil)
 			mockEngineIO.EXPECT().Send(gomock.Any()).Return(nil)
 
@@ -269,6 +273,7 @@ func TestSendPacketWithAckTimeout(t *testing.T) {
 		mockTimer := mocks.NewMockTimer(ctrl)
 		mockLogger := mocks.NewMockLogger(ctrl)
 
+		mockParser.EXPECT().HasBinary(gomock.Any()).Return(false).AnyTimes()
 		mockParser.EXPECT().Serialize(gomock.Any()).Return([]byte{}, nil)
 		mockEngineIO.EXPECT().Send(gomock.Any()).Return(nil)
 		mockTimer.EXPECT().After(gomock.Any()).DoAndReturn(func(time.Duration) <-chan time.Time {
@@ -325,6 +330,7 @@ func TestSendPacketWithAckTimeout(t *testing.T) {
 		mockTimer := mocks.NewMockTimer(ctrl)
 		mockLogger := mocks.NewMockLogger(ctrl)
 
+		mockParser.EXPECT().HasBinary(gomock.Any()).Return(false).AnyTimes()
 		mockParser.EXPECT().Serialize(gomock.Any()).Return([]byte{}, nil)
 		mockEngineIO.EXPECT().Send(gomock.Any()).Return(nil)
 		mockTimer.EXPECT().After(gomock.Any()).DoAndReturn(func(time.Duration) <-chan time.Time {
@@ -411,6 +417,7 @@ func TestSendPacket(t *testing.T) {
 				parser:   mockParser,
 			}
 
+			mockParser.EXPECT().HasBinary(gomock.Any()).Return(false).AnyTimes()
 			mockParser.EXPECT().Serialize(gomock.Any()).Return([]byte{}, tt.serializeErr)
 			if tt.serializeErr == nil {
 				mockEngineIO.EXPECT().Send(gomock.Any()).Return(tt.sendErr)

--- a/socket.io/v5/client/handlers.go
+++ b/socket.io/v5/client/handlers.go
@@ -33,6 +33,90 @@ func (c *Client) onMessage(data []byte) {
 		return
 	}
 
+	// A binary event/ack header is not complete until its attachment frames
+	// arrive. Stage it and wait for onBinaryAttachment to reassemble and
+	// dispatch it. A zero-attachment binary packet is reassembled immediately.
+	if msg.BinaryAttachments != nil {
+		if c.stageBinary(msg) {
+			return
+		}
+	}
+
+	c.dispatch(msg)
+}
+
+// stageBinary stores a binary header awaiting attachments. It returns true when
+// the message is incomplete (more attachments expected) and the caller must not
+// dispatch yet; it returns false once the message is fully reconstructed (e.g.
+// zero attachments) so the caller dispatches it normally.
+func (c *Client) stageBinary(msg *socketio_v5.Message) bool {
+	needed := *msg.BinaryAttachments
+	c.binaryMu.Lock()
+	if needed == 0 {
+		c.clearPendingLocked()
+		c.binaryMu.Unlock()
+		if err := c.parser.ReconstructBinary(msg, nil); err != nil {
+			c.logger.Errorf("Can't reconstruct binary message: %v", err)
+			return true
+		}
+		return false
+	}
+	c.pendingBinary = msg
+	c.pendingNeeded = needed
+	c.pendingAttachments = make([][]byte, 0, needed)
+	c.binaryMu.Unlock()
+	return true
+}
+
+// onBinaryAttachment collects a binary attachment frame and, once the staged
+// header has received all of its expected attachments, reconstructs and
+// dispatches the complete message.
+func (c *Client) onBinaryAttachment(data []byte) {
+	c.binaryMu.Lock()
+	if c.pendingBinary == nil {
+		c.binaryMu.Unlock()
+		c.logger.Errorf("received binary attachment without a pending binary packet, dropping")
+		return
+	}
+	// Copy the frame: the transport may reuse the underlying buffer.
+	buf := make([]byte, len(data))
+	copy(buf, data)
+	c.pendingAttachments = append(c.pendingAttachments, buf)
+	if len(c.pendingAttachments) < c.pendingNeeded {
+		c.binaryMu.Unlock()
+		return
+	}
+	msg := c.pendingBinary
+	attachments := c.pendingAttachments
+	c.clearPendingLocked()
+	c.binaryMu.Unlock()
+
+	if err := c.parser.ReconstructBinary(msg, attachments); err != nil {
+		c.logger.Errorf("Can't reconstruct binary message: %v", err)
+		return
+	}
+	c.dispatch(msg)
+}
+
+// clearPendingLocked resets the staged binary state. The caller must hold
+// binaryMu.
+func (c *Client) clearPendingLocked() {
+	c.pendingBinary = nil
+	c.pendingNeeded = 0
+	c.pendingAttachments = nil
+}
+
+// dispatch routes a fully decoded message (binary or text) to the appropriate
+// namespace handlers. Binary events/acks are normalized to their text packet
+// type so the existing dispatch paths handle them uniformly.
+func (c *Client) dispatch(msg *socketio_v5.Message) {
+	switch msg.Type {
+	case socketio_v5.PacketBinaryEvent:
+		msg.Type = socketio_v5.PacketEvent
+	case socketio_v5.PacketBinaryAck:
+		msg.Type = socketio_v5.PacketAck
+	}
+
 	// Handle ACK packets first — they don't carry a meaningful namespace,
 	// so they must not be dropped by the unknown-namespace guard below.
 	if msg.Type == socketio_v5.PacketAck {

--- a/socket.io/v5/client/handlers.go
+++ b/socket.io/v5/client/handlers.go
@@ -63,10 +63,27 @@ func (c *Client) stageBinary(msg *socketio_v5.Message) bool {
 	}
 	c.pendingBinary = msg
 	c.pendingNeeded = needed
-	c.pendingAttachments = make([][]byte, 0, needed)
+	// needed comes straight off the wire (the parser accepts up to an 18-digit
+	// count), so it must not be used directly as a slice capacity: a malformed
+	// or hostile header such as "599999999999999999-[...]" would make
+	// make([][]byte, 0, needed) panic ("cap out of range") or attempt a huge
+	// allocation — a remotely triggerable crash. Cap the preallocation; the
+	// slice still grows via append as real attachment frames arrive, and
+	// pendingNeeded keeps the true completion target.
+	prealloc := needed
+	if prealloc > maxPreallocAttachments {
+		prealloc = maxPreallocAttachments
+	}
+	c.pendingAttachments = make([][]byte, 0, prealloc)
 	c.binaryMu.Unlock()
 	return true
 }
+
+// maxPreallocAttachments bounds the capacity preallocated for a staged binary
+// message's attachments, decoupling the allocation from the untrusted on-the-wire
+// attachment count. Real Socket.IO messages carry only a handful of attachments,
+// so this is never a limit in practice.
+const maxPreallocAttachments = 64
 
 // onBinaryAttachment collects a binary attachment frame and, once the staged
 // header has received all of its expected attachments, reconstructs and

--- a/socket.io/v5/client/handlers.go
+++ b/socket.io/v5/client/handlers.go
@@ -61,15 +61,24 @@ func (c *Client) stageBinary(msg *socketio_v5.Message) bool {
 		}
 		return false
 	}
+	// needed is the completion target taken straight off the wire (the parser
+	// accepts up to an 18-digit count). Reject an unrealistic count: it not only
+	// can't be used as a slice capacity, it must not become pendingNeeded either —
+	// otherwise onBinaryAttachment would keep copying and retaining every frame a
+	// hostile peer streams toward a target that never arrives, pinning unbounded
+	// memory. No realistic Socket.IO event carries this many attachments, so drop
+	// the message without staging.
+	if needed > maxBinaryAttachments {
+		c.clearPendingLocked()
+		c.binaryMu.Unlock()
+		c.logger.Errorf("binary header declares %d attachments, exceeding the maximum of %d; dropping message", needed, maxBinaryAttachments)
+		return true
+	}
 	c.pendingBinary = msg
 	c.pendingNeeded = needed
-	// needed comes straight off the wire (the parser accepts up to an 18-digit
-	// count), so it must not be used directly as a slice capacity: a malformed
-	// or hostile header such as "599999999999999999-[...]" would make
-	// make([][]byte, 0, needed) panic ("cap out of range") or attempt a huge
-	// allocation — a remotely triggerable crash. Cap the preallocation; the
-	// slice still grows via append as real attachment frames arrive, and
-	// pendingNeeded keeps the true completion target.
+	// Bound the preallocation independently: even a within-limit count should not
+	// be trusted as an exact capacity hint. The slice still grows via append as
+	// real attachment frames arrive.
 	prealloc := needed
 	if prealloc > maxPreallocAttachments {
 		prealloc = maxPreallocAttachments
@@ -79,11 +88,21 @@ func (c *Client) stageBinary(msg *socketio_v5.Message) bool {
 	return true
 }
 
-// maxPreallocAttachments bounds the capacity preallocated for a staged binary
-// message's attachments, decoupling the allocation from the untrusted on-the-wire
-// attachment count. Real Socket.IO messages carry only a handful of attachments,
-// so this is never a limit in practice.
-const maxPreallocAttachments = 64
+const (
+	// maxBinaryAttachments bounds the attachment count a binary header may declare.
+	// The count is the completion target the client collects toward, so an
+	// unrealistic wire value would let a hostile peer pin unbounded memory by
+	// streaming frames that never reach the target. No legitimate Socket.IO event
+	// carries anywhere near this many []byte payloads, so it never trips in
+	// practice while rejecting absurd counts (e.g. an 18-digit header).
+	maxBinaryAttachments = 1 << 16
+
+	// maxPreallocAttachments bounds the capacity preallocated for a staged binary
+	// message's attachments, decoupling the allocation from the (now range-checked)
+	// on-the-wire attachment count. Real Socket.IO messages carry only a handful of
+	// attachments, so this is never a limit in practice.
+	maxPreallocAttachments = 64
+)
 
 // onBinaryAttachment collects a binary attachment frame and, once the staged
 // header has received all of its expected attachments, reconstructs and

--- a/socket.io/v5/client/mocks/deps.go
+++ b/socket.io/v5/client/mocks/deps.go
@@ -36,6 +36,20 @@ func (m *MockParser) EXPECT() *MockParserMockRecorder {
 	return m.recorder
 }
 
+// HasBinary mocks base method.
+func (m *MockParser) HasBinary(event *socketio_v5.Event) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasBinary", event)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasBinary indicates an expected call of HasBinary.
+func (mr *MockParserMockRecorder) HasBinary(event interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasBinary", reflect.TypeOf((*MockParser)(nil).HasBinary), event)
+}
+
 // Parse mocks base method.
 func (m *MockParser) Parse(arg0 []byte) (*socketio_v5.Message, error) {
 	m.ctrl.T.Helper()
@@ -51,6 +65,20 @@ func (mr *MockParserMockRecorder) Parse(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Parse", reflect.TypeOf((*MockParser)(nil).Parse), arg0)
 }
 
+// ReconstructBinary mocks base method.
+func (m *MockParser) ReconstructBinary(msg *socketio_v5.Message, attachments [][]byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReconstructBinary", msg, attachments)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReconstructBinary indicates an expected call of ReconstructBinary.
+func (mr *MockParserMockRecorder) ReconstructBinary(msg, attachments interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconstructBinary", reflect.TypeOf((*MockParser)(nil).ReconstructBinary), msg, attachments)
+}
+
 // Serialize mocks base method.
 func (m *MockParser) Serialize(arg0 *socketio_v5.Message) ([]byte, error) {
 	m.ctrl.T.Helper()
@@ -64,6 +92,22 @@ func (m *MockParser) Serialize(arg0 *socketio_v5.Message) ([]byte, error) {
 func (mr *MockParserMockRecorder) Serialize(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Serialize", reflect.TypeOf((*MockParser)(nil).Serialize), arg0)
+}
+
+// SerializeBinary mocks base method.
+func (m *MockParser) SerializeBinary(arg0 *socketio_v5.Message) ([]byte, [][]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SerializeBinary", arg0)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].([][]byte)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// SerializeBinary indicates an expected call of SerializeBinary.
+func (mr *MockParserMockRecorder) SerializeBinary(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SerializeBinary", reflect.TypeOf((*MockParser)(nil).SerializeBinary), arg0)
 }
 
 // WrapCallback mocks base method.
@@ -155,6 +199,20 @@ func (m *MockEngineIOClient) Send(message []byte) error {
 func (mr *MockEngineIOClientMockRecorder) Send(message interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockEngineIOClient)(nil).Send), message)
+}
+
+// SendBinary mocks base method.
+func (m *MockEngineIOClient) SendBinary(message []byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendBinary", message)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendBinary indicates an expected call of SendBinary.
+func (mr *MockEngineIOClientMockRecorder) SendBinary(message interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendBinary", reflect.TypeOf((*MockEngineIOClient)(nil).SendBinary), message)
 }
 
 // MockLogger is a mock of Logger interface.

--- a/socket.io/v5/parser/default/binary.go
+++ b/socket.io/v5/parser/default/binary.go
@@ -4,9 +4,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 
 	socketio_v5 "github.com/maldikhan/go.socket.io/socket.io/v5"
 )
+
+// maxBinaryScanDepth bounds the recursion of valueHasBinary so a pathological or
+// cyclic structure (e.g. a struct that points back at itself through a pointer or
+// interface) can never make HasBinary hang or overflow the stack. Real payloads
+// are far shallower than this, so the bound never trips for legitimate data.
+const maxBinaryScanDepth = 100
 
 // ErrParseBinary is returned when binary attachments cannot be reconciled with
 // the placeholders found in a PacketBinaryEvent/PacketBinaryAck payload.
@@ -126,9 +133,15 @@ func (p *SocketIOV5DefaultParser) HasBinary(event *socketio_v5.Event) bool {
 }
 
 // valueHasBinary reports whether a payload value contains any []byte, searching
-// nested slices and maps so binary buffers placed inside structures are found.
+// nested slices, maps AND struct fields (including through pointers and
+// interfaces) so binary buffers placed anywhere reachable inside a Go value are
+// found. This is what lets Emit("upload", struct{ File []byte }{...}) be encoded
+// as a real binary packet instead of base64-stringifying the bytes.
 func valueHasBinary(value interface{}) bool {
+	// Fast paths for the common, already-decoded shapes avoid the reflect cost.
 	switch v := value.(type) {
+	case nil:
+		return false
 	case []byte:
 		return true
 	case map[string]interface{}:
@@ -137,12 +150,73 @@ func valueHasBinary(value interface{}) bool {
 				return true
 			}
 		}
+		return false
 	case []interface{}:
 		for _, item := range v {
 			if valueHasBinary(item) {
 				return true
 			}
 		}
+		return false
+	}
+	return reflectHasBinary(reflect.ValueOf(value), maxBinaryScanDepth)
+}
+
+// reflectHasBinary walks an arbitrary reflect.Value looking for a []byte leaf.
+// depth bounds the recursion to guard against cyclic structures reached via
+// pointers/interfaces. A []byte is the binary leaf (Slice of Uint8); any other
+// slice/array is recursed into element by element.
+func reflectHasBinary(rv reflect.Value, depth int) bool {
+	if depth <= 0 || !rv.IsValid() {
+		return false
+	}
+
+	switch rv.Kind() {
+	case reflect.Ptr, reflect.Interface:
+		if rv.IsNil() {
+			return false
+		}
+		return reflectHasBinary(rv.Elem(), depth-1)
+	case reflect.Slice:
+		// []byte is the binary leaf; anything else is a slice to descend into.
+		if rv.Type().Elem().Kind() == reflect.Uint8 {
+			return true
+		}
+		for i := 0; i < rv.Len(); i++ {
+			if reflectHasBinary(rv.Index(i), depth-1) {
+				return true
+			}
+		}
+		return false
+	case reflect.Array:
+		// A [N]byte array is not a Socket.IO binary attachment (only []byte is),
+		// so arrays are always descended into element by element.
+		for i := 0; i < rv.Len(); i++ {
+			if reflectHasBinary(rv.Index(i), depth-1) {
+				return true
+			}
+		}
+		return false
+	case reflect.Map:
+		for _, key := range rv.MapKeys() {
+			if reflectHasBinary(rv.MapIndex(key), depth-1) {
+				return true
+			}
+		}
+		return false
+	case reflect.Struct:
+		t := rv.Type()
+		for i := 0; i < rv.NumField(); i++ {
+			// Only exported fields are readable by reflect and marshalable by
+			// encoding/json; unexported fields can never become attachments.
+			if t.Field(i).PkgPath != "" {
+				continue
+			}
+			if reflectHasBinary(rv.Field(i), depth-1) {
+				return true
+			}
+		}
+		return false
 	}
 	return false
 }
@@ -150,7 +224,10 @@ func valueHasBinary(value interface{}) bool {
 // extractBinary walks a payload value and replaces every []byte with a
 // {"_placeholder":true,"num":N} marker, appending the buffer to *attachments in
 // the order encountered. The returned value is safe to JSON-marshal as the
-// binary event header. Nested slices and maps are traversed.
+// binary event header. Nested slices and maps are traversed; arbitrary structs,
+// pointers and typed containers are handled via reflection so binary inside a
+// Go struct (e.g. struct{ File []byte }) becomes a real attachment rather than
+// a base64 string.
 func extractBinary(value interface{}, attachments *[][]byte) interface{} {
 	switch v := value.(type) {
 	case []byte:
@@ -169,9 +246,114 @@ func extractBinary(value interface{}, attachments *[][]byte) interface{} {
 			out[i] = extractBinary(item, attachments)
 		}
 		return out
+	case nil:
+		return nil
 	default:
-		return value
+		return reflectExtractBinary(reflect.ValueOf(value), attachments, maxBinaryScanDepth)
 	}
+}
+
+// reflectExtractBinary mirrors extractBinary for arbitrary Go values reached via
+// reflection. It returns a JSON-marshalable tree (maps/slices/scalars) with every
+// []byte replaced by a placeholder and appended to *attachments. Values that
+// cannot contain binary (or once the depth bound is hit) are returned via their
+// interface{} so encoding/json serializes them normally. Only exported struct
+// fields are emitted, matching encoding/json and valueHasBinary.
+func reflectExtractBinary(rv reflect.Value, attachments *[][]byte, depth int) interface{} {
+	if !rv.IsValid() {
+		return nil
+	}
+	if depth <= 0 {
+		return rv.Interface()
+	}
+
+	switch rv.Kind() {
+	case reflect.Ptr, reflect.Interface:
+		if rv.IsNil() {
+			return rv.Interface()
+		}
+		return reflectExtractBinary(rv.Elem(), attachments, depth-1)
+	case reflect.Slice:
+		if rv.Type().Elem().Kind() == reflect.Uint8 {
+			// []byte leaf -> attachment + placeholder.
+			buf := rv.Bytes()
+			num := len(*attachments)
+			*attachments = append(*attachments, buf)
+			return map[string]interface{}{"_placeholder": true, "num": num}
+		}
+		out := make([]interface{}, rv.Len())
+		for i := 0; i < rv.Len(); i++ {
+			out[i] = reflectExtractBinary(rv.Index(i), attachments, depth-1)
+		}
+		return out
+	case reflect.Array:
+		out := make([]interface{}, rv.Len())
+		for i := 0; i < rv.Len(); i++ {
+			out[i] = reflectExtractBinary(rv.Index(i), attachments, depth-1)
+		}
+		return out
+	case reflect.Map:
+		out := make(map[string]interface{}, rv.Len())
+		for _, key := range rv.MapKeys() {
+			out[mapKeyString(key)] = reflectExtractBinary(rv.MapIndex(key), attachments, depth-1)
+		}
+		return out
+	case reflect.Struct:
+		t := rv.Type()
+		out := make(map[string]interface{}, rv.NumField())
+		for i := 0; i < rv.NumField(); i++ {
+			field := t.Field(i)
+			if field.PkgPath != "" {
+				continue // unexported
+			}
+			name, omit := jsonFieldName(field)
+			if omit {
+				continue
+			}
+			out[name] = reflectExtractBinary(rv.Field(i), attachments, depth-1)
+		}
+		return out
+	default:
+		return rv.Interface()
+	}
+}
+
+// mapKeyString renders a map key as a JSON object key. encoding/json requires
+// map keys to be strings (or types implementing TextMarshaler / integer kinds);
+// fmt.Sprint reproduces the string and integer renderings json uses, which is
+// all that is needed to carry binary placeholders out of a typed map.
+func mapKeyString(key reflect.Value) string {
+	return fmt.Sprint(key.Interface())
+}
+
+// jsonFieldName returns the JSON object key for a struct field, honoring a
+// `json:"name,options"` tag. A `json:"-"` tag omits the field (the obscure
+// `json:"-,"` literal-dash form is not supported; it is vanishingly rare and not
+// needed for binary payloads). An empty tag name falls back to the field name.
+func jsonFieldName(field reflect.StructField) (string, bool) {
+	tag := field.Tag.Get("json")
+	if tag == "-" {
+		return "", true
+	}
+	name := tag
+	if comma := indexComma(tag); comma >= 0 {
+		name = tag[:comma]
+	}
+	if name == "" {
+		return field.Name, false
+	}
+	return name, false
+}
+
+// indexComma returns the index of the first comma in s, or -1. (Avoids pulling
+// in strings just for this; keeps the helper trivially Go 1.18 compatible.)
+func indexComma(s string) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == ',' {
+			return i
+		}
+	}
+	return -1
 }
 
 // SerializeBinary encodes a message whose event payloads contain binary data as

--- a/socket.io/v5/parser/default/binary.go
+++ b/socket.io/v5/parser/default/binary.go
@@ -1,0 +1,221 @@
+package socketio_v5_parser_default
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	socketio_v5 "github.com/maldikhan/go.socket.io/socket.io/v5"
+)
+
+// ErrParseBinary is returned when binary attachments cannot be reconciled with
+// the placeholders found in a PacketBinaryEvent/PacketBinaryAck payload.
+var ErrParseBinary = errors.New("parse binary error")
+
+// ReconstructBinary replaces every {"_placeholder":true,"num":N} marker in the
+// message's event payloads with attachments[N], exposing the binary data as
+// []byte. It must be called once all expected attachments (msg.BinaryAttachments)
+// have been collected. On success BinaryAttachments is cleared so the message is
+// indistinguishable from a fully decoded event.
+func (p *SocketIOV5DefaultParser) ReconstructBinary(msg *socketio_v5.Message, attachments [][]byte) error {
+	if msg == nil {
+		return fmt.Errorf("%w: %v", ErrParseBinary, errors.New("empty package"))
+	}
+	expected := 0
+	if msg.BinaryAttachments != nil {
+		expected = *msg.BinaryAttachments
+	}
+	if len(attachments) != expected {
+		return fmt.Errorf("%w: expected %d attachments, got %d", ErrParseBinary, expected, len(attachments))
+	}
+	if msg.Event != nil {
+		for i, payload := range msg.Event.Payloads {
+			raw, ok := payload.(json.RawMessage)
+			if !ok {
+				// Already-decoded payloads (e.g. a custom payload parser) are left
+				// untouched; only raw JSON can contain placeholders.
+				continue
+			}
+			var decoded interface{}
+			if err := json.Unmarshal(raw, &decoded); err != nil {
+				return fmt.Errorf("%w: %v", ErrParseBinary, err)
+			}
+			replaced, err := replacePlaceholders(decoded, attachments)
+			if err != nil {
+				return err
+			}
+			msg.Event.Payloads[i] = replaced
+		}
+	}
+	msg.BinaryAttachments = nil
+	return nil
+}
+
+// replacePlaceholders walks a decoded JSON value and substitutes any placeholder
+// object with the matching binary attachment ([]byte). Nested arrays and objects
+// are traversed so attachments inside structures are reconstructed too.
+func replacePlaceholders(value interface{}, attachments [][]byte) (interface{}, error) {
+	switch v := value.(type) {
+	case map[string]interface{}:
+		if buf, ok, err := asPlaceholder(v, attachments); err != nil {
+			return nil, err
+		} else if ok {
+			return buf, nil
+		}
+		for key, item := range v {
+			replaced, err := replacePlaceholders(item, attachments)
+			if err != nil {
+				return nil, err
+			}
+			v[key] = replaced
+		}
+		return v, nil
+	case []interface{}:
+		for i, item := range v {
+			replaced, err := replacePlaceholders(item, attachments)
+			if err != nil {
+				return nil, err
+			}
+			v[i] = replaced
+		}
+		return v, nil
+	default:
+		return value, nil
+	}
+}
+
+// asPlaceholder reports whether m is a binary placeholder and, if so, returns
+// the attachment it points at. It returns ok == false for ordinary objects.
+func asPlaceholder(m map[string]interface{}, attachments [][]byte) ([]byte, bool, error) {
+	flag, hasFlag := m["_placeholder"]
+	if !hasFlag {
+		return nil, false, nil
+	}
+	isPlaceholder, _ := flag.(bool)
+	if !isPlaceholder {
+		return nil, false, nil
+	}
+	numValue, hasNum := m["num"]
+	if !hasNum {
+		return nil, false, fmt.Errorf("%w: %v", ErrParseBinary, errors.New("placeholder without num"))
+	}
+	num, ok := numValue.(float64)
+	if !ok {
+		return nil, false, fmt.Errorf("%w: %v", ErrParseBinary, errors.New("placeholder num is not a number"))
+	}
+	idx := int(num)
+	if idx < 0 || idx >= len(attachments) {
+		return nil, false, fmt.Errorf("%w: placeholder index %d out of range", ErrParseBinary, idx)
+	}
+	return attachments[idx], true, nil
+}
+
+// HasBinary reports whether the event carries any []byte payload that requires
+// a PacketBinaryEvent/PacketBinaryAck encoding. Callers use it to decide between
+// Serialize (text) and SerializeBinary.
+func (p *SocketIOV5DefaultParser) HasBinary(event *socketio_v5.Event) bool {
+	if event == nil {
+		return false
+	}
+	for _, payload := range event.Payloads {
+		if valueHasBinary(payload) {
+			return true
+		}
+	}
+	return false
+}
+
+// valueHasBinary reports whether a payload value contains any []byte, searching
+// nested slices and maps so binary buffers placed inside structures are found.
+func valueHasBinary(value interface{}) bool {
+	switch v := value.(type) {
+	case []byte:
+		return true
+	case map[string]interface{}:
+		for _, item := range v {
+			if valueHasBinary(item) {
+				return true
+			}
+		}
+	case []interface{}:
+		for _, item := range v {
+			if valueHasBinary(item) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// extractBinary walks a payload value and replaces every []byte with a
+// {"_placeholder":true,"num":N} marker, appending the buffer to *attachments in
+// the order encountered. The returned value is safe to JSON-marshal as the
+// binary event header. Nested slices and maps are traversed.
+func extractBinary(value interface{}, attachments *[][]byte) interface{} {
+	switch v := value.(type) {
+	case []byte:
+		num := len(*attachments)
+		*attachments = append(*attachments, v)
+		return map[string]interface{}{"_placeholder": true, "num": num}
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(v))
+		for key, item := range v {
+			out[key] = extractBinary(item, attachments)
+		}
+		return out
+	case []interface{}:
+		out := make([]interface{}, len(v))
+		for i, item := range v {
+			out[i] = extractBinary(item, attachments)
+		}
+		return out
+	default:
+		return value
+	}
+}
+
+// SerializeBinary encodes a message whose event payloads contain binary data as
+// a PacketBinaryEvent/PacketBinaryAck. It returns the header packet (with the
+// attachment count and {"_placeholder"} markers) and the ordered list of binary
+// attachments to send as separate frames after the header.
+func (p *SocketIOV5DefaultParser) SerializeBinary(msg *socketio_v5.Message) ([]byte, [][]byte, error) {
+	if msg == nil || msg.Event == nil {
+		return nil, nil, fmt.Errorf("%w: %v", ErrParseBinary, errors.New("empty event"))
+	}
+
+	// Map the requested text type onto its binary counterpart so callers may
+	// pass either PacketEvent/PacketAck or the binary variants.
+	var binaryType socketio_v5.SocketIOPacket
+	switch msg.Type {
+	case socketio_v5.PacketEvent, socketio_v5.PacketBinaryEvent:
+		binaryType = socketio_v5.PacketBinaryEvent
+	case socketio_v5.PacketAck, socketio_v5.PacketBinaryAck:
+		binaryType = socketio_v5.PacketBinaryAck
+	default:
+		return nil, nil, fmt.Errorf("%w: %v", ErrParseBinary, errors.New("not an event or ack"))
+	}
+
+	var attachments [][]byte
+	placeholders := make([]interface{}, len(msg.Event.Payloads))
+	for i, payload := range msg.Event.Payloads {
+		placeholders[i] = extractBinary(payload, &attachments)
+	}
+
+	count := len(attachments)
+	headerMsg := &socketio_v5.Message{
+		Type:              binaryType,
+		BinaryAttachments: &count,
+		NS:                msg.NS,
+		AckId:             msg.AckId,
+		Event: &socketio_v5.Event{
+			Name:     msg.Event.Name,
+			Payloads: placeholders,
+		},
+	}
+
+	header, err := p.serializeHeader(headerMsg)
+	if err != nil {
+		return nil, nil, err
+	}
+	return header, attachments, nil
+}

--- a/socket.io/v5/parser/default/binary.go
+++ b/socket.io/v5/parser/default/binary.go
@@ -207,12 +207,12 @@ func reflectHasBinary(rv reflect.Value, depth int) bool {
 	// its bytes go out via that marshaler (e.g. time.Time, json.RawMessage), never
 	// as a binary attachment. For Interface kind rv.Type() is the interface itself
 	// (no marshaler) and the concrete type is re-checked after the deref below.
-	if implementsMarshaler(rv.Type()) {
+	if ownsEncoding(rv) {
 		return false
 	}
 
 	switch rv.Kind() {
-	case reflect.Ptr, reflect.Interface:
+	case reflect.Pointer, reflect.Interface:
 		if rv.IsNil() {
 			return false
 		}
@@ -263,21 +263,30 @@ func reflectHasBinary(rv reflect.Value, depth int) bool {
 	return false
 }
 
-// implementsMarshaler reports whether t controls its own JSON or text encoding via
-// json.Marshaler / encoding.TextMarshaler, on EITHER a value or a pointer receiver.
-// The pointer-receiver case matters because encoding/json invokes a pointer
-// marshaler for the addressable values it builds (slice/array elements, addressable
-// struct fields). If we descended into such a value and swapped its []byte for a
-// sentinel, the marshaler would encode the sentinel bytes itself (e.g. as hex) and
-// never emit the base64 needle splicePlaceholders looks for — corrupting the output
-// and leaving an orphan attachment. Treating these types as owning their encoding
-// keeps the binary path byte-for-byte consistent with the text path for them.
-func implementsMarshaler(t reflect.Type) bool {
+// ownsEncoding reports whether rv controls its own JSON or text encoding via
+// json.Marshaler / encoding.TextMarshaler, in which case its bytes are emitted by
+// that marshaler (e.g. time.Time, json.RawMessage) and must never be lifted into a
+// binary attachment.
+//
+// A value-receiver marshaler always owns its encoding. A type that implements the
+// marshaler only on its POINTER receiver is honored by encoding/json ONLY when the
+// value is addressable — slice/array elements, addressable struct fields, pointer
+// derefs. For a non-addressable value held in an interface{} (a top-level Emit
+// payload, a map value) json ignores the pointer marshaler and encodes the exported
+// fields instead, so we must descend to find binary there rather than treat it as
+// marshaler-owned. rv.CanAddr() mirrors that rule exactly, because
+// reflectHasBinary/transformBinary recurse over the original values whose
+// addressability matches what encoding/json sees.
+func ownsEncoding(rv reflect.Value) bool {
+	t := rv.Type()
 	if t.Implements(jsonMarshalerType) || t.Implements(textMarshalerType) {
 		return true
 	}
-	pt := reflect.PtrTo(t)
-	return pt.Implements(jsonMarshalerType) || pt.Implements(textMarshalerType)
+	if rv.CanAddr() {
+		pt := reflect.PointerTo(t)
+		return pt.Implements(jsonMarshalerType) || pt.Implements(textMarshalerType)
+	}
+	return false
 }
 
 // extractBinary returns a JSON-marshalable representation of one event payload in
@@ -322,7 +331,7 @@ func transformBinary(rv reflect.Value, attachments *[][]byte, sentinels map[stri
 	}
 
 	switch rv.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		np := reflect.New(rv.Type().Elem())
 		np.Elem().Set(transformBinary(rv.Elem(), attachments, sentinels, nonce, depth-1))
 		return np
@@ -442,7 +451,7 @@ func isEmptyValue(v reflect.Value) bool {
 		return v.Uint() == 0
 	case reflect.Float32, reflect.Float64:
 		return v.Float() == 0
-	case reflect.Interface, reflect.Ptr:
+	case reflect.Interface, reflect.Pointer:
 		return v.IsNil()
 	}
 	return false

--- a/socket.io/v5/parser/default/binary.go
+++ b/socket.io/v5/parser/default/binary.go
@@ -267,11 +267,26 @@ func reflectExtractBinary(rv reflect.Value, attachments *[][]byte, depth int) in
 		return rv.Interface()
 	}
 
+	// Only hand-serialize subtrees that actually contain a []byte. Anything with
+	// no binary inside is returned via its interface{} so encoding/json renders
+	// it natively, preserving custom json.Marshaler implementations, `json:"..."`
+	// tags, omitempty and embedded fields. This is why a struct{ File []byte; T
+	// time.Time } keeps T as its RFC3339 string instead of the empty object a
+	// blind field-by-field reflection walk would produce. (A []byte leaf reports
+	// true here and falls through to the Slice case below.)
+	if !reflectHasBinary(rv, depth) {
+		return rv.Interface()
+	}
+
+	// Past the guard, rv is known to contain a []byte, so its kind is necessarily
+	// a container: Ptr/Interface (wrapper), Slice/Array/Map, or Struct. Scalars
+	// can never hold binary and have already returned above, so there is no
+	// "default" path to reach here. Struct is handled after the switch as the
+	// remaining container kind.
 	switch rv.Kind() {
 	case reflect.Ptr, reflect.Interface:
-		if rv.IsNil() {
-			return rv.Interface()
-		}
+		// Non-nil: a nil pointer/interface cannot contain binary and was returned
+		// by the guard above.
 		return reflectExtractBinary(rv.Elem(), attachments, depth-1)
 	case reflect.Slice:
 		if rv.Type().Elem().Kind() == reflect.Uint8 {
@@ -298,24 +313,25 @@ func reflectExtractBinary(rv reflect.Value, attachments *[][]byte, depth int) in
 			out[mapKeyString(key)] = reflectExtractBinary(rv.MapIndex(key), attachments, depth-1)
 		}
 		return out
-	case reflect.Struct:
-		t := rv.Type()
-		out := make(map[string]interface{}, rv.NumField())
-		for i := 0; i < rv.NumField(); i++ {
-			field := t.Field(i)
-			if field.PkgPath != "" {
-				continue // unexported
-			}
-			name, omit := jsonFieldName(field)
-			if omit {
-				continue
-			}
-			out[name] = reflectExtractBinary(rv.Field(i), attachments, depth-1)
-		}
-		return out
-	default:
-		return rv.Interface()
 	}
+
+	// Remaining binary-bearing kind: struct. Only exported fields are emitted,
+	// and each field is recursed so a binary-free field (e.g. time.Time) is
+	// returned via the guard and rendered natively by encoding/json.
+	t := rv.Type()
+	out := make(map[string]interface{}, rv.NumField())
+	for i := 0; i < rv.NumField(); i++ {
+		field := t.Field(i)
+		if field.PkgPath != "" {
+			continue // unexported
+		}
+		name, omit := jsonFieldName(field)
+		if omit {
+			continue
+		}
+		out[name] = reflectExtractBinary(rv.Field(i), attachments, depth-1)
+	}
+	return out
 }
 
 // mapKeyString renders a map key as a JSON object key. encoding/json requires

--- a/socket.io/v5/parser/default/binary.go
+++ b/socket.io/v5/parser/default/binary.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"sort"
 
 	socketio_v5 "github.com/maldikhan/go.socket.io/socket.io/v5"
 )
@@ -327,23 +328,26 @@ func extractBinary(value interface{}, attachments *[][]byte) (interface{}, error
 	if _, err := randRead(nonce); err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrParseBinary, err)
 	}
-	sentinels := make(map[string]int)
-	transformed := transformBinary(reflect.ValueOf(value), attachments, sentinels, nonce, maxBinaryScanDepth)
+	sentinels := make(map[string][]byte)
+	transformed := transformBinary(reflect.ValueOf(value), sentinels, nonce, maxBinaryScanDepth)
 	data, err := json.Marshal(transformed.Interface())
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrParseBinary, err)
 	}
-	return json.RawMessage(splicePlaceholders(data, sentinels)), nil
+	return json.RawMessage(splicePlaceholders(data, sentinels, attachments)), nil
 }
 
 // transformBinary returns a value of the SAME type as rv in which every []byte on
 // a binary-bearing path is replaced by a unique sentinel slice; each sentinel's
-// base64 rendering is recorded in sentinels (keyed to its attachment index) and
-// the original bytes are appended to *attachments. Subtrees with no binary (or
-// whose type owns its encoding, or once the depth bound is hit) are returned
-// unchanged and shared with the original — they are never mutated, because only
-// freshly built containers are ever written to.
-func transformBinary(rv reflect.Value, attachments *[][]byte, sentinels map[string]int, nonce []byte, depth int) reflect.Value {
+// base64 rendering is recorded in sentinels mapped to the original bytes. The
+// attachment list and placeholder numbering are NOT assigned here — they are
+// finalized by splicePlaceholders against the marshaled output, so a sentinel
+// whose field encoding/json ends up dropping (e.g. a json tag/name conflict)
+// never becomes an orphan attachment. Subtrees with no binary (or whose type owns
+// its encoding, or once the depth bound is hit) are returned unchanged and shared
+// with the original — they are never mutated, because only freshly built
+// containers are ever written to.
+func transformBinary(rv reflect.Value, sentinels map[string][]byte, nonce []byte, depth int) reflect.Value {
 	if depth <= 0 || !rv.IsValid() || !reflectHasBinary(rv, depth) {
 		return rv
 	}
@@ -351,31 +355,31 @@ func transformBinary(rv reflect.Value, attachments *[][]byte, sentinels map[stri
 	switch rv.Kind() {
 	case reflect.Pointer:
 		np := reflect.New(rv.Type().Elem())
-		np.Elem().Set(transformBinary(rv.Elem(), attachments, sentinels, nonce, depth-1))
+		np.Elem().Set(transformBinary(rv.Elem(), sentinels, nonce, depth-1))
 		return np
 	case reflect.Interface:
 		out := reflect.New(rv.Type()).Elem()
-		out.Set(transformBinary(rv.Elem(), attachments, sentinels, nonce, depth-1))
+		out.Set(transformBinary(rv.Elem(), sentinels, nonce, depth-1))
 		return out
 	case reflect.Slice:
 		if rv.Type().Elem().Kind() == reflect.Uint8 {
-			return sentinelSlice(rv, attachments, sentinels, nonce)
+			return sentinelSlice(rv, sentinels, nonce)
 		}
 		ns := reflect.MakeSlice(rv.Type(), rv.Len(), rv.Len())
 		for i := 0; i < rv.Len(); i++ {
-			ns.Index(i).Set(transformBinary(rv.Index(i), attachments, sentinels, nonce, depth-1))
+			ns.Index(i).Set(transformBinary(rv.Index(i), sentinels, nonce, depth-1))
 		}
 		return ns
 	case reflect.Array:
 		na := reflect.New(rv.Type()).Elem()
 		for i := 0; i < rv.Len(); i++ {
-			na.Index(i).Set(transformBinary(rv.Index(i), attachments, sentinels, nonce, depth-1))
+			na.Index(i).Set(transformBinary(rv.Index(i), sentinels, nonce, depth-1))
 		}
 		return na
 	case reflect.Map:
 		nm := reflect.MakeMap(rv.Type())
 		for _, key := range rv.MapKeys() {
-			nm.SetMapIndex(key, transformBinary(rv.MapIndex(key), attachments, sentinels, nonce, depth-1))
+			nm.SetMapIndex(key, transformBinary(rv.MapIndex(key), sentinels, nonce, depth-1))
 		}
 		return nm
 	}
@@ -400,25 +404,26 @@ func transformBinary(rv reflect.Value, attachments *[][]byte, sentinels map[stri
 		if omitempty && isEmptyValue(fv) {
 			continue
 		}
-		ns.Field(i).Set(transformBinary(fv, attachments, sentinels, nonce, depth-1))
+		ns.Field(i).Set(transformBinary(fv, sentinels, nonce, depth-1))
 	}
 	return ns
 }
 
-// sentinelSlice records rv's bytes as the next attachment and returns a same-typed
-// slice holding a unique sentinel. encoding/json renders the sentinel as a base64
-// string, which splicePlaceholders then rewrites into the placeholder object.
-func sentinelSlice(rv reflect.Value, attachments *[][]byte, sentinels map[string]int, nonce []byte) reflect.Value {
+// sentinelSlice records rv's bytes under a unique sentinel and returns a
+// same-typed slice holding that sentinel. encoding/json renders the sentinel as a
+// base64 string, which splicePlaceholders then rewrites into the placeholder
+// object (and only then assigns the attachment its index). The per-serialization
+// index is the current sentinel count, which (with the random nonce) keeps every
+// sentinel — and thus its base64 needle — unique.
+func sentinelSlice(rv reflect.Value, sentinels map[string][]byte, nonce []byte) reflect.Value {
 	orig := rv.Bytes()
 	buf := make([]byte, len(orig))
 	copy(buf, orig)
-	num := len(*attachments)
-	*attachments = append(*attachments, buf)
 
-	// num is a slice length, hence always non-negative; the conversion to the
-	// fixed-width index is safe (no overflow/sign change).
-	sentinel := makeSentinel(nonce, uint64(num))
-	sentinels[base64.StdEncoding.EncodeToString(sentinel)] = num
+	// len(sentinels) is non-negative, so the conversion to the fixed-width index
+	// is safe (no overflow/sign change).
+	sentinel := makeSentinel(nonce, uint64(len(sentinels)))
+	sentinels[base64.StdEncoding.EncodeToString(sentinel)] = buf
 
 	sv := reflect.ValueOf(sentinel)
 	if rv.Type() == byteSliceType {
@@ -450,12 +455,35 @@ func makeSentinel(nonce []byte, num uint64) []byte {
 	return append(s, idx[:]...)
 }
 
-// splicePlaceholders rewrites each sentinel's base64 JSON string ("<b64>") into a
-// {"_placeholder":true,"num":N} object. Each sentinel is unique, so it appears
-// exactly once.
-func splicePlaceholders(data []byte, sentinels map[string]int) []byte {
-	for b64, num := range sentinels {
-		needle := []byte(`"` + b64 + `"`)
+// splicePlaceholders finalizes the binary attachments for one marshaled payload.
+// It rewrites each sentinel's base64 JSON string ("<b64>") into a
+// {"_placeholder":true,"num":N} object, assigning the surviving sentinels
+// contiguous attachment indices (continuing from the message-wide *attachments)
+// in order of their appearance in data, and appends their bytes to *attachments in
+// the same order. A sentinel whose field encoding/json dropped (e.g. a json
+// tag/name conflict) never appears in data, so it is discarded here rather than
+// left as an orphan attachment with no placeholder — keeping the attachment count,
+// the placeholder numbering, and the bytes consistent. Each sentinel is unique, so
+// it appears at most once.
+func splicePlaceholders(data []byte, sentinels map[string][]byte, attachments *[][]byte) []byte {
+	// Collect the sentinels that actually survived into the marshaled output,
+	// ordered by where they appear so numbering is deterministic.
+	type presentSentinel struct {
+		pos int
+		b64 string
+	}
+	present := make([]presentSentinel, 0, len(sentinels))
+	for b64 := range sentinels {
+		if pos := bytes.Index(data, []byte(`"`+b64+`"`)); pos >= 0 {
+			present = append(present, presentSentinel{pos: pos, b64: b64})
+		}
+	}
+	sort.Slice(present, func(i, j int) bool { return present[i].pos < present[j].pos })
+
+	for _, s := range present {
+		num := len(*attachments)
+		*attachments = append(*attachments, sentinels[s.b64])
+		needle := []byte(`"` + s.b64 + `"`)
 		repl := []byte(fmt.Sprintf(`{"_placeholder":true,"num":%d}`, num))
 		data = bytes.Replace(data, needle, repl, 1)
 	}

--- a/socket.io/v5/parser/default/binary.go
+++ b/socket.io/v5/parser/default/binary.go
@@ -421,12 +421,19 @@ func sentinelSlice(rv reflect.Value, attachments *[][]byte, sentinels map[string
 	sentinels[base64.StdEncoding.EncodeToString(sentinel)] = num
 
 	sv := reflect.ValueOf(sentinel)
-	if rv.Type() != byteSliceType {
-		// Preserve a named []byte type (e.g. type Blob []byte) so the copy stays
-		// assignable to its field/element.
-		sv = sv.Convert(rv.Type())
+	if rv.Type() == byteSliceType {
+		return sv
 	}
-	return sv
+	// rv is a named byte-slice type. A type whose underlying type is []byte
+	// (e.g. type Blob []byte) is convertible from []byte, but a slice of a *named*
+	// uint8 element (e.g. type Octet uint8; []Octet) is NOT — sv.Convert would
+	// panic. Build the same-typed slice element by element instead, which works
+	// for both; encoding/json still renders it as the sentinel's base64 needle.
+	named := reflect.MakeSlice(rv.Type(), len(sentinel), len(sentinel))
+	for i, b := range sentinel {
+		named.Index(i).SetUint(uint64(b))
+	}
+	return named
 }
 
 // makeSentinel builds the unique, marshaling-stable byte token for attachment num:

--- a/socket.io/v5/parser/default/binary.go
+++ b/socket.io/v5/parser/default/binary.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"reflect"
 
 	socketio_v5 "github.com/maldikhan/go.socket.io/socket.io/v5"
@@ -142,11 +143,15 @@ func asPlaceholder(m map[string]interface{}, attachments [][]byte) ([]byte, bool
 	if !ok {
 		return nil, false, fmt.Errorf("%w: %v", ErrParseBinary, errors.New("placeholder num is not a number"))
 	}
-	idx := int(num)
-	if idx < 0 || idx >= len(attachments) {
-		return nil, false, fmt.Errorf("%w: placeholder index %d out of range", ErrParseBinary, idx)
+	// num arrives as a JSON number (float64) straight off the wire. Reject a
+	// fractional, negative, or out-of-range value rather than letting int(num)
+	// silently truncate it (e.g. 1.5 -> 1, substituting the wrong attachment) or
+	// overflow on a huge value and index out of bounds. Comparing as float64
+	// before converting keeps int(num) exact and in range.
+	if num != math.Trunc(num) || num < 0 || num >= float64(len(attachments)) {
+		return nil, false, fmt.Errorf("%w: placeholder num %v is not a valid attachment index", ErrParseBinary, num)
 	}
-	return attachments[idx], true, nil
+	return attachments[int(num)], true, nil
 }
 
 // HasBinary reports whether the event carries any []byte payload that requires

--- a/socket.io/v5/parser/default/binary.go
+++ b/socket.io/v5/parser/default/binary.go
@@ -388,7 +388,9 @@ func sentinelSlice(rv reflect.Value, attachments *[][]byte, sentinels map[string
 	num := len(*attachments)
 	*attachments = append(*attachments, buf)
 
-	sentinel := makeSentinel(nonce, num)
+	// num is a slice length, hence always non-negative; the conversion to the
+	// fixed-width index is safe (no overflow/sign change).
+	sentinel := makeSentinel(nonce, uint64(num))
 	sentinels[base64.StdEncoding.EncodeToString(sentinel)] = num
 
 	sv := reflect.ValueOf(sentinel)
@@ -405,12 +407,12 @@ func sentinelSlice(rv reflect.Value, attachments *[][]byte, sentinels map[string
 // makes the token (and thus its base64 needle) unpredictable to an application
 // payload; the index keeps tokens distinct within one serialization (see
 // sentinelMagic).
-func makeSentinel(nonce []byte, num int) []byte {
+func makeSentinel(nonce []byte, num uint64) []byte {
 	s := make([]byte, 0, len(sentinelMagic)+len(nonce)+8)
 	s = append(s, sentinelMagic...)
 	s = append(s, nonce...)
 	var idx [8]byte
-	binary.BigEndian.PutUint64(idx[:], uint64(num))
+	binary.BigEndian.PutUint64(idx[:], num)
 	return append(s, idx[:]...)
 }
 

--- a/socket.io/v5/parser/default/binary.go
+++ b/socket.io/v5/parser/default/binary.go
@@ -15,6 +15,12 @@ import (
 // are far shallower than this, so the bound never trips for legitimate data.
 const maxBinaryScanDepth = 100
 
+// rawMessageType is json.RawMessage's reflect type. Although it is a []byte
+// under the hood, it carries pre-encoded JSON that must pass through to
+// encoding/json unchanged — it is NOT a Socket.IO binary attachment. It is
+// matched by reflect type (not the []byte fast path, which a named type skips).
+var rawMessageType = reflect.TypeOf(json.RawMessage(nil))
+
 // ErrParseBinary is returned when binary attachments cannot be reconciled with
 // the placeholders found in a PacketBinaryEvent/PacketBinaryAck payload.
 var ErrParseBinary = errors.New("parse binary error")
@@ -178,6 +184,11 @@ func reflectHasBinary(rv reflect.Value, depth int) bool {
 		}
 		return reflectHasBinary(rv.Elem(), depth-1)
 	case reflect.Slice:
+		// json.RawMessage is pre-encoded JSON, not binary, even though it is a
+		// []byte under the hood.
+		if rv.Type() == rawMessageType {
+			return false
+		}
 		// []byte is the binary leaf; anything else is a slice to descend into.
 		if rv.Type().Elem().Kind() == reflect.Uint8 {
 			return true

--- a/socket.io/v5/parser/default/binary.go
+++ b/socket.io/v5/parser/default/binary.go
@@ -602,6 +602,19 @@ func (p *SocketIOV5DefaultParser) SerializeBinary(msg *socketio_v5.Message) ([]b
 			Payloads: placeholders,
 		},
 	}
+	if count == 0 {
+		// HasBinary saw a []byte, but no placeholder survived into the
+		// marshaled payloads (e.g. the only buffer sat in a `json:"-"` field
+		// or was dropped by omitempty). The wire form carries no binary, so
+		// emit the plain EVENT/ACK packet instead of a 0-attachment binary
+		// one — peers should not be asked to reconstruct an empty set.
+		if binaryType == socketio_v5.PacketBinaryEvent {
+			headerMsg.Type = socketio_v5.PacketEvent
+		} else {
+			headerMsg.Type = socketio_v5.PacketAck
+		}
+		headerMsg.BinaryAttachments = nil
+	}
 
 	header, err := p.serializeHeader(headerMsg)
 	if err != nil {

--- a/socket.io/v5/parser/default/binary.go
+++ b/socket.io/v5/parser/default/binary.go
@@ -170,6 +170,19 @@ func (p *SocketIOV5DefaultParser) HasBinary(event *socketio_v5.Event) bool {
 // found. This is what lets Emit("upload", struct{ File []byte }{...}) be encoded
 // as a real binary packet instead of base64-stringifying the bytes.
 func valueHasBinary(value interface{}) bool {
+	return valueHasBinaryDepth(value, maxBinaryScanDepth)
+}
+
+// valueHasBinaryDepth is valueHasBinary with an explicit recursion bound. The
+// depth is threaded through the map/slice fast paths (not just the reflect path)
+// so a self-referential map[string]interface{} / []interface{} — which Emit hands
+// to HasBinary before encoding/json gets a chance to reject the cycle — can never
+// overflow the stack; it simply stops at the bound and reports no binary, exactly
+// as reflectHasBinary does for cyclic structures reached via pointers/interfaces.
+func valueHasBinaryDepth(value interface{}, depth int) bool {
+	if depth <= 0 {
+		return false
+	}
 	// Fast paths for the common, already-decoded shapes avoid the reflect cost.
 	switch v := value.(type) {
 	case nil:
@@ -178,20 +191,20 @@ func valueHasBinary(value interface{}) bool {
 		return true
 	case map[string]interface{}:
 		for _, item := range v {
-			if valueHasBinary(item) {
+			if valueHasBinaryDepth(item, depth-1) {
 				return true
 			}
 		}
 		return false
 	case []interface{}:
 		for _, item := range v {
-			if valueHasBinary(item) {
+			if valueHasBinaryDepth(item, depth-1) {
 				return true
 			}
 		}
 		return false
 	}
-	return reflectHasBinary(reflect.ValueOf(value), maxBinaryScanDepth)
+	return reflectHasBinary(reflect.ValueOf(value), depth)
 }
 
 // reflectHasBinary walks an arbitrary reflect.Value looking for a []byte leaf.

--- a/socket.io/v5/parser/default/binary.go
+++ b/socket.io/v5/parser/default/binary.go
@@ -1,6 +1,9 @@
 package socketio_v5_parser_default
 
 import (
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,11 +18,23 @@ import (
 // are far shallower than this, so the bound never trips for legitimate data.
 const maxBinaryScanDepth = 100
 
-// rawMessageType is json.RawMessage's reflect type. Although it is a []byte
-// under the hood, it carries pre-encoded JSON that must pass through to
-// encoding/json unchanged — it is NOT a Socket.IO binary attachment. It is
-// matched by reflect type (not the []byte fast path, which a named type skips).
-var rawMessageType = reflect.TypeOf(json.RawMessage(nil))
+var (
+	// byteSliceType is the unnamed []byte type, used to tell a plain []byte from a
+	// named alias (e.g. type Blob []byte) so the latter's type is preserved.
+	byteSliceType = reflect.TypeOf([]byte(nil))
+	// jsonMarshalerType / textMarshalerType are the marshaler interfaces. A value
+	// whose type implements either owns its own encoding (e.g. time.Time ->
+	// RFC3339, json.RawMessage -> verbatim), so its bytes are emitted by that
+	// marshaler and are never lifted into Socket.IO binary attachments.
+	jsonMarshalerType = reflect.TypeOf((*json.Marshaler)(nil)).Elem()
+	textMarshalerType = reflect.TypeOf((*interface{ MarshalText() ([]byte, error) })(nil)).Elem()
+)
+
+// sentinelMagic prefixes every binary sentinel slice. Combined with the
+// attachment index it makes each sentinel unique (so its base64 form is a unique
+// needle for splicePlaceholders) and, thanks to the control bytes, astronomically
+// unlikely to collide with real string data in a payload.
+var sentinelMagic = []byte{0x1b, 'S', 'I', 'O', 'B', 'I', 'N', 0x1b}
 
 // ErrParseBinary is returned when binary attachments cannot be reconciled with
 // the placeholders found in a PacketBinaryEvent/PacketBinaryAck payload.
@@ -177,6 +192,14 @@ func reflectHasBinary(rv reflect.Value, depth int) bool {
 		return false
 	}
 
+	// A type that controls its own JSON/text encoding owns its representation;
+	// its bytes go out via that marshaler (e.g. time.Time, json.RawMessage), never
+	// as a binary attachment. For Interface kind rv.Type() is the interface itself
+	// (no marshaler) and the concrete type is re-checked after the deref below.
+	if implementsMarshaler(rv.Type()) {
+		return false
+	}
+
 	switch rv.Kind() {
 	case reflect.Ptr, reflect.Interface:
 		if rv.IsNil() {
@@ -184,12 +207,9 @@ func reflectHasBinary(rv reflect.Value, depth int) bool {
 		}
 		return reflectHasBinary(rv.Elem(), depth-1)
 	case reflect.Slice:
-		// json.RawMessage is pre-encoded JSON, not binary, even though it is a
-		// []byte under the hood.
-		if rv.Type() == rawMessageType {
-			return false
-		}
 		// []byte is the binary leaf; anything else is a slice to descend into.
+		// (json.RawMessage and other marshaler-owned byte slices were already
+		// excluded by the implementsMarshaler check above.)
 		if rv.Type().Elem().Kind() == reflect.Uint8 {
 			return true
 		}
@@ -232,144 +252,199 @@ func reflectHasBinary(rv reflect.Value, depth int) bool {
 	return false
 }
 
-// extractBinary walks a payload value and replaces every []byte with a
-// {"_placeholder":true,"num":N} marker, appending the buffer to *attachments in
-// the order encountered. The returned value is safe to JSON-marshal as the
-// binary event header. Nested slices and maps are traversed; arbitrary structs,
-// pointers and typed containers are handled via reflection so binary inside a
-// Go struct (e.g. struct{ File []byte }) becomes a real attachment rather than
-// a base64 string.
-func extractBinary(value interface{}, attachments *[][]byte) interface{} {
-	switch v := value.(type) {
-	case []byte:
-		num := len(*attachments)
-		*attachments = append(*attachments, v)
-		return map[string]interface{}{"_placeholder": true, "num": num}
-	case map[string]interface{}:
-		out := make(map[string]interface{}, len(v))
-		for key, item := range v {
-			out[key] = extractBinary(item, attachments)
-		}
-		return out
-	case []interface{}:
-		out := make([]interface{}, len(v))
-		for i, item := range v {
-			out[i] = extractBinary(item, attachments)
-		}
-		return out
-	case nil:
-		return nil
-	default:
-		return reflectExtractBinary(reflect.ValueOf(value), attachments, maxBinaryScanDepth)
-	}
+// implementsMarshaler reports whether t (or *t) controls its own JSON or text
+// encoding via json.Marshaler / encoding.TextMarshaler.
+func implementsMarshaler(t reflect.Type) bool {
+	return t.Implements(jsonMarshalerType) || t.Implements(textMarshalerType)
 }
 
-// reflectExtractBinary mirrors extractBinary for arbitrary Go values reached via
-// reflection. It returns a JSON-marshalable tree (maps/slices/scalars) with every
-// []byte replaced by a placeholder and appended to *attachments. Values that
-// cannot contain binary (or once the depth bound is hit) are returned via their
-// interface{} so encoding/json serializes them normally. Only exported struct
-// fields are emitted, matching encoding/json and valueHasBinary.
-func reflectExtractBinary(rv reflect.Value, attachments *[][]byte, depth int) interface{} {
-	if !rv.IsValid() {
-		return nil
+// extractBinary returns a JSON-marshalable representation of one event payload in
+// which every []byte has been lifted into *attachments and replaced by a
+// {"_placeholder":true,"num":N} marker. Payloads with no binary are returned
+// unchanged so encoding/json renders them verbatim.
+//
+// For payloads that DO contain binary, the encoding is delegated to
+// encoding/json: a same-typed copy is built in which each []byte is swapped for a
+// unique sentinel, the copy is marshaled (so json tags, omitempty, ,string,
+// embedded fields and json.Marshaler implementations are honored exactly as on
+// the text Serialize path), and the sentinels' base64 renderings are spliced back
+// into placeholder objects. The header is therefore byte-for-byte identical to
+// the non-binary path apart from the lifted buffers.
+func extractBinary(value interface{}, attachments *[][]byte) (interface{}, error) {
+	if !valueHasBinary(value) {
+		return value, nil
 	}
-	if depth <= 0 {
-		return rv.Interface()
+	sentinels := make(map[string]int)
+	transformed := transformBinary(reflect.ValueOf(value), attachments, sentinels, maxBinaryScanDepth)
+	data, err := json.Marshal(transformed.Interface())
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrParseBinary, err)
+	}
+	return json.RawMessage(splicePlaceholders(data, sentinels)), nil
+}
+
+// transformBinary returns a value of the SAME type as rv in which every []byte on
+// a binary-bearing path is replaced by a unique sentinel slice; each sentinel's
+// base64 rendering is recorded in sentinels (keyed to its attachment index) and
+// the original bytes are appended to *attachments. Subtrees with no binary (or
+// whose type owns its encoding, or once the depth bound is hit) are returned
+// unchanged and shared with the original — they are never mutated, because only
+// freshly built containers are ever written to.
+func transformBinary(rv reflect.Value, attachments *[][]byte, sentinels map[string]int, depth int) reflect.Value {
+	if depth <= 0 || !rv.IsValid() || !reflectHasBinary(rv, depth) {
+		return rv
 	}
 
-	// Only hand-serialize subtrees that actually contain a []byte. Anything with
-	// no binary inside is returned via its interface{} so encoding/json renders
-	// it natively, preserving custom json.Marshaler implementations, `json:"..."`
-	// tags, omitempty and embedded fields. This is why a struct{ File []byte; T
-	// time.Time } keeps T as its RFC3339 string instead of the empty object a
-	// blind field-by-field reflection walk would produce. (A []byte leaf reports
-	// true here and falls through to the Slice case below.)
-	if !reflectHasBinary(rv, depth) {
-		return rv.Interface()
-	}
-
-	// Past the guard, rv is known to contain a []byte, so its kind is necessarily
-	// a container: Ptr/Interface (wrapper), Slice/Array/Map, or Struct. Scalars
-	// can never hold binary and have already returned above, so there is no
-	// "default" path to reach here. Struct is handled after the switch as the
-	// remaining container kind.
 	switch rv.Kind() {
-	case reflect.Ptr, reflect.Interface:
-		// Non-nil: a nil pointer/interface cannot contain binary and was returned
-		// by the guard above.
-		return reflectExtractBinary(rv.Elem(), attachments, depth-1)
+	case reflect.Ptr:
+		np := reflect.New(rv.Type().Elem())
+		np.Elem().Set(transformBinary(rv.Elem(), attachments, sentinels, depth-1))
+		return np
+	case reflect.Interface:
+		out := reflect.New(rv.Type()).Elem()
+		out.Set(transformBinary(rv.Elem(), attachments, sentinels, depth-1))
+		return out
 	case reflect.Slice:
 		if rv.Type().Elem().Kind() == reflect.Uint8 {
-			// []byte leaf -> attachment + placeholder.
-			buf := rv.Bytes()
-			num := len(*attachments)
-			*attachments = append(*attachments, buf)
-			return map[string]interface{}{"_placeholder": true, "num": num}
+			return sentinelSlice(rv, attachments, sentinels)
 		}
-		out := make([]interface{}, rv.Len())
+		ns := reflect.MakeSlice(rv.Type(), rv.Len(), rv.Len())
 		for i := 0; i < rv.Len(); i++ {
-			out[i] = reflectExtractBinary(rv.Index(i), attachments, depth-1)
+			ns.Index(i).Set(transformBinary(rv.Index(i), attachments, sentinels, depth-1))
 		}
-		return out
+		return ns
 	case reflect.Array:
-		out := make([]interface{}, rv.Len())
+		na := reflect.New(rv.Type()).Elem()
 		for i := 0; i < rv.Len(); i++ {
-			out[i] = reflectExtractBinary(rv.Index(i), attachments, depth-1)
+			na.Index(i).Set(transformBinary(rv.Index(i), attachments, sentinels, depth-1))
 		}
-		return out
+		return na
 	case reflect.Map:
-		out := make(map[string]interface{}, rv.Len())
+		nm := reflect.MakeMap(rv.Type())
 		for _, key := range rv.MapKeys() {
-			out[mapKeyString(key)] = reflectExtractBinary(rv.MapIndex(key), attachments, depth-1)
+			nm.SetMapIndex(key, transformBinary(rv.MapIndex(key), attachments, sentinels, depth-1))
 		}
-		return out
+		return nm
 	}
 
-	// Remaining binary-bearing kind: struct. Only exported fields are emitted,
-	// and each field is recursed so a binary-free field (e.g. time.Time) is
-	// returned via the guard and rendered natively by encoding/json.
+	// Remaining binary-bearing kind: struct. A same-typed copy is built so json
+	// applies the real field tags during marshaling; only exported fields are
+	// copied (matching json and valueHasBinary), `json:"-"` fields are dropped,
+	// and an omitempty field that json would omit is left zero so it stays omitted
+	// rather than being forced in by a (non-empty) sentinel.
+	ns := reflect.New(rv.Type()).Elem()
 	t := rv.Type()
-	out := make(map[string]interface{}, rv.NumField())
 	for i := 0; i < rv.NumField(); i++ {
 		field := t.Field(i)
 		if field.PkgPath != "" {
 			continue // unexported
 		}
-		name, omit := jsonFieldName(field)
-		if omit {
+		skip, omitempty := jsonFieldOptions(field)
+		if skip {
 			continue
 		}
-		out[name] = reflectExtractBinary(rv.Field(i), attachments, depth-1)
+		fv := rv.Field(i)
+		if omitempty && isEmptyValue(fv) {
+			continue
+		}
+		ns.Field(i).Set(transformBinary(fv, attachments, sentinels, depth-1))
 	}
-	return out
+	return ns
 }
 
-// mapKeyString renders a map key as a JSON object key. encoding/json requires
-// map keys to be strings (or types implementing TextMarshaler / integer kinds);
-// fmt.Sprint reproduces the string and integer renderings json uses, which is
-// all that is needed to carry binary placeholders out of a typed map.
-func mapKeyString(key reflect.Value) string {
-	return fmt.Sprint(key.Interface())
+// sentinelSlice records rv's bytes as the next attachment and returns a same-typed
+// slice holding a unique sentinel. encoding/json renders the sentinel as a base64
+// string, which splicePlaceholders then rewrites into the placeholder object.
+func sentinelSlice(rv reflect.Value, attachments *[][]byte, sentinels map[string]int) reflect.Value {
+	orig := rv.Bytes()
+	buf := make([]byte, len(orig))
+	copy(buf, orig)
+	num := len(*attachments)
+	*attachments = append(*attachments, buf)
+
+	sentinel := makeSentinel(num)
+	sentinels[base64.StdEncoding.EncodeToString(sentinel)] = num
+
+	sv := reflect.ValueOf(sentinel)
+	if rv.Type() != byteSliceType {
+		// Preserve a named []byte type (e.g. type Blob []byte) so the copy stays
+		// assignable to its field/element.
+		sv = sv.Convert(rv.Type())
+	}
+	return sv
 }
 
-// jsonFieldName returns the JSON object key for a struct field, honoring a
-// `json:"name,options"` tag. A `json:"-"` tag omits the field (the obscure
-// `json:"-,"` literal-dash form is not supported; it is vanishingly rare and not
-// needed for binary payloads). An empty tag name falls back to the field name.
-func jsonFieldName(field reflect.StructField) (string, bool) {
+// makeSentinel builds the unique, marshaling-stable byte token for attachment num
+// (see sentinelMagic).
+func makeSentinel(num int) []byte {
+	s := make([]byte, len(sentinelMagic)+8)
+	copy(s, sentinelMagic)
+	binary.BigEndian.PutUint64(s[len(sentinelMagic):], uint64(num))
+	return s
+}
+
+// splicePlaceholders rewrites each sentinel's base64 JSON string ("<b64>") into a
+// {"_placeholder":true,"num":N} object. Each sentinel is unique, so it appears
+// exactly once.
+func splicePlaceholders(data []byte, sentinels map[string]int) []byte {
+	for b64, num := range sentinels {
+		needle := []byte(`"` + b64 + `"`)
+		repl := []byte(fmt.Sprintf(`{"_placeholder":true,"num":%d}`, num))
+		data = bytes.Replace(data, needle, repl, 1)
+	}
+	return data
+}
+
+// isEmptyValue mirrors encoding/json's emptiness test for omitempty so the binary
+// path omits exactly the fields the text path would.
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+	return false
+}
+
+// jsonFieldOptions reports whether a struct field is dropped by `json:"-"` and
+// whether it carries the omitempty option. The field name is not needed:
+// transformBinary copies into the same struct type, so encoding/json applies the
+// real tag (name, ,string, etc.) when it marshals.
+func jsonFieldOptions(field reflect.StructField) (skip, omitempty bool) {
 	tag := field.Tag.Get("json")
 	if tag == "-" {
-		return "", true
+		return true, false
 	}
-	name := tag
 	if comma := indexComma(tag); comma >= 0 {
-		name = tag[:comma]
+		omitempty = hasOmitempty(tag[comma+1:])
 	}
-	if name == "" {
-		return field.Name, false
+	return false, omitempty
+}
+
+// hasOmitempty reports whether the comma-separated json tag options contain
+// "omitempty".
+func hasOmitempty(opts string) bool {
+	for opts != "" {
+		var part string
+		if i := indexComma(opts); i >= 0 {
+			part, opts = opts[:i], opts[i+1:]
+		} else {
+			part, opts = opts, ""
+		}
+		if part == "omitempty" {
+			return true
+		}
 	}
-	return name, false
+	return false
 }
 
 // indexComma returns the index of the first comma in s, or -1. (Avoids pulling
@@ -407,7 +482,11 @@ func (p *SocketIOV5DefaultParser) SerializeBinary(msg *socketio_v5.Message) ([]b
 	var attachments [][]byte
 	placeholders := make([]interface{}, len(msg.Event.Payloads))
 	for i, payload := range msg.Event.Payloads {
-		placeholders[i] = extractBinary(payload, &attachments)
+		pv, err := extractBinary(payload, &attachments)
+		if err != nil {
+			return nil, nil, err
+		}
+		placeholders[i] = pv
 	}
 
 	count := len(attachments)

--- a/socket.io/v5/parser/default/binary.go
+++ b/socket.io/v5/parser/default/binary.go
@@ -2,6 +2,7 @@ package socketio_v5_parser_default
 
 import (
 	"bytes"
+	"crypto/rand"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
@@ -30,11 +31,21 @@ var (
 	textMarshalerType = reflect.TypeOf((*interface{ MarshalText() ([]byte, error) })(nil)).Elem()
 )
 
-// sentinelMagic prefixes every binary sentinel slice. Combined with the
-// attachment index it makes each sentinel unique (so its base64 form is a unique
-// needle for splicePlaceholders) and, thanks to the control bytes, astronomically
-// unlikely to collide with real string data in a payload.
+// sentinelMagic prefixes every binary sentinel slice. Each sentinel is also given
+// a per-serialization random nonce and the attachment index, so its base64 form is
+// a unique needle for splicePlaceholders that an application payload cannot
+// predict: a user string can therefore never be mistaken for a sentinel (and so
+// never rewritten into a placeholder) except with cryptographically negligible
+// probability. The leading control bytes keep it visually distinct in logs.
 var sentinelMagic = []byte{0x1b, 'S', 'I', 'O', 'B', 'I', 'N', 0x1b}
+
+// sentinelNonceLen is the number of random bytes mixed into every sentinel of a
+// single serialization, making the sentinels' base64 needles unguessable.
+const sentinelNonceLen = 16
+
+// randRead is the source of sentinel-nonce randomness, indirected through a
+// package var only so tests can force the (otherwise unreachable) rand failure.
+var randRead = rand.Read
 
 // ErrParseBinary is returned when binary attachments cannot be reconciled with
 // the placeholders found in a PacketBinaryEvent/PacketBinaryAck payload.
@@ -252,10 +263,21 @@ func reflectHasBinary(rv reflect.Value, depth int) bool {
 	return false
 }
 
-// implementsMarshaler reports whether t (or *t) controls its own JSON or text
-// encoding via json.Marshaler / encoding.TextMarshaler.
+// implementsMarshaler reports whether t controls its own JSON or text encoding via
+// json.Marshaler / encoding.TextMarshaler, on EITHER a value or a pointer receiver.
+// The pointer-receiver case matters because encoding/json invokes a pointer
+// marshaler for the addressable values it builds (slice/array elements, addressable
+// struct fields). If we descended into such a value and swapped its []byte for a
+// sentinel, the marshaler would encode the sentinel bytes itself (e.g. as hex) and
+// never emit the base64 needle splicePlaceholders looks for — corrupting the output
+// and leaving an orphan attachment. Treating these types as owning their encoding
+// keeps the binary path byte-for-byte consistent with the text path for them.
 func implementsMarshaler(t reflect.Type) bool {
-	return t.Implements(jsonMarshalerType) || t.Implements(textMarshalerType)
+	if t.Implements(jsonMarshalerType) || t.Implements(textMarshalerType) {
+		return true
+	}
+	pt := reflect.PtrTo(t)
+	return pt.Implements(jsonMarshalerType) || pt.Implements(textMarshalerType)
 }
 
 // extractBinary returns a JSON-marshalable representation of one event payload in
@@ -274,8 +296,12 @@ func extractBinary(value interface{}, attachments *[][]byte) (interface{}, error
 	if !valueHasBinary(value) {
 		return value, nil
 	}
+	nonce := make([]byte, sentinelNonceLen)
+	if _, err := randRead(nonce); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrParseBinary, err)
+	}
 	sentinels := make(map[string]int)
-	transformed := transformBinary(reflect.ValueOf(value), attachments, sentinels, maxBinaryScanDepth)
+	transformed := transformBinary(reflect.ValueOf(value), attachments, sentinels, nonce, maxBinaryScanDepth)
 	data, err := json.Marshal(transformed.Interface())
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrParseBinary, err)
@@ -290,7 +316,7 @@ func extractBinary(value interface{}, attachments *[][]byte) (interface{}, error
 // whose type owns its encoding, or once the depth bound is hit) are returned
 // unchanged and shared with the original — they are never mutated, because only
 // freshly built containers are ever written to.
-func transformBinary(rv reflect.Value, attachments *[][]byte, sentinels map[string]int, depth int) reflect.Value {
+func transformBinary(rv reflect.Value, attachments *[][]byte, sentinels map[string]int, nonce []byte, depth int) reflect.Value {
 	if depth <= 0 || !rv.IsValid() || !reflectHasBinary(rv, depth) {
 		return rv
 	}
@@ -298,31 +324,31 @@ func transformBinary(rv reflect.Value, attachments *[][]byte, sentinels map[stri
 	switch rv.Kind() {
 	case reflect.Ptr:
 		np := reflect.New(rv.Type().Elem())
-		np.Elem().Set(transformBinary(rv.Elem(), attachments, sentinels, depth-1))
+		np.Elem().Set(transformBinary(rv.Elem(), attachments, sentinels, nonce, depth-1))
 		return np
 	case reflect.Interface:
 		out := reflect.New(rv.Type()).Elem()
-		out.Set(transformBinary(rv.Elem(), attachments, sentinels, depth-1))
+		out.Set(transformBinary(rv.Elem(), attachments, sentinels, nonce, depth-1))
 		return out
 	case reflect.Slice:
 		if rv.Type().Elem().Kind() == reflect.Uint8 {
-			return sentinelSlice(rv, attachments, sentinels)
+			return sentinelSlice(rv, attachments, sentinels, nonce)
 		}
 		ns := reflect.MakeSlice(rv.Type(), rv.Len(), rv.Len())
 		for i := 0; i < rv.Len(); i++ {
-			ns.Index(i).Set(transformBinary(rv.Index(i), attachments, sentinels, depth-1))
+			ns.Index(i).Set(transformBinary(rv.Index(i), attachments, sentinels, nonce, depth-1))
 		}
 		return ns
 	case reflect.Array:
 		na := reflect.New(rv.Type()).Elem()
 		for i := 0; i < rv.Len(); i++ {
-			na.Index(i).Set(transformBinary(rv.Index(i), attachments, sentinels, depth-1))
+			na.Index(i).Set(transformBinary(rv.Index(i), attachments, sentinels, nonce, depth-1))
 		}
 		return na
 	case reflect.Map:
 		nm := reflect.MakeMap(rv.Type())
 		for _, key := range rv.MapKeys() {
-			nm.SetMapIndex(key, transformBinary(rv.MapIndex(key), attachments, sentinels, depth-1))
+			nm.SetMapIndex(key, transformBinary(rv.MapIndex(key), attachments, sentinels, nonce, depth-1))
 		}
 		return nm
 	}
@@ -347,7 +373,7 @@ func transformBinary(rv reflect.Value, attachments *[][]byte, sentinels map[stri
 		if omitempty && isEmptyValue(fv) {
 			continue
 		}
-		ns.Field(i).Set(transformBinary(fv, attachments, sentinels, depth-1))
+		ns.Field(i).Set(transformBinary(fv, attachments, sentinels, nonce, depth-1))
 	}
 	return ns
 }
@@ -355,14 +381,14 @@ func transformBinary(rv reflect.Value, attachments *[][]byte, sentinels map[stri
 // sentinelSlice records rv's bytes as the next attachment and returns a same-typed
 // slice holding a unique sentinel. encoding/json renders the sentinel as a base64
 // string, which splicePlaceholders then rewrites into the placeholder object.
-func sentinelSlice(rv reflect.Value, attachments *[][]byte, sentinels map[string]int) reflect.Value {
+func sentinelSlice(rv reflect.Value, attachments *[][]byte, sentinels map[string]int, nonce []byte) reflect.Value {
 	orig := rv.Bytes()
 	buf := make([]byte, len(orig))
 	copy(buf, orig)
 	num := len(*attachments)
 	*attachments = append(*attachments, buf)
 
-	sentinel := makeSentinel(num)
+	sentinel := makeSentinel(nonce, num)
 	sentinels[base64.StdEncoding.EncodeToString(sentinel)] = num
 
 	sv := reflect.ValueOf(sentinel)
@@ -374,13 +400,18 @@ func sentinelSlice(rv reflect.Value, attachments *[][]byte, sentinels map[string
 	return sv
 }
 
-// makeSentinel builds the unique, marshaling-stable byte token for attachment num
-// (see sentinelMagic).
-func makeSentinel(num int) []byte {
-	s := make([]byte, len(sentinelMagic)+8)
-	copy(s, sentinelMagic)
-	binary.BigEndian.PutUint64(s[len(sentinelMagic):], uint64(num))
-	return s
+// makeSentinel builds the unique, marshaling-stable byte token for attachment num:
+// the fixed magic, this serialization's random nonce, and the index. The nonce
+// makes the token (and thus its base64 needle) unpredictable to an application
+// payload; the index keeps tokens distinct within one serialization (see
+// sentinelMagic).
+func makeSentinel(nonce []byte, num int) []byte {
+	s := make([]byte, 0, len(sentinelMagic)+len(nonce)+8)
+	s = append(s, sentinelMagic...)
+	s = append(s, nonce...)
+	var idx [8]byte
+	binary.BigEndian.PutUint64(idx[:], uint64(num))
+	return append(s, idx[:]...)
 }
 
 // splicePlaceholders rewrites each sentinel's base64 JSON string ("<b64>") into a

--- a/socket.io/v5/parser/default/binary.go
+++ b/socket.io/v5/parser/default/binary.go
@@ -194,7 +194,11 @@ func valueHasBinaryDepth(value interface{}, depth int) bool {
 	case nil:
 		return false
 	case []byte:
-		return true
+		// A nil byte slice is rendered by encoding/json as JSON null — it is a
+		// nullable value, not an empty buffer, so it must stay on the text path
+		// (matching the JS client, where null is not binary). An empty non-nil
+		// slice IS binary: it becomes a zero-length attachment.
+		return v != nil
 	case map[string]interface{}:
 		for _, item := range v {
 			if valueHasBinaryDepth(item, depth-1) {
@@ -239,9 +243,12 @@ func reflectHasBinary(rv reflect.Value, depth int) bool {
 	case reflect.Slice:
 		// []byte is the binary leaf; anything else is a slice to descend into.
 		// (json.RawMessage and other marshaler-owned byte slices were already
-		// excluded by the implementsMarshaler check above.)
+		// excluded by the implementsMarshaler check above.) A nil byte slice is
+		// NOT binary: encoding/json renders it as null, so it stays a nullable
+		// JSON value instead of becoming an empty attachment. transformBinary
+		// relies on this — it never lifts a subtree this function rejects.
 		if rv.Type().Elem().Kind() == reflect.Uint8 {
-			return true
+			return !rv.IsNil()
 		}
 		for i := 0; i < rv.Len(); i++ {
 			if reflectHasBinary(rv.Index(i), depth-1) {

--- a/socket.io/v5/parser/default/binary_coverage_test.go
+++ b/socket.io/v5/parser/default/binary_coverage_test.go
@@ -1,0 +1,188 @@
+package socketio_v5_parser_default
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	socketio_v5 "github.com/maldikhan/go.socket.io/socket.io/v5"
+)
+
+// These tests target the remaining reflective branches of the SEND/RECEIVE
+// binary paths so the package keeps 100% statement coverage.
+
+// reflectExtractBinary: top-level pointer payload (Ptr deref) and a typed slice
+// of non-byte elements that contain binary (slice element recursion).
+func TestSerializeBinary_TopLevelPointerAndTypedSlice(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	t.Run("top-level pointer to struct with bytes", func(t *testing.T) {
+		data := []byte("ptr-top")
+		_, attachments, err := parser.SerializeBinary(&socketio_v5.Message{
+			Type: socketio_v5.PacketEvent,
+			NS:   "/",
+			Event: &socketio_v5.Event{
+				Name:     "ev",
+				Payloads: []interface{}{&uploadStruct{File: data}},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, attachments, 1)
+		assert.True(t, bytes.Equal(data, attachments[0]))
+	})
+
+	t.Run("typed slice of structs containing bytes", func(t *testing.T) {
+		_, attachments, err := parser.SerializeBinary(&socketio_v5.Message{
+			Type: socketio_v5.PacketEvent,
+			NS:   "/",
+			Event: &socketio_v5.Event{
+				Name:     "ev",
+				Payloads: []interface{}{[]uploadStruct{{File: []byte("a")}, {File: []byte("b")}}},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, attachments, 2)
+		assert.Equal(t, []byte("a"), attachments[0])
+		assert.Equal(t, []byte("b"), attachments[1])
+	})
+
+	t.Run("typed slice element nil interface inside slice", func(t *testing.T) {
+		// []interface{} is handled by the fast path, but a typed []*uploadStruct
+		// with a nil element reaches reflectExtractBinary and exercises the
+		// invalid/nil element handling.
+		_, attachments, err := parser.SerializeBinary(&socketio_v5.Message{
+			Type: socketio_v5.PacketEvent,
+			NS:   "/",
+			Event: &socketio_v5.Event{
+				Name:     "ev",
+				Payloads: []interface{}{[]*uploadStruct{nil, {File: []byte("z")}}},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, attachments, 1)
+		assert.Equal(t, []byte("z"), attachments[0])
+	})
+}
+
+// reflectExtractBinary depth<=0: a deeply self-referential pointer chain hits
+// the depth bound and returns the raw value, which then fails json.Marshal
+// (proving termination rather than a hang).
+func TestSerializeBinary_DepthBoundReturnsRaw(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	a := &cyclic{Name: "a"}
+	a.Self = a
+
+	_, _, err := parser.SerializeBinary(&socketio_v5.Message{
+		Type: socketio_v5.PacketEvent,
+		NS:   "/",
+		Event: &socketio_v5.Event{
+			Name:     "ev",
+			Payloads: []interface{}{a},
+		},
+	})
+	// The cyclic pointer chain hits the depth bound; the leftover *cyclic is not
+	// JSON-marshalable as a finite document, so Marshal errors. No hang.
+	assert.Error(t, err)
+}
+
+// reflectHasBinary depth<=0 / interface branch: a self-referential struct with
+// NO binary must terminate and report false (depth bound), and one with binary
+// reachable before the bound reports true.
+func TestHasBinary_DepthBound(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	a := &cyclic{Name: "a"}
+	a.Self = a
+	assert.False(t, parser.HasBinary(&socketio_v5.Event{
+		Name:     "ev",
+		Payloads: []interface{}{a},
+	}))
+}
+
+// WrapCallback: the json.Marshal-error fallback path. A reconstructed value that
+// cannot be marshaled (contains a channel) and is not assignable must be
+// reported and skipped without panicking.
+func TestWrapCallback_MarshalErrorSkipped(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	called := false
+	cb := func(v noBinaryStruct) { called = true }
+	wrapped := parser.WrapCallback(cb)
+	require.NotNil(t, wrapped)
+
+	// map[string]interface{} with an unmarshalable channel value: not assignable
+	// to noBinaryStruct, and json.Marshal fails -> skipped.
+	wrapped([]interface{}{map[string]interface{}{"x": make(chan int)}})
+	assert.False(t, called)
+}
+
+// Direct unit tests of extractBinary's reflective leaf cases that are awkward to
+// trigger end-to-end: a nil pointer leaf and the depth bound.
+func TestExtractBinary_NilPointerLeaf(t *testing.T) {
+	t.Parallel()
+	var attachments [][]byte
+	var nilPtr *[]byte
+	// A typed nil pointer reaches reflectExtractBinary's Ptr/IsNil branch and is
+	// returned as-is, producing no attachment.
+	out := extractBinary(nilPtr, &attachments)
+	assert.Len(t, attachments, 0)
+	assert.Nil(t, out)
+}
+
+func TestReflectExtractBinary_DepthBound(t *testing.T) {
+	t.Parallel()
+	var attachments [][]byte
+	// depth == 0 returns the value via Interface() without recursing.
+	out := reflectExtractBinary(reflect.ValueOf("x"), &attachments, 0)
+	assert.Equal(t, "x", out)
+	assert.Len(t, attachments, 0)
+}
+
+func TestReflectExtractBinary_InvalidValue(t *testing.T) {
+	t.Parallel()
+	var attachments [][]byte
+	// An invalid reflect.Value (the zero Value) returns nil.
+	out := reflectExtractBinary(reflect.Value{}, &attachments, 5)
+	assert.Nil(t, out)
+	assert.Len(t, attachments, 0)
+}
+
+// reflectHasBinary: a typed map with NO binary must return false (the Map-case
+// fall-through), and reflectExtractBinary must skip unexported struct fields
+// (the PkgPath continue) when reached through the reflective path.
+func TestHasBinary_TypedMapWithoutBinary(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+	assert.False(t, parser.HasBinary(&socketio_v5.Event{
+		Name:     "ev",
+		Payloads: []interface{}{map[string]int{"a": 1, "b": 2}},
+	}))
+}
+
+func TestSerializeBinary_StructWithUnexportedField(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	// A struct with both an exported []byte and an unexported field reaches
+	// reflectExtractBinary; the unexported field is skipped (PkgPath continue)
+	// and only the exported bytes become an attachment.
+	_, attachments, err := parser.SerializeBinary(&socketio_v5.Message{
+		Type: socketio_v5.PacketEvent,
+		NS:   "/",
+		Event: &socketio_v5.Event{
+			Name:     "ev",
+			Payloads: []interface{}{unexportedBinaryStruct{secret: []byte("ignored"), Name: "n"}},
+		},
+	})
+	require.NoError(t, err)
+	// secret is unexported, so it is NOT extracted; no attachment is produced.
+	assert.Len(t, attachments, 0)
+}

--- a/socket.io/v5/parser/default/binary_coverage_test.go
+++ b/socket.io/v5/parser/default/binary_coverage_test.go
@@ -186,3 +186,23 @@ func TestSerializeBinary_StructWithUnexportedField(t *testing.T) {
 	// secret is unexported, so it is NOT extracted; no attachment is produced.
 	assert.Len(t, attachments, 0)
 }
+
+// A struct with an EXPORTED []byte reaches reflectExtractBinary's struct walk
+// (the value contains binary), and its unexported sibling field exercises the
+// PkgPath continue while the bytes still become an attachment.
+func TestSerializeBinary_ExportedBinaryWithUnexportedField(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	_, attachments, err := parser.SerializeBinary(&socketio_v5.Message{
+		Type: socketio_v5.PacketEvent,
+		NS:   "/",
+		Event: &socketio_v5.Event{
+			Name:     "ev",
+			Payloads: []interface{}{exportedBinaryWithUnexported{File: []byte("x"), secret: "s"}},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, attachments, 1)
+	assert.Equal(t, []byte("x"), attachments[0])
+}

--- a/socket.io/v5/parser/default/binary_coverage_test.go
+++ b/socket.io/v5/parser/default/binary_coverage_test.go
@@ -166,22 +166,20 @@ func TestExtractBinary_NilPointerLeaf(t *testing.T) {
 
 func TestTransformBinary_DepthBound(t *testing.T) {
 	t.Parallel()
-	var attachments [][]byte
-	sentinels := map[string]int{}
+	sentinels := map[string][]byte{}
 	// depth == 0 returns the value unchanged without recursing.
-	out := transformBinary(reflect.ValueOf("x"), &attachments, sentinels, nil, 0)
+	out := transformBinary(reflect.ValueOf("x"), sentinels, nil, 0)
 	assert.Equal(t, "x", out.Interface())
-	assert.Len(t, attachments, 0)
+	assert.Len(t, sentinels, 0)
 }
 
 func TestTransformBinary_InvalidValue(t *testing.T) {
 	t.Parallel()
-	var attachments [][]byte
-	sentinels := map[string]int{}
+	sentinels := map[string][]byte{}
 	// An invalid reflect.Value (the zero Value) is returned as-is, no panic.
-	out := transformBinary(reflect.Value{}, &attachments, sentinels, nil, 5)
+	out := transformBinary(reflect.Value{}, sentinels, nil, 5)
 	assert.False(t, out.IsValid())
-	assert.Len(t, attachments, 0)
+	assert.Len(t, sentinels, 0)
 }
 
 // blobType is a named []byte alias, exercising sentinelSlice's type-preserving

--- a/socket.io/v5/parser/default/binary_coverage_test.go
+++ b/socket.io/v5/parser/default/binary_coverage_test.go
@@ -107,6 +107,30 @@ func TestHasBinary_DepthBound(t *testing.T) {
 	}))
 }
 
+// valueHasBinary fast-path depth bound (Codex P2, binary.go:181): a
+// self-referential map[string]interface{} / []interface{} is handed to HasBinary
+// before encoding/json can reject the cycle, so the map/slice fast paths must be
+// depth-bounded too — otherwise scanning for binary recurses forever and
+// overflows the stack. Both shapes must terminate and report no binary.
+func TestHasBinary_FastPathCycleTerminates(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	cyclicMap := map[string]interface{}{}
+	cyclicMap["self"] = cyclicMap
+	assert.False(t, parser.HasBinary(&socketio_v5.Event{
+		Name:     "ev",
+		Payloads: []interface{}{cyclicMap},
+	}))
+
+	cyclicSlice := make([]interface{}, 1)
+	cyclicSlice[0] = cyclicSlice
+	assert.False(t, parser.HasBinary(&socketio_v5.Event{
+		Name:     "ev",
+		Payloads: []interface{}{cyclicSlice},
+	}))
+}
+
 // WrapCallback: the json.Marshal-error fallback path. A reconstructed value that
 // cannot be marshaled (contains a channel) and is not assignable must be
 // reported and skipped without panicking.

--- a/socket.io/v5/parser/default/binary_coverage_test.go
+++ b/socket.io/v5/parser/default/binary_coverage_test.go
@@ -185,7 +185,7 @@ func TestTransformBinary_InvalidValue(t *testing.T) {
 }
 
 // blobType is a named []byte alias, exercising sentinelSlice's type-preserving
-// Convert branch.
+// named-byte-slice branch.
 type blobType []byte
 
 // transformKinds drives the remaining transformBinary / isEmptyValue / hasOmitempty

--- a/socket.io/v5/parser/default/binary_coverage_test.go
+++ b/socket.io/v5/parser/default/binary_coverage_test.go
@@ -2,6 +2,7 @@ package socketio_v5_parser_default
 
 import (
 	"bytes"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -144,7 +145,7 @@ func TestTransformBinary_DepthBound(t *testing.T) {
 	var attachments [][]byte
 	sentinels := map[string]int{}
 	// depth == 0 returns the value unchanged without recursing.
-	out := transformBinary(reflect.ValueOf("x"), &attachments, sentinels, 0)
+	out := transformBinary(reflect.ValueOf("x"), &attachments, sentinels, nil, 0)
 	assert.Equal(t, "x", out.Interface())
 	assert.Len(t, attachments, 0)
 }
@@ -154,7 +155,7 @@ func TestTransformBinary_InvalidValue(t *testing.T) {
 	var attachments [][]byte
 	sentinels := map[string]int{}
 	// An invalid reflect.Value (the zero Value) is returned as-is, no panic.
-	out := transformBinary(reflect.Value{}, &attachments, sentinels, 5)
+	out := transformBinary(reflect.Value{}, &attachments, sentinels, nil, 5)
 	assert.False(t, out.IsValid())
 	assert.Len(t, attachments, 0)
 }
@@ -281,4 +282,18 @@ func TestSerializeBinary_ExportedBinaryWithUnexportedField(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, attachments, 1)
 	assert.Equal(t, []byte("x"), attachments[0])
+}
+
+// extractBinary surfaces a failure of the sentinel-nonce random source as an
+// ErrParseBinary rather than emitting predictable sentinels. randRead is swapped
+// in a NON-parallel test so the override is fully restored before any t.Parallel()
+// test resumes.
+func TestExtractBinary_RandFailure(t *testing.T) {
+	orig := randRead
+	randRead = func([]byte) (int, error) { return 0, errors.New("no entropy") }
+	defer func() { randRead = orig }()
+
+	var attachments [][]byte
+	_, err := extractBinary(uploadStruct{File: []byte{0x01}}, &attachments)
+	assert.ErrorIs(t, err, ErrParseBinary)
 }

--- a/socket.io/v5/parser/default/binary_coverage_test.go
+++ b/socket.io/v5/parser/default/binary_coverage_test.go
@@ -124,40 +124,116 @@ func TestWrapCallback_MarshalErrorSkipped(t *testing.T) {
 	assert.False(t, called)
 }
 
-// Direct unit tests of extractBinary's reflective leaf cases that are awkward to
-// trigger end-to-end: a nil pointer leaf and the depth bound.
+// Direct unit tests of extractBinary's leaf cases that are awkward to trigger
+// end-to-end: a binary-free typed nil pointer, and transformBinary's depth /
+// invalid-value guards.
 func TestExtractBinary_NilPointerLeaf(t *testing.T) {
 	t.Parallel()
 	var attachments [][]byte
 	var nilPtr *[]byte
-	// A typed nil pointer reaches reflectExtractBinary's Ptr/IsNil branch and is
-	// returned as-is, producing no attachment.
-	out := extractBinary(nilPtr, &attachments)
+	// A typed nil pointer contains no binary, so extractBinary returns it as-is
+	// (json renders it as null) with no attachment.
+	out, err := extractBinary(nilPtr, &attachments)
+	require.NoError(t, err)
 	assert.Len(t, attachments, 0)
 	assert.Nil(t, out)
 }
 
-func TestReflectExtractBinary_DepthBound(t *testing.T) {
+func TestTransformBinary_DepthBound(t *testing.T) {
 	t.Parallel()
 	var attachments [][]byte
-	// depth == 0 returns the value via Interface() without recursing.
-	out := reflectExtractBinary(reflect.ValueOf("x"), &attachments, 0)
-	assert.Equal(t, "x", out)
+	sentinels := map[string]int{}
+	// depth == 0 returns the value unchanged without recursing.
+	out := transformBinary(reflect.ValueOf("x"), &attachments, sentinels, 0)
+	assert.Equal(t, "x", out.Interface())
 	assert.Len(t, attachments, 0)
 }
 
-func TestReflectExtractBinary_InvalidValue(t *testing.T) {
+func TestTransformBinary_InvalidValue(t *testing.T) {
 	t.Parallel()
 	var attachments [][]byte
-	// An invalid reflect.Value (the zero Value) returns nil.
-	out := reflectExtractBinary(reflect.Value{}, &attachments, 5)
-	assert.Nil(t, out)
+	sentinels := map[string]int{}
+	// An invalid reflect.Value (the zero Value) is returned as-is, no panic.
+	out := transformBinary(reflect.Value{}, &attachments, sentinels, 5)
+	assert.False(t, out.IsValid())
 	assert.Len(t, attachments, 0)
+}
+
+// blobType is a named []byte alias, exercising sentinelSlice's type-preserving
+// Convert branch.
+type blobType []byte
+
+// transformKinds drives the remaining transformBinary / isEmptyValue / hasOmitempty
+// branches in one binary-bearing struct: a named []byte (Convert), an array of
+// []byte (Array case), a map of []byte (Map case), omitempty fields of every
+// emptiness kind (all skipped), a struct-typed omitempty field (isEmptyValue
+// default -> not skipped), and a multi-option tag (hasOmitempty continuation).
+type transformKinds struct {
+	File  []byte            `json:"file"`
+	Named blobType          `json:"named"`
+	Arr   [2][]byte         `json:"arr"`
+	M     map[string][]byte `json:"m"`
+
+	S     string         `json:"s,omitempty"`
+	B     bool           `json:"b,omitempty"`
+	I     int            `json:"i,omitempty"`
+	U     uint           `json:"u,omitempty"`
+	F     float64        `json:"f,omitempty"`
+	Sl    []int          `json:"sl,omitempty"`
+	Mp    map[string]int `json:"mp,omitempty"`
+	P     *int           `json:"p,omitempty"`
+	If    interface{}    `json:"if,omitempty"`
+	ArrO  [0]int         `json:"arro,omitempty"`
+	Multi int            `json:"multi,string,omitempty"`
+
+	Keep struct{ X int } `json:"keep,omitempty"` // struct kind: never "empty"
+}
+
+func TestSerializeBinary_TransformKindsCoverage(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	payload := transformKinds{
+		File:  []byte("f"),
+		Named: blobType("n"),
+		Arr:   [2][]byte{[]byte("a0"), []byte("a1")},
+		M:     map[string][]byte{"k": []byte("mv")},
+		// all omitempty scalar/container fields left empty -> omitted
+	}
+	header, attachments, err := parser.SerializeBinary(&socketio_v5.Message{
+		Type: socketio_v5.PacketEvent, NS: "/", Event: &socketio_v5.Event{
+			Name: "ev", Payloads: []interface{}{payload},
+		},
+	})
+	require.NoError(t, err)
+	// File + Named + Arr(2) + M(1) = 5 attachments.
+	require.Len(t, attachments, 5)
+
+	headerStr := string(header)
+	// Empty omitempty fields are dropped; the struct-typed field is kept.
+	assert.NotContains(t, headerStr, `"s"`)
+	assert.NotContains(t, headerStr, `"multi"`)
+	assert.Contains(t, headerStr, `"keep"`)
+	assert.Contains(t, headerStr, `"_placeholder"`)
+}
+
+// extractBinary surfaces a json.Marshal error for a binary-bearing payload whose
+// non-binary part is unencodable (a func field), covering the error branch.
+func TestExtractBinary_MarshalError(t *testing.T) {
+	t.Parallel()
+	type withFunc struct {
+		File []byte
+		Fn   func() `json:"fn"`
+	}
+	var attachments [][]byte
+	_, err := extractBinary(withFunc{File: []byte("x"), Fn: func() {}}, &attachments)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrParseBinary)
 }
 
 // reflectHasBinary: a typed map with NO binary must return false (the Map-case
-// fall-through), and reflectExtractBinary must skip unexported struct fields
-// (the PkgPath continue) when reached through the reflective path.
+// fall-through), and the reflective path must skip unexported struct fields
+// (the PkgPath continue).
 func TestHasBinary_TypedMapWithoutBinary(t *testing.T) {
 	t.Parallel()
 	parser := NewParser(WithLogger(logger))

--- a/socket.io/v5/parser/default/binary_struct_test.go
+++ b/socket.io/v5/parser/default/binary_struct_test.go
@@ -1,0 +1,482 @@
+package socketio_v5_parser_default
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	socketio_v5 "github.com/maldikhan/go.socket.io/socket.io/v5"
+)
+
+// --- Bug A: HasBinary must detect []byte inside structs / pointers / nested
+// containers on the SEND path. ---
+
+type uploadStruct struct {
+	File []byte
+	Name string
+}
+
+type nestedStruct struct {
+	Inner uploadStruct
+}
+
+type sliceStruct struct {
+	Files [][]byte
+}
+
+type mapStruct struct {
+	Files map[string][]byte
+}
+
+type noBinaryStruct struct {
+	Name string
+	Age  int
+}
+
+type unexportedBinaryStruct struct {
+	secret []byte // unexported: not marshalable, must be ignored
+	Name   string
+}
+
+type cyclic struct {
+	Self *cyclic
+	Name string
+}
+
+func TestHasBinary_StructPayloads(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	data := []byte{0x01, 0x02, 0x03, 0xff}
+
+	tests := []struct {
+		name    string
+		payload interface{}
+		want    bool
+	}{
+		{"struct with []byte field", uploadStruct{File: data, Name: "x"}, true},
+		{"pointer to struct with []byte", &uploadStruct{File: data}, true},
+		{"nested struct with []byte", nestedStruct{Inner: uploadStruct{File: data}}, true},
+		{"struct with [][]byte slice", sliceStruct{Files: [][]byte{data}}, true},
+		{"struct with map[string][]byte", mapStruct{Files: map[string][]byte{"a": data}}, true},
+		{"typed slice of structs with []byte", []uploadStruct{{File: data}}, true},
+		{"typed map to struct with []byte", map[string]uploadStruct{"k": {File: data}}, true},
+
+		{"struct without []byte", noBinaryStruct{Name: "x", Age: 1}, false},
+		{"pointer to struct without []byte", &noBinaryStruct{Name: "x"}, false},
+		{"unexported []byte field is ignored", unexportedBinaryStruct{secret: data, Name: "x"}, false},
+		{"plain []string is not binary", []string{"a", "b"}, false},
+		{"nil pointer struct", (*uploadStruct)(nil), false},
+		{"plain string", "hello", false},
+		{"nil payload", nil, false},
+
+		// Fast-path / existing-shape cases stay correct.
+		{"plain []byte", data, true},
+		{"map[string]interface{} with []byte", map[string]interface{}{"f": data}, true},
+		{"[]interface{} with []byte", []interface{}{"x", data}, true},
+		{"map[string]interface{} without []byte", map[string]interface{}{"f": "s"}, false},
+		{"[]interface{} without []byte", []interface{}{"x", 1}, false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			event := &socketio_v5.Event{Name: "upload", Payloads: []interface{}{tt.payload}}
+			assert.Equal(t, tt.want, parser.HasBinary(event))
+		})
+	}
+}
+
+func TestHasBinary_NilEvent(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+	assert.False(t, parser.HasBinary(nil))
+}
+
+// A cyclic structure must not hang HasBinary (depth guard).
+func TestHasBinary_CyclicDoesNotHang(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	a := &cyclic{Name: "a"}
+	a.Self = a // self-reference
+
+	event := &socketio_v5.Event{Name: "ev", Payloads: []interface{}{a}}
+	// No []byte anywhere, so the result is false, and crucially it returns.
+	assert.False(t, parser.HasBinary(event))
+
+	// Same but with binary reachable before the cycle would matter.
+	b := &cyclic{Name: "b"}
+	b.Self = b
+	withBin := struct {
+		Loop *cyclic
+		File []byte
+	}{Loop: b, File: []byte{0x09}}
+	event2 := &socketio_v5.Event{Name: "ev", Payloads: []interface{}{withBin}}
+	assert.True(t, parser.HasBinary(event2))
+}
+
+// Full Emit->SerializeBinary round-trip: a struct{File []byte} must produce a
+// real BINARY packet with the bytes as an attachment, not a base64 string.
+func TestSerializeBinary_StructProducesAttachment(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	data := []byte{0xde, 0xad, 0xbe, 0xef}
+	event := &socketio_v5.Event{
+		Name:     "upload",
+		Payloads: []interface{}{uploadStruct{File: data, Name: "pic"}},
+	}
+
+	require.True(t, parser.HasBinary(event), "HasBinary must select the binary path")
+
+	header, attachments, err := parser.SerializeBinary(&socketio_v5.Message{
+		Type:  socketio_v5.PacketEvent,
+		NS:    "/",
+		Event: event,
+	})
+	require.NoError(t, err)
+
+	// Exactly one attachment, equal to the original bytes (NOT base64).
+	require.Len(t, attachments, 1)
+	assert.True(t, bytes.Equal(data, attachments[0]), "attachment must be the raw bytes")
+
+	// Header is a PacketBinaryEvent ("5"), declares 1 attachment ("1-") and uses
+	// a placeholder for the bytes rather than a base64 string.
+	headerStr := string(header)
+	assert.Equal(t, byte('5'), header[0], "must be a binary event packet")
+	assert.Contains(t, headerStr, "1-")
+	assert.Contains(t, headerStr, "_placeholder")
+	assert.Contains(t, headerStr, `"num":0`)
+	// The struct's other field must survive in the header JSON.
+	assert.Contains(t, headerStr, `"Name":"pic"`)
+	// Base64 of {0xde,0xad,0xbe,0xef} is "3q2+7w==" — it must NOT appear.
+	assert.NotContains(t, headerStr, "3q2+7w==")
+}
+
+// Contrast: a struct without []byte stays on the plain text Serialize path and
+// (if it ever went through SerializeBinary) yields zero attachments.
+func TestSerialize_NonBinaryStructStaysText(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	event := &socketio_v5.Event{
+		Name:     "hello",
+		Payloads: []interface{}{noBinaryStruct{Name: "x", Age: 7}},
+	}
+	require.False(t, parser.HasBinary(event))
+
+	out, err := parser.Serialize(&socketio_v5.Message{
+		Type:  socketio_v5.PacketEvent,
+		NS:    "/",
+		Event: event,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, byte('2'), out[0], "must be a plain event packet")
+	assert.Contains(t, string(out), `"Name":"x"`)
+}
+
+// --- Bug B: typed STRUCT handlers must receive reconstructed binary on the
+// RECEIVE path. ---
+
+func TestWrapCallback_StructHandlerReceivesBinary(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	original := []byte{0x00, 0x10, 0x20, 0x7f, 0xfe}
+
+	var got uploadStruct
+	called := false
+	cb := func(v uploadStruct) {
+		got = v
+		called = true
+	}
+
+	wrapped := parser.WrapCallback(cb)
+	require.NotNil(t, wrapped)
+
+	// Reconstruction produces a map[string]interface{} that is NOT directly
+	// assignable to uploadStruct; the marshal/unmarshal fallback must convert it.
+	reconstructed := map[string]interface{}{
+		"File": original,
+		"Name": "pic",
+	}
+	wrapped([]interface{}{reconstructed})
+
+	require.True(t, called, "struct handler must fire")
+	assert.Equal(t, "pic", got.Name)
+	// CRUCIAL: the []byte round-trips through base64 back to the original bytes.
+	assert.True(t, bytes.Equal(original, got.File), "File must equal original bytes")
+}
+
+func TestWrapCallback_NestedStructHandlerReceivesBinary(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	original := []byte("nested-bytes")
+
+	var got nestedStruct
+	cb := func(v nestedStruct) { got = v }
+	wrapped := parser.WrapCallback(cb)
+	require.NotNil(t, wrapped)
+
+	reconstructed := map[string]interface{}{
+		"Inner": map[string]interface{}{
+			"File": original,
+			"Name": "n",
+		},
+	}
+	wrapped([]interface{}{reconstructed})
+
+	assert.Equal(t, "n", got.Inner.Name)
+	assert.True(t, bytes.Equal(original, got.Inner.File))
+}
+
+// The existing direct-assignment fast paths must keep working.
+func TestWrapCallback_MapAndByteHandlersStillWork(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	original := []byte{1, 2, 3}
+
+	t.Run("map[string]interface{} handler", func(t *testing.T) {
+		var got map[string]interface{}
+		cb := func(v map[string]interface{}) { got = v }
+		wrapped := parser.WrapCallback(cb)
+		require.NotNil(t, wrapped)
+		in := map[string]interface{}{"file": original}
+		wrapped([]interface{}{in})
+		require.NotNil(t, got)
+		assert.True(t, bytes.Equal(original, got["file"].([]byte)))
+	})
+
+	t.Run("[]byte handler", func(t *testing.T) {
+		var got []byte
+		cb := func(v []byte) { got = v }
+		wrapped := parser.WrapCallback(cb)
+		require.NotNil(t, wrapped)
+		wrapped([]interface{}{original})
+		assert.True(t, bytes.Equal(original, got))
+	})
+}
+
+// A non-RawMessage value that can neither be assigned nor marshaled into the
+// target type must be reported and skipped (no panic, callback not called).
+func TestWrapCallback_UnconvertibleValueSkipped(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	called := false
+	cb := func(v int) { called = true }
+	wrapped := parser.WrapCallback(cb)
+	require.NotNil(t, wrapped)
+
+	// A string value cannot json.Unmarshal into an int.
+	wrapped([]interface{}{"not-an-int"})
+	assert.False(t, called)
+}
+
+// json.RawMessage path is unchanged: ordinary JSON still unmarshals into a
+// struct handler.
+func TestWrapCallback_RawMessageStructStillWorks(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	var got noBinaryStruct
+	cb := func(v noBinaryStruct) { got = v }
+	wrapped := parser.WrapCallback(cb)
+	require.NotNil(t, wrapped)
+
+	wrapped([]interface{}{json.RawMessage(`{"Name":"z","Age":5}`)})
+	assert.Equal(t, "z", got.Name)
+	assert.Equal(t, 5, got.Age)
+}
+
+// --- Additional reflective coverage for the SEND path (extractBinary). ---
+
+type taggedStruct struct {
+	File    []byte `json:"file"`
+	Skipped string `json:"-"`
+	Renamed string `json:"renamed,omitempty"`
+	Empty   string `json:",omitempty"` // empty tag name -> field name "Empty"
+}
+
+type arrayStruct struct {
+	Two [2][]byte
+}
+
+type ptrFieldStruct struct {
+	File *[]byte
+}
+
+// SerializeBinary must honor json tags, skip json:"-" fields, descend through
+// pointer fields and fixed-size arrays, and stringify non-string map keys.
+func TestSerializeBinary_ReflectiveShapes(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	t.Run("json tags and dash handling", func(t *testing.T) {
+		data := []byte{0xaa}
+		header, attachments, err := parser.SerializeBinary(&socketio_v5.Message{
+			Type: socketio_v5.PacketEvent,
+			NS:   "/",
+			Event: &socketio_v5.Event{
+				Name:     "ev",
+				Payloads: []interface{}{taggedStruct{File: data, Skipped: "x", Renamed: "r", Empty: "e"}},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, attachments, 1)
+		assert.Equal(t, data, attachments[0])
+		hs := string(header)
+		assert.Contains(t, hs, `"file":`)        // tag-renamed []byte key
+		assert.Contains(t, hs, `"renamed":"r"`)  // tag with options
+		assert.Contains(t, hs, `"Empty":"e"`)    // empty tag name -> field name
+		assert.NotContains(t, hs, `"Skipped"`)   // json:"-" omitted
+		assert.NotContains(t, hs, `"x"`)         // skipped value gone
+		assert.Contains(t, hs, `"_placeholder"`) // bytes became a placeholder
+	})
+
+	t.Run("array of []byte field", func(t *testing.T) {
+		_, attachments, err := parser.SerializeBinary(&socketio_v5.Message{
+			Type: socketio_v5.PacketEvent,
+			NS:   "/",
+			Event: &socketio_v5.Event{
+				Name:     "ev",
+				Payloads: []interface{}{arrayStruct{Two: [2][]byte{{1}, {2}}}},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, attachments, 2)
+		assert.Equal(t, []byte{1}, attachments[0])
+		assert.Equal(t, []byte{2}, attachments[1])
+	})
+
+	t.Run("pointer-to-[]byte field", func(t *testing.T) {
+		b := []byte("ptr")
+		_, attachments, err := parser.SerializeBinary(&socketio_v5.Message{
+			Type: socketio_v5.PacketEvent,
+			NS:   "/",
+			Event: &socketio_v5.Event{
+				Name:     "ev",
+				Payloads: []interface{}{ptrFieldStruct{File: &b}},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, attachments, 1)
+		assert.Equal(t, []byte("ptr"), attachments[0])
+	})
+
+	t.Run("nil pointer-to-[]byte field yields no attachment", func(t *testing.T) {
+		_, attachments, err := parser.SerializeBinary(&socketio_v5.Message{
+			Type: socketio_v5.PacketEvent,
+			NS:   "/",
+			Event: &socketio_v5.Event{
+				Name:     "ev",
+				Payloads: []interface{}{ptrFieldStruct{File: nil}},
+			},
+		})
+		require.NoError(t, err)
+		assert.Len(t, attachments, 0)
+	})
+
+	t.Run("non-string map key with binary value", func(t *testing.T) {
+		header, attachments, err := parser.SerializeBinary(&socketio_v5.Message{
+			Type: socketio_v5.PacketEvent,
+			NS:   "/",
+			Event: &socketio_v5.Event{
+				Name:     "ev",
+				Payloads: []interface{}{map[int][]byte{7: {0x1}}},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, attachments, 1)
+		assert.Equal(t, []byte{0x1}, attachments[0])
+		assert.Contains(t, string(header), `"7"`) // int key stringified
+	})
+
+	t.Run("nil payload extracts nothing", func(t *testing.T) {
+		_, attachments, err := parser.SerializeBinary(&socketio_v5.Message{
+			Type: socketio_v5.PacketEvent,
+			NS:   "/",
+			Event: &socketio_v5.Event{
+				Name:     "ev",
+				Payloads: []interface{}{nil},
+			},
+		})
+		require.NoError(t, err)
+		assert.Len(t, attachments, 0)
+	})
+
+	t.Run("scalar payload passes through", func(t *testing.T) {
+		header, attachments, err := parser.SerializeBinary(&socketio_v5.Message{
+			Type: socketio_v5.PacketEvent,
+			NS:   "/",
+			Event: &socketio_v5.Event{
+				Name:     "ev",
+				Payloads: []interface{}{42},
+			},
+		})
+		require.NoError(t, err)
+		assert.Len(t, attachments, 0)
+		assert.Contains(t, string(header), "42")
+	})
+}
+
+// reflectExtractBinary / reflectHasBinary must terminate on cyclic structures
+// (depth bound) without hanging, including when serializing.
+func TestSerializeBinary_CyclicTerminates(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	a := &cyclic{Name: "a"}
+	a.Self = a
+
+	withBin := struct {
+		Loop *cyclic
+		File []byte
+	}{Loop: a, File: []byte{0x42}}
+
+	// HasBinary must terminate and report true via the File field.
+	require.True(t, parser.HasBinary(&socketio_v5.Event{
+		Name: "ev", Payloads: []interface{}{withBin},
+	}))
+
+	// SerializeBinary walks the same structure; it must also terminate. The
+	// cyclic pointer chain hits the depth bound and is returned as-is, which is
+	// not JSON-marshalable, so an error is returned rather than a hang.
+	_, _, err := parser.SerializeBinary(&socketio_v5.Message{
+		Type:  socketio_v5.PacketEvent,
+		NS:    "/",
+		Event: &socketio_v5.Event{Name: "ev", Payloads: []interface{}{withBin}},
+	})
+	assert.Error(t, err)
+}
+
+// reflectHasBinary array branch and []byte-array (not binary) cases.
+func TestHasBinary_ArrayAndByteArray(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	// [3][]byte array containing binary -> true.
+	assert.True(t, parser.HasBinary(&socketio_v5.Event{
+		Name:     "ev",
+		Payloads: []interface{}{[3][]byte{{1}, nil, nil}},
+	}))
+
+	// A [4]byte array is NOT a Socket.IO attachment (only []byte is) -> false.
+	assert.False(t, parser.HasBinary(&socketio_v5.Event{
+		Name:     "ev",
+		Payloads: []interface{}{[4]byte{1, 2, 3, 4}},
+	}))
+
+	// Typed slice of non-binary -> false.
+	assert.False(t, parser.HasBinary(&socketio_v5.Event{
+		Name:     "ev",
+		Payloads: []interface{}{[]int{1, 2, 3}},
+	}))
+}

--- a/socket.io/v5/parser/default/binary_struct_test.go
+++ b/socket.io/v5/parser/default/binary_struct_test.go
@@ -289,6 +289,85 @@ func TestSerializeBinary_HonorsJSONTagOptions(t *testing.T) {
 	assert.Contains(t, headerStr, `"file":{"_placeholder":true,"num":0}`)
 }
 
+// Regression (Codex P2, binary.go:393): a user string that happens to equal a
+// sentinel's base64 must never be rewritten into a placeholder. The deterministic
+// scheme made the attachment-0 sentinel base64 a fixed, guessable string
+// ("G1NJT0JJThsAAAAAAAAAAA=="); a payload carrying that string BEFORE the real
+// []byte (map keys marshal sorted, so "a" < "b") had its string spliced into the
+// placeholder while the real binary field was left as the sentinel text. The
+// per-serialization random nonce makes the needle unguessable, so the user string
+// survives verbatim and only the real []byte becomes the placeholder.
+func TestSerializeBinary_UserStringMatchingOldSentinelPreserved(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	const oldSentinelB64 = "G1NJT0JJThsAAAAAAAAAAA==" // base64 of the former fixed attachment-0 sentinel
+	event := &socketio_v5.Event{
+		Name: "upload",
+		Payloads: []interface{}{map[string]interface{}{
+			"a": oldSentinelB64,
+			"b": []byte{0x01, 0x02},
+		}},
+	}
+	require.True(t, parser.HasBinary(event))
+
+	header, attachments, err := parser.SerializeBinary(&socketio_v5.Message{
+		Type: socketio_v5.PacketEvent, NS: "/", Event: event,
+	})
+	require.NoError(t, err)
+	require.Len(t, attachments, 1)
+	assert.Equal(t, []byte{0x01, 0x02}, attachments[0])
+
+	headerStr := string(header)
+	assert.Contains(t, headerStr, `"a":"`+oldSentinelB64+`"`, "user string must survive verbatim")
+	assert.Contains(t, headerStr, `"b":{"_placeholder":true,"num":0}`, "only the real []byte is a placeholder")
+}
+
+// Regression (Codex P2, binary.go:313): for a slice whose element type encodes its
+// own bytes via a POINTER-receiver json.Marshaler, encoding/json invokes that
+// marshaler on each (addressable) element. The send path must NOT descend into such
+// an element and swap its []byte for a sentinel the marshaler would re-encode
+// (here as hex) instead of emitting the base64 needle. implementsMarshaler now
+// recognizes pointer-receiver marshalers, so the type owns its encoding: HasBinary
+// is false and the value renders exactly as on the text path, with no orphan
+// attachment.
+type hexBlob struct {
+	Data []byte
+}
+
+// MarshalJSON is defined on the POINTER receiver, so only *hexBlob (not hexBlob)
+// satisfies json.Marshaler — the exact case json applies to slice elements.
+func (h *hexBlob) MarshalJSON() ([]byte, error) {
+	const hexdigits = "0123456789abcdef"
+	out := make([]byte, 0, len(h.Data)*2+2)
+	out = append(out, '"')
+	for _, b := range h.Data {
+		out = append(out, hexdigits[b>>4], hexdigits[b&0x0f])
+	}
+	return append(out, '"'), nil
+}
+
+func TestSerializeBinary_PointerMarshalerSliceNotCorrupted(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	event := &socketio_v5.Event{
+		Name:     "blobs",
+		Payloads: []interface{}{[]hexBlob{{Data: []byte{0xaa, 0xbb}}}},
+	}
+	// The marshaler owns the bytes, so this is not a binary attachment payload.
+	require.False(t, parser.HasBinary(event))
+
+	out, err := parser.Serialize(&socketio_v5.Message{
+		Type: socketio_v5.PacketEvent, NS: "/", Event: event,
+	})
+	require.NoError(t, err)
+	outStr := string(out)
+	assert.Contains(t, outStr, `"aabb"`, "pointer marshaler output must be preserved")
+	assert.NotContains(t, outStr, "_placeholder", "no placeholder for marshaler-owned bytes")
+	assert.NotContains(t, outStr, "SIOBIN", "no leaked sentinel")
+}
+
 // Contrast: a struct without []byte stays on the plain text Serialize path and
 // (if it ever went through SerializeBinary) yields zero attachments.
 func TestSerialize_NonBinaryStructStaysText(t *testing.T) {

--- a/socket.io/v5/parser/default/binary_struct_test.go
+++ b/socket.io/v5/parser/default/binary_struct_test.go
@@ -258,6 +258,37 @@ func TestSerializeBinary_RawMessageStaysInline(t *testing.T) {
 	assert.Contains(t, headerStr, `"num":0`)
 }
 
+// A binary-bearing struct must honor json tag OPTIONS (,string and ,omitempty)
+// exactly as the text Serialize path would, since the hybrid send path delegates
+// the encoding to encoding/json. This is the regression Codex flagged: previously
+// the manual walk kept only the field name and dropped the options.
+func TestSerializeBinary_HonorsJSONTagOptions(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	type tagged struct {
+		File []byte `json:"file"`
+		ID   int    `json:"id,string"`      // ,string -> numeric value quoted
+		Note string `json:"note,omitempty"` // empty -> omitted entirely
+	}
+	event := &socketio_v5.Event{
+		Name:     "upload",
+		Payloads: []interface{}{tagged{File: []byte{0x01}, ID: 7, Note: ""}},
+	}
+	require.True(t, parser.HasBinary(event))
+
+	header, attachments, err := parser.SerializeBinary(&socketio_v5.Message{
+		Type: socketio_v5.PacketEvent, NS: "/", Event: event,
+	})
+	require.NoError(t, err)
+	require.Len(t, attachments, 1)
+
+	headerStr := string(header)
+	assert.Contains(t, headerStr, `"id":"7"`, ",string option must quote the number")
+	assert.NotContains(t, headerStr, `"note"`, "empty omitempty field must be dropped")
+	assert.Contains(t, headerStr, `"file":{"_placeholder":true,"num":0}`)
+}
+
 // Contrast: a struct without []byte stays on the plain text Serialize path and
 // (if it ever went through SerializeBinary) yields zero attachments.
 func TestSerialize_NonBinaryStructStaysText(t *testing.T) {

--- a/socket.io/v5/parser/default/binary_struct_test.go
+++ b/socket.io/v5/parser/default/binary_struct_test.go
@@ -611,6 +611,31 @@ func TestWrapCallback_UnconvertibleValueSkipped(t *testing.T) {
 	assert.False(t, called)
 }
 
+// A reconstructed binary []byte must NOT be passed to a json.RawMessage
+// handler as-is (arbitrary bytes are not JSON, even though []byte is
+// assignable to RawMessage). It must arrive as the base64 JSON string the
+// equivalent non-binary payload would have, keeping the RawMessage
+// always-valid-JSON invariant.
+func TestWrapCallback_RawMessageHandlerGetsValidJSONForBinary(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	original := []byte{0x00, 0xff, 0x10, 0x7f} // deliberately not valid JSON
+
+	var got json.RawMessage
+	cb := func(v json.RawMessage) { got = v }
+	wrapped := parser.WrapCallback(cb)
+	require.NotNil(t, wrapped)
+
+	wrapped([]interface{}{original})
+
+	require.NotNil(t, got)
+	assert.True(t, json.Valid(got), "RawMessage handler must receive valid JSON, got %q", got)
+	var roundTripped []byte
+	require.NoError(t, json.Unmarshal(got, &roundTripped))
+	assert.True(t, bytes.Equal(original, roundTripped), "base64 round-trip must reproduce the original bytes")
+}
+
 // json.RawMessage path is unchanged: ordinary JSON still unmarshals into a
 // struct handler.
 func TestWrapCallback_RawMessageStructStillWorks(t *testing.T) {

--- a/socket.io/v5/parser/default/binary_struct_test.go
+++ b/socket.io/v5/parser/default/binary_struct_test.go
@@ -3,6 +3,7 @@ package socketio_v5_parser_default
 import (
 	"bytes"
 	"encoding/json"
+	"reflect"
 	"testing"
 	"time"
 
@@ -440,6 +441,52 @@ func TestSerializeBinary_NamedUint8ElementSliceNoPanic(t *testing.T) {
 	require.Len(t, attachments, 1)
 	assert.Equal(t, []byte{1, 2, 255}, attachments[0])
 	assert.Contains(t, string(header), `{"_placeholder":true,"num":0}`)
+}
+
+// Regression (Codex P2, binary.go struct transform): a []byte field that
+// encoding/json drops (here via a json tag/name conflict) must NOT be lifted into
+// an orphan attachment. The attachment list is finalized against the marshaled
+// output, so a sentinel that never appears is discarded — the binary header stays
+// consistent (zero attachments, no placeholder) and matches the text path.
+func TestSerializeBinary_DroppedConflictFieldNotOrphaned(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	// Two fields mapping to the same JSON name; encoding/json's conflict
+	// resolution omits both. Built via reflect.StructOf so the deliberately
+	// duplicated json tag does not trip govet's structtag check. The []byte field
+	// is therefore never marshaled.
+	conflictType := reflect.StructOf([]reflect.StructField{
+		{Name: "A", Type: reflect.TypeOf([]byte(nil)), Tag: `json:"x"`},
+		{Name: "B", Type: reflect.TypeOf(""), Tag: `json:"x"`},
+	})
+	cv := reflect.New(conflictType).Elem()
+	cv.Field(0).SetBytes([]byte{1, 2, 3})
+	cv.Field(1).SetString("hi")
+
+	event := &socketio_v5.Event{
+		Name:     "ev",
+		Payloads: []interface{}{cv.Interface()},
+	}
+	require.True(t, parser.HasBinary(event))
+
+	header, attachments, err := parser.SerializeBinary(&socketio_v5.Message{
+		Type: socketio_v5.PacketEvent, NS: "/", Event: event,
+	})
+	require.NoError(t, err)
+	// json drops both conflicting fields, so no attachment survives and no
+	// placeholder is emitted — not a count=1 header with an orphan frame.
+	require.Len(t, attachments, 0)
+	headerStr := string(header)
+	assert.Contains(t, headerStr, `["ev",{}]`)
+	assert.NotContains(t, headerStr, "_placeholder")
+
+	// The binary header's payload matches what the plain text path produces.
+	text, err := parser.Serialize(&socketio_v5.Message{
+		Type: socketio_v5.PacketEvent, NS: "/", Event: event,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, string(text), `["ev",{}]`)
 }
 
 // Contrast: a struct without []byte stays on the plain text Serialize path and

--- a/socket.io/v5/parser/default/binary_struct_test.go
+++ b/socket.io/v5/parser/default/binary_struct_test.go
@@ -415,6 +415,33 @@ func TestSerializeBinary_PointerMarshalerNonAddressableLiftsBinary(t *testing.T)
 	})
 }
 
+// octet is a defined uint8 type; []octet is a byte slice whose element type is
+// named. encoding/json base64-encodes it like []byte, so the binary path lifts it
+// into an attachment — but []byte is not convertible to []octet, so sentinelSlice
+// must build the same-typed slice element by element rather than Convert.
+type octet uint8
+
+// Regression (Codex P2, binary.go:427): emitting a slice of a named uint8 element
+// must not panic in sentinelSlice and must lift the bytes into a binary attachment.
+func TestSerializeBinary_NamedUint8ElementSliceNoPanic(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	event := &socketio_v5.Event{
+		Name:     "upload",
+		Payloads: []interface{}{[]octet{1, 2, 255}},
+	}
+	require.True(t, parser.HasBinary(event))
+
+	header, attachments, err := parser.SerializeBinary(&socketio_v5.Message{
+		Type: socketio_v5.PacketEvent, NS: "/", Event: event,
+	})
+	require.NoError(t, err)
+	require.Len(t, attachments, 1)
+	assert.Equal(t, []byte{1, 2, 255}, attachments[0])
+	assert.Contains(t, string(header), `{"_placeholder":true,"num":0}`)
+}
+
 // Contrast: a struct without []byte stays on the plain text Serialize path and
 // (if it ever went through SerializeBinary) yields zero attachments.
 func TestSerialize_NonBinaryStructStaysText(t *testing.T) {

--- a/socket.io/v5/parser/default/binary_struct_test.go
+++ b/socket.io/v5/parser/default/binary_struct_test.go
@@ -327,10 +327,10 @@ func TestSerializeBinary_UserStringMatchingOldSentinelPreserved(t *testing.T) {
 // own bytes via a POINTER-receiver json.Marshaler, encoding/json invokes that
 // marshaler on each (addressable) element. The send path must NOT descend into such
 // an element and swap its []byte for a sentinel the marshaler would re-encode
-// (here as hex) instead of emitting the base64 needle. implementsMarshaler now
-// recognizes pointer-receiver marshalers, so the type owns its encoding: HasBinary
-// is false and the value renders exactly as on the text path, with no orphan
-// attachment.
+// (here as hex) instead of emitting the base64 needle. ownsEncoding treats an
+// addressable pointer-receiver marshaler as owning its encoding, so HasBinary is
+// false for the slice and the value renders exactly as on the text path, with no
+// orphan attachment.
 type hexBlob struct {
 	Data []byte
 }
@@ -366,6 +366,53 @@ func TestSerializeBinary_PointerMarshalerSliceNotCorrupted(t *testing.T) {
 	assert.Contains(t, outStr, `"aabb"`, "pointer marshaler output must be preserved")
 	assert.NotContains(t, outStr, "_placeholder", "no placeholder for marshaler-owned bytes")
 	assert.NotContains(t, outStr, "SIOBIN", "no leaked sentinel")
+}
+
+// Regression (Codex P2, binary.go:280): a type implementing json.Marshaler only on
+// its POINTER receiver is honored by encoding/json ONLY for addressable values. For
+// a NON-addressable value — a top-level Emit payload or a map value held in an
+// interface{} — json ignores the pointer marshaler and encodes the exported fields
+// (base64 for the []byte). ownsEncoding must therefore NOT treat such values as
+// marshaler-owned: HasBinary descends and the []byte is correctly lifted into a
+// Socket.IO binary attachment instead of being buried as base64 JSON.
+func TestSerializeBinary_PointerMarshalerNonAddressableLiftsBinary(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	t.Run("top-level value", func(t *testing.T) {
+		t.Parallel()
+		event := &socketio_v5.Event{
+			Name:     "upload",
+			Payloads: []interface{}{hexBlob{Data: []byte{0xaa, 0xbb}}},
+		}
+		require.True(t, parser.HasBinary(event), "non-addressable *hexBlob value must descend")
+
+		header, attachments, err := parser.SerializeBinary(&socketio_v5.Message{
+			Type: socketio_v5.PacketEvent, NS: "/", Event: event,
+		})
+		require.NoError(t, err)
+		require.Len(t, attachments, 1)
+		assert.Equal(t, []byte{0xaa, 0xbb}, attachments[0])
+		headerStr := string(header)
+		assert.Contains(t, headerStr, `{"_placeholder":true,"num":0}`)
+		assert.NotContains(t, headerStr, "aabb", "pointer marshaler must NOT run for a non-addressable value")
+	})
+
+	t.Run("map value", func(t *testing.T) {
+		t.Parallel()
+		event := &socketio_v5.Event{
+			Name:     "upload",
+			Payloads: []interface{}{map[string]interface{}{"blob": hexBlob{Data: []byte{0x01, 0x02}}}},
+		}
+		require.True(t, parser.HasBinary(event), "non-addressable map value must descend")
+
+		_, attachments, err := parser.SerializeBinary(&socketio_v5.Message{
+			Type: socketio_v5.PacketEvent, NS: "/", Event: event,
+		})
+		require.NoError(t, err)
+		require.Len(t, attachments, 1)
+		assert.Equal(t, []byte{0x01, 0x02}, attachments[0])
+	})
 }
 
 // Contrast: a struct without []byte stays on the plain text Serialize path and

--- a/socket.io/v5/parser/default/binary_struct_test.go
+++ b/socket.io/v5/parser/default/binary_struct_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -39,6 +40,14 @@ type noBinaryStruct struct {
 type unexportedBinaryStruct struct {
 	secret []byte // unexported: not marshalable, must be ignored
 	Name   string
+}
+
+// exportedBinaryWithUnexported carries an exported []byte (so the value enters
+// reflectExtractBinary's struct handling) alongside an unexported field that the
+// PkgPath check must skip.
+type exportedBinaryWithUnexported struct {
+	File   []byte // exported: extracted as an attachment
+	secret string // unexported: skipped via the PkgPath continue
 }
 
 type cyclic struct {
@@ -156,6 +165,47 @@ func TestSerializeBinary_StructProducesAttachment(t *testing.T) {
 	assert.Contains(t, headerStr, `"Name":"pic"`)
 	// Base64 of {0xde,0xad,0xbe,0xef} is "3q2+7w==" — it must NOT appear.
 	assert.NotContains(t, headerStr, "3q2+7w==")
+}
+
+// A struct that mixes a []byte field with a field relying on a custom
+// json.Marshaler (time.Time -> RFC3339) must extract the bytes as an attachment
+// while keeping the marshaler-driven field encoded exactly as encoding/json
+// would render it on the plain Serialize path — not flattened to "{}" by a blind
+// field-by-field reflection walk.
+func TestSerializeBinary_StructPreservesJSONMarshaler(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	type withTime struct {
+		File []byte    `json:"file"`
+		T    time.Time `json:"t"`
+	}
+	data := []byte{0x01, 0x02, 0x03}
+	ts := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	wantTS, err := json.Marshal(ts) // exactly what encoding/json would emit
+	require.NoError(t, err)
+
+	event := &socketio_v5.Event{
+		Name:     "upload",
+		Payloads: []interface{}{withTime{File: data, T: ts}},
+	}
+	require.True(t, parser.HasBinary(event))
+
+	header, attachments, err := parser.SerializeBinary(&socketio_v5.Message{
+		Type:  socketio_v5.PacketEvent,
+		NS:    "/",
+		Event: event,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, attachments, 1)
+	assert.True(t, bytes.Equal(data, attachments[0]))
+
+	headerStr := string(header)
+	assert.Contains(t, headerStr, "_placeholder", "the []byte field becomes a placeholder")
+	// time.Time must keep its RFC3339 rendering, NOT collapse to an empty object.
+	assert.Contains(t, headerStr, `"t":`+string(wantTS))
+	assert.NotContains(t, headerStr, `"t":{}`, "json.Marshaler must be honored, not flattened")
 }
 
 // Contrast: a struct without []byte stays on the plain text Serialize path and

--- a/socket.io/v5/parser/default/binary_struct_test.go
+++ b/socket.io/v5/parser/default/binary_struct_test.go
@@ -50,6 +50,18 @@ type exportedBinaryWithUnexported struct {
 	secret string // unexported: skipped via the PkgPath continue
 }
 
+// rawMessageStruct holds pre-encoded JSON that must NOT be treated as binary.
+type rawMessageStruct struct {
+	Meta json.RawMessage
+}
+
+// rawAndBytesStruct mixes pass-through JSON with a real binary field: only File
+// must become an attachment; Meta stays inline JSON.
+type rawAndBytesStruct struct {
+	Meta json.RawMessage
+	File []byte
+}
+
 type cyclic struct {
 	Self *cyclic
 	Name string
@@ -78,6 +90,11 @@ func TestHasBinary_StructPayloads(t *testing.T) {
 		{"pointer to struct without []byte", &noBinaryStruct{Name: "x"}, false},
 		{"unexported []byte field is ignored", unexportedBinaryStruct{secret: data, Name: "x"}, false},
 		{"plain []string is not binary", []string{"a", "b"}, false},
+		// json.RawMessage is a []byte alias but carries pre-encoded JSON, so it
+		// must take the text path, not be sent as a binary attachment.
+		{"top-level json.RawMessage is not binary", json.RawMessage(`{"a":1}`), false},
+		{"struct field json.RawMessage is not binary", rawMessageStruct{Meta: json.RawMessage(`[1,2]`)}, false},
+		{"struct mixing []byte and RawMessage is binary", rawAndBytesStruct{Meta: json.RawMessage(`{}`), File: data}, true},
 		{"nil pointer struct", (*uploadStruct)(nil), false},
 		{"plain string", "hello", false},
 		{"nil payload", nil, false},
@@ -206,6 +223,39 @@ func TestSerializeBinary_StructPreservesJSONMarshaler(t *testing.T) {
 	// time.Time must keep its RFC3339 rendering, NOT collapse to an empty object.
 	assert.Contains(t, headerStr, `"t":`+string(wantTS))
 	assert.NotContains(t, headerStr, `"t":{}`, "json.Marshaler must be honored, not flattened")
+}
+
+// A struct mixing a json.RawMessage with a real []byte must extract only the
+// bytes as an attachment while the RawMessage stays inline in the header JSON
+// (as the array/object it encodes), not as a second attachment or a base64
+// string.
+func TestSerializeBinary_RawMessageStaysInline(t *testing.T) {
+	t.Parallel()
+	parser := NewParser(WithLogger(logger))
+
+	data := []byte{0x09, 0x08}
+	event := &socketio_v5.Event{
+		Name:     "upload",
+		Payloads: []interface{}{rawAndBytesStruct{Meta: json.RawMessage(`{"k":1}`), File: data}},
+	}
+	require.True(t, parser.HasBinary(event))
+
+	header, attachments, err := parser.SerializeBinary(&socketio_v5.Message{
+		Type:  socketio_v5.PacketEvent,
+		NS:    "/",
+		Event: event,
+	})
+	require.NoError(t, err)
+
+	// Only the []byte field becomes an attachment.
+	require.Len(t, attachments, 1)
+	assert.Equal(t, data, attachments[0])
+
+	headerStr := string(header)
+	// RawMessage is emitted as the JSON it carries, not as a placeholder.
+	assert.Contains(t, headerStr, `"Meta":{"k":1}`)
+	assert.Contains(t, headerStr, "_placeholder", "the []byte field is a placeholder")
+	assert.Contains(t, headerStr, `"num":0`)
 }
 
 // Contrast: a struct without []byte stays on the plain text Serialize path and

--- a/socket.io/v5/parser/default/binary_test.go
+++ b/socket.io/v5/parser/default/binary_test.go
@@ -1,0 +1,583 @@
+package socketio_v5_parser_default
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	socketio_v5 "github.com/maldikhan/go.socket.io/socket.io/v5"
+)
+
+// newBinaryParser builds a default parser with a silent logger for the binary
+// tests.
+func newBinaryParser() *SocketIOV5DefaultParser {
+	return NewParser(WithLogger(logger))
+}
+
+// TestParser_WrapCallback_Binary verifies that a reconstructed []byte payload
+// is passed straight through to a []byte callback parameter (rather than being
+// JSON-unmarshaled), which is how binary attachments reach handlers/acks.
+func TestParser_WrapCallback_Binary(t *testing.T) {
+	t.Parallel()
+	p := newBinaryParser()
+
+	t.Run("byte slice passthrough", func(t *testing.T) {
+		var got []byte
+		cb := p.WrapCallback(func(b []byte) { got = b })
+		require.NotNil(t, cb)
+		cb([]interface{}{[]byte{0x1, 0x2, 0x3}})
+		assert.Equal(t, []byte{0x1, 0x2, 0x3}, got)
+	})
+
+	t.Run("mixed binary and json args", func(t *testing.T) {
+		var gotStr string
+		var gotBin []byte
+		cb := p.WrapCallback(func(s string, b []byte) {
+			gotStr = s
+			gotBin = b
+		})
+		require.NotNil(t, cb)
+		cb([]interface{}{json.RawMessage(`"name"`), []byte("data")})
+		assert.Equal(t, "name", gotStr)
+		assert.Equal(t, []byte("data"), gotBin)
+	})
+
+	t.Run("byte payload to non-byte param is rejected", func(t *testing.T) {
+		called := false
+		cb := p.WrapCallback(func(s string) { called = true })
+		require.NotNil(t, cb)
+		cb([]interface{}{[]byte("data")})
+		assert.False(t, called, "binary payload must not bind to a string parameter")
+	})
+}
+
+func TestParser_HasBinary(t *testing.T) {
+	t.Parallel()
+	p := newBinaryParser()
+
+	tests := []struct {
+		name  string
+		event *socketio_v5.Event
+		want  bool
+	}{
+		{name: "nil event", event: nil, want: false},
+		{
+			name:  "text only",
+			event: &socketio_v5.Event{Name: "ev", Payloads: []interface{}{"hello", 42}},
+			want:  false,
+		},
+		{
+			name:  "direct binary",
+			event: &socketio_v5.Event{Name: "ev", Payloads: []interface{}{[]byte{1, 2, 3}}},
+			want:  true,
+		},
+		{
+			name: "binary nested in slice",
+			event: &socketio_v5.Event{Name: "ev", Payloads: []interface{}{
+				[]interface{}{"a", []byte{9}},
+			}},
+			want: true,
+		},
+		{
+			name: "binary nested in map",
+			event: &socketio_v5.Event{Name: "ev", Payloads: []interface{}{
+				map[string]interface{}{"file": []byte{7}},
+			}},
+			want: true,
+		},
+		{
+			name: "no binary in nested structures",
+			event: &socketio_v5.Event{Name: "ev", Payloads: []interface{}{
+				map[string]interface{}{"x": []interface{}{"y", 1}},
+			}},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, p.HasBinary(tt.event))
+		})
+	}
+}
+
+func TestParser_SerializeBinary(t *testing.T) {
+	t.Parallel()
+	p := newBinaryParser()
+
+	t.Run("single attachment event", func(t *testing.T) {
+		header, attachments, err := p.SerializeBinary(&socketio_v5.Message{
+			Type: socketio_v5.PacketEvent,
+			NS:   "/",
+			Event: &socketio_v5.Event{
+				Name:     "binEvent",
+				Payloads: []interface{}{[]byte{0x1, 0x2, 0x3}},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`51-["binEvent",{"_placeholder":true,"num":0}]`), header)
+		require.Len(t, attachments, 1)
+		assert.Equal(t, []byte{0x1, 0x2, 0x3}, attachments[0])
+	})
+
+	t.Run("multiple attachments preserve order", func(t *testing.T) {
+		header, attachments, err := p.SerializeBinary(&socketio_v5.Message{
+			Type: socketio_v5.PacketEvent,
+			NS:   "/",
+			Event: &socketio_v5.Event{
+				Name:     "multi",
+				Payloads: []interface{}{[]byte("first"), "text", []byte("second")},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`52-["multi",{"_placeholder":true,"num":0},"text",{"_placeholder":true,"num":1}]`), header)
+		require.Len(t, attachments, 2)
+		assert.Equal(t, []byte("first"), attachments[0])
+		assert.Equal(t, []byte("second"), attachments[1])
+	})
+
+	t.Run("binary nested in map and slice", func(t *testing.T) {
+		header, attachments, err := p.SerializeBinary(&socketio_v5.Message{
+			Type: socketio_v5.PacketEvent,
+			NS:   "/",
+			Event: &socketio_v5.Event{
+				Name: "nested",
+				Payloads: []interface{}{
+					map[string]interface{}{"file": []byte("data")},
+					[]interface{}{[]byte("more")},
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, attachments, 2)
+		assert.Equal(t, []byte("data"), attachments[0])
+		assert.Equal(t, []byte("more"), attachments[1])
+		// The header must carry the attachment count and the placeholders.
+		assert.Contains(t, string(header), `52-`)
+		assert.Contains(t, string(header), `"_placeholder":true`)
+	})
+
+	t.Run("ack with namespace and ack id", func(t *testing.T) {
+		header, attachments, err := p.SerializeBinary(&socketio_v5.Message{
+			Type:  socketio_v5.PacketAck,
+			NS:    "/admin",
+			AckId: intPtr(7),
+			Event: &socketio_v5.Event{
+				Payloads: []interface{}{[]byte{0xFF}},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`61-/admin,7[{"_placeholder":true,"num":0}]`), header)
+		require.Len(t, attachments, 1)
+		assert.Equal(t, []byte{0xFF}, attachments[0])
+	})
+
+	t.Run("nil message", func(t *testing.T) {
+		_, _, err := p.SerializeBinary(nil)
+		assert.ErrorIs(t, err, ErrParseBinary)
+	})
+
+	t.Run("nil event", func(t *testing.T) {
+		_, _, err := p.SerializeBinary(&socketio_v5.Message{Type: socketio_v5.PacketEvent})
+		assert.ErrorIs(t, err, ErrParseBinary)
+	})
+
+	t.Run("non event/ack type", func(t *testing.T) {
+		_, _, err := p.SerializeBinary(&socketio_v5.Message{
+			Type:  socketio_v5.PacketConnect,
+			Event: &socketio_v5.Event{Name: "x", Payloads: []interface{}{[]byte{1}}},
+		})
+		assert.ErrorIs(t, err, ErrParseBinary)
+	})
+
+	t.Run("unserializable payload", func(t *testing.T) {
+		_, _, err := p.SerializeBinary(&socketio_v5.Message{
+			Type: socketio_v5.PacketEvent,
+			Event: &socketio_v5.Event{
+				Name:     "x",
+				Payloads: []interface{}{[]byte{1}, make(chan int)},
+			},
+		})
+		assert.Error(t, err)
+	})
+}
+
+func TestParser_ReconstructBinary(t *testing.T) {
+	t.Parallel()
+	p := newBinaryParser()
+
+	t.Run("single placeholder", func(t *testing.T) {
+		msg := &socketio_v5.Message{
+			Type:              socketio_v5.PacketBinaryEvent,
+			NS:                "/",
+			BinaryAttachments: intPtr(1),
+			Event: &socketio_v5.Event{
+				Name:     "binEvent",
+				Payloads: []interface{}{json.RawMessage(`{"_placeholder":true,"num":0}`)},
+			},
+		}
+		err := p.ReconstructBinary(msg, [][]byte{{0x1, 0x2, 0x3}})
+		require.NoError(t, err)
+		assert.Nil(t, msg.BinaryAttachments)
+		require.Len(t, msg.Event.Payloads, 1)
+		assert.Equal(t, []byte{0x1, 0x2, 0x3}, msg.Event.Payloads[0])
+	})
+
+	t.Run("placeholder nested in object", func(t *testing.T) {
+		msg := &socketio_v5.Message{
+			Type:              socketio_v5.PacketBinaryEvent,
+			NS:                "/",
+			BinaryAttachments: intPtr(1),
+			Event: &socketio_v5.Event{
+				Name:     "binEvent",
+				Payloads: []interface{}{json.RawMessage(`{"file":{"_placeholder":true,"num":0},"name":"x"}`)},
+			},
+		}
+		err := p.ReconstructBinary(msg, [][]byte{[]byte("payload")})
+		require.NoError(t, err)
+		obj, ok := msg.Event.Payloads[0].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, []byte("payload"), obj["file"])
+		assert.Equal(t, "x", obj["name"])
+	})
+
+	t.Run("placeholder nested in array", func(t *testing.T) {
+		msg := &socketio_v5.Message{
+			Type:              socketio_v5.PacketBinaryEvent,
+			NS:                "/",
+			BinaryAttachments: intPtr(2),
+			Event: &socketio_v5.Event{
+				Name:     "binEvent",
+				Payloads: []interface{}{json.RawMessage(`["a",{"_placeholder":true,"num":1},{"_placeholder":true,"num":0}]`)},
+			},
+		}
+		err := p.ReconstructBinary(msg, [][]byte{[]byte("zero"), []byte("one")})
+		require.NoError(t, err)
+		arr, ok := msg.Event.Payloads[0].([]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "a", arr[0])
+		assert.Equal(t, []byte("one"), arr[1])
+		assert.Equal(t, []byte("zero"), arr[2])
+	})
+
+	t.Run("zero attachments", func(t *testing.T) {
+		msg := &socketio_v5.Message{
+			Type:              socketio_v5.PacketBinaryEvent,
+			NS:                "/",
+			BinaryAttachments: intPtr(0),
+			Event: &socketio_v5.Event{
+				Name:     "binEvent",
+				Payloads: []interface{}{json.RawMessage(`"text"`)},
+			},
+		}
+		err := p.ReconstructBinary(msg, nil)
+		require.NoError(t, err)
+		assert.Nil(t, msg.BinaryAttachments)
+	})
+
+	t.Run("nil message", func(t *testing.T) {
+		assert.ErrorIs(t, p.ReconstructBinary(nil, nil), ErrParseBinary)
+	})
+
+	t.Run("count mismatch", func(t *testing.T) {
+		msg := &socketio_v5.Message{
+			Type:              socketio_v5.PacketBinaryEvent,
+			BinaryAttachments: intPtr(2),
+			Event:             &socketio_v5.Event{Name: "x"},
+		}
+		assert.ErrorIs(t, p.ReconstructBinary(msg, [][]byte{{1}}), ErrParseBinary)
+	})
+
+	t.Run("placeholder index out of range", func(t *testing.T) {
+		msg := &socketio_v5.Message{
+			Type:              socketio_v5.PacketBinaryEvent,
+			BinaryAttachments: intPtr(1),
+			Event: &socketio_v5.Event{
+				Name:     "x",
+				Payloads: []interface{}{json.RawMessage(`{"_placeholder":true,"num":5}`)},
+			},
+		}
+		assert.ErrorIs(t, p.ReconstructBinary(msg, [][]byte{{1}}), ErrParseBinary)
+	})
+
+	t.Run("placeholder without num", func(t *testing.T) {
+		msg := &socketio_v5.Message{
+			Type:              socketio_v5.PacketBinaryEvent,
+			BinaryAttachments: intPtr(1),
+			Event: &socketio_v5.Event{
+				Name:     "x",
+				Payloads: []interface{}{json.RawMessage(`{"_placeholder":true}`)},
+			},
+		}
+		assert.ErrorIs(t, p.ReconstructBinary(msg, [][]byte{{1}}), ErrParseBinary)
+	})
+
+	t.Run("placeholder num not a number", func(t *testing.T) {
+		msg := &socketio_v5.Message{
+			Type:              socketio_v5.PacketBinaryEvent,
+			BinaryAttachments: intPtr(1),
+			Event: &socketio_v5.Event{
+				Name:     "x",
+				Payloads: []interface{}{json.RawMessage(`{"_placeholder":true,"num":"a"}`)},
+			},
+		}
+		assert.ErrorIs(t, p.ReconstructBinary(msg, [][]byte{{1}}), ErrParseBinary)
+	})
+
+	t.Run("invalid placeholder nested in object propagates error", func(t *testing.T) {
+		msg := &socketio_v5.Message{
+			Type:              socketio_v5.PacketBinaryEvent,
+			BinaryAttachments: intPtr(1),
+			Event: &socketio_v5.Event{
+				Name:     "x",
+				Payloads: []interface{}{json.RawMessage(`{"file":{"_placeholder":true,"num":9}}`)},
+			},
+		}
+		assert.ErrorIs(t, p.ReconstructBinary(msg, [][]byte{{1}}), ErrParseBinary)
+	})
+
+	t.Run("invalid placeholder nested in array propagates error", func(t *testing.T) {
+		msg := &socketio_v5.Message{
+			Type:              socketio_v5.PacketBinaryEvent,
+			BinaryAttachments: intPtr(1),
+			Event: &socketio_v5.Event{
+				Name:     "x",
+				Payloads: []interface{}{json.RawMessage(`["a",{"_placeholder":true,"num":9}]`)},
+			},
+		}
+		assert.ErrorIs(t, p.ReconstructBinary(msg, [][]byte{{1}}), ErrParseBinary)
+	})
+
+	t.Run("invalid json payload", func(t *testing.T) {
+		msg := &socketio_v5.Message{
+			Type:              socketio_v5.PacketBinaryEvent,
+			BinaryAttachments: intPtr(1),
+			Event: &socketio_v5.Event{
+				Name:     "x",
+				Payloads: []interface{}{json.RawMessage(`{not json}`)},
+			},
+		}
+		assert.ErrorIs(t, p.ReconstructBinary(msg, [][]byte{{1}}), ErrParseBinary)
+	})
+
+	t.Run("placeholder flag false is a plain object", func(t *testing.T) {
+		msg := &socketio_v5.Message{
+			Type:              socketio_v5.PacketBinaryEvent,
+			BinaryAttachments: intPtr(0),
+			Event: &socketio_v5.Event{
+				Name:     "x",
+				Payloads: []interface{}{json.RawMessage(`{"_placeholder":false,"num":0}`)},
+			},
+		}
+		require.NoError(t, p.ReconstructBinary(msg, nil))
+		obj, ok := msg.Event.Payloads[0].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, false, obj["_placeholder"])
+	})
+
+	t.Run("non-raw payload is left untouched", func(t *testing.T) {
+		msg := &socketio_v5.Message{
+			Type:              socketio_v5.PacketBinaryEvent,
+			BinaryAttachments: intPtr(0),
+			Event: &socketio_v5.Event{
+				Name:     "x",
+				Payloads: []interface{}{"already decoded"},
+			},
+		}
+		require.NoError(t, p.ReconstructBinary(msg, nil))
+		assert.Equal(t, "already decoded", msg.Event.Payloads[0])
+	})
+}
+
+func TestParser_validateMessage_Binary(t *testing.T) {
+	t.Parallel()
+	p := newBinaryParser()
+
+	t.Run("binary event without name fails", func(t *testing.T) {
+		_, err := p.Serialize(&socketio_v5.Message{
+			Type:  socketio_v5.PacketBinaryEvent,
+			Event: &socketio_v5.Event{Name: ""},
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("binary event with name serializes", func(t *testing.T) {
+		count := 0
+		_, err := p.Serialize(&socketio_v5.Message{
+			Type:              socketio_v5.PacketBinaryEvent,
+			NS:                "/",
+			BinaryAttachments: &count,
+			Event:             &socketio_v5.Event{Name: "ev"},
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("binary ack without event fails", func(t *testing.T) {
+		_, err := p.Serialize(&socketio_v5.Message{
+			Type: socketio_v5.PacketBinaryAck,
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("binary ack with event serializes", func(t *testing.T) {
+		count := 0
+		_, err := p.Serialize(&socketio_v5.Message{
+			Type:              socketio_v5.PacketBinaryAck,
+			NS:                "/",
+			AckId:             intPtr(1),
+			BinaryAttachments: &count,
+			Event:             &socketio_v5.Event{Payloads: []interface{}{}},
+		})
+		assert.NoError(t, err)
+	})
+}
+
+func TestParser_ReconstructBinary_ScalarPayload(t *testing.T) {
+	t.Parallel()
+	p := newBinaryParser()
+
+	// A scalar (non-object, non-array) payload exercises the default branch of
+	// replacePlaceholders and is returned unchanged.
+	msg := &socketio_v5.Message{
+		Type:              socketio_v5.PacketBinaryEvent,
+		NS:                "/",
+		BinaryAttachments: intPtr(1),
+		Event: &socketio_v5.Event{
+			Name:     "ev",
+			Payloads: []interface{}{json.RawMessage(`"scalar"`), json.RawMessage(`{"_placeholder":true,"num":0}`)},
+		},
+	}
+	require.NoError(t, p.ReconstructBinary(msg, [][]byte{[]byte("buf")}))
+	assert.Equal(t, "scalar", msg.Event.Payloads[0])
+	assert.Equal(t, []byte("buf"), msg.Event.Payloads[1])
+}
+
+// TestParser_BinaryRoundTrip verifies serialize -> parse -> reconstruct restores
+// the original binary payloads for both events and acks, including multiple and
+// nested attachments.
+func TestParser_BinaryRoundTrip(t *testing.T) {
+	t.Parallel()
+	p := newBinaryParser()
+
+	tests := []struct {
+		name string
+		msg  *socketio_v5.Message
+	}{
+		{
+			name: "single binary event",
+			msg: &socketio_v5.Message{
+				Type: socketio_v5.PacketEvent,
+				NS:   "/",
+				Event: &socketio_v5.Event{
+					Name:     "ev",
+					Payloads: []interface{}{[]byte{0x0, 0x1, 0x2, 0xFF}},
+				},
+			},
+		},
+		{
+			name: "multi binary with text",
+			msg: &socketio_v5.Message{
+				Type: socketio_v5.PacketEvent,
+				NS:   "/admin",
+				Event: &socketio_v5.Event{
+					Name:     "ev",
+					Payloads: []interface{}{[]byte("a"), []byte("bb"), []byte("ccc")},
+				},
+			},
+		},
+		{
+			name: "binary ack with id",
+			msg: &socketio_v5.Message{
+				Type:  socketio_v5.PacketAck,
+				NS:    "/",
+				AckId: intPtr(42),
+				Event: &socketio_v5.Event{
+					Payloads: []interface{}{[]byte("ack-bytes")},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			header, attachments, err := p.SerializeBinary(tt.msg)
+			require.NoError(t, err)
+
+			parsed, err := p.Parse(header)
+			require.NoError(t, err)
+			require.NotNil(t, parsed.BinaryAttachments)
+			require.Equal(t, len(attachments), *parsed.BinaryAttachments)
+
+			require.NoError(t, p.ReconstructBinary(parsed, attachments))
+
+			// Compare reconstructed []byte payloads with the originals.
+			require.Len(t, parsed.Event.Payloads, len(tt.msg.Event.Payloads))
+			for i, want := range tt.msg.Event.Payloads {
+				assert.Equal(t, want, parsed.Event.Payloads[i])
+			}
+			// Namespace and ack id survive the round trip.
+			assert.Equal(t, tt.msg.NS, parsed.NS)
+			if tt.msg.AckId != nil {
+				require.NotNil(t, parsed.AckId)
+				assert.Equal(t, *tt.msg.AckId, *parsed.AckId)
+			}
+		})
+	}
+}
+
+// TestParser_ParseBinaryAttachmentCount exercises the attachment-count parsing
+// edge cases on the binary packet header.
+func TestParser_ParseBinaryAttachmentCount(t *testing.T) {
+	t.Parallel()
+	p := newBinaryParser()
+
+	tests := []struct {
+		name    string
+		input   []byte
+		wantErr error
+		count   *int
+	}{
+		{
+			name:  "binary ack zero attachments",
+			input: []byte(`60-["data"]`),
+			count: intPtr(0),
+		},
+		{
+			name:    "missing dash",
+			input:   []byte(`51["ev"]`),
+			wantErr: ErrParsePackage,
+		},
+		{
+			name:    "no count digits",
+			input:   []byte(`5-["ev"]`),
+			wantErr: ErrParsePackage,
+		},
+		{
+			name:    "absurdly long count",
+			input:   []byte(`51234567890123456789-["ev"]`),
+			wantErr: ErrParsePackage,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			msg, err := p.Parse(tt.input)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, msg.BinaryAttachments)
+			assert.Equal(t, *tt.count, *msg.BinaryAttachments)
+		})
+	}
+}

--- a/socket.io/v5/parser/default/binary_test.go
+++ b/socket.io/v5/parser/default/binary_test.go
@@ -51,6 +51,85 @@ func TestParser_WrapCallback_Binary(t *testing.T) {
 		cb([]interface{}{[]byte("data")})
 		assert.False(t, called, "binary payload must not bind to a string parameter")
 	})
+
+	t.Run("malformed json raw message is rejected", func(t *testing.T) {
+		called := false
+		cb := p.WrapCallback(func(n int) { called = true })
+		require.NotNil(t, cb)
+		// A json.RawMessage that cannot unmarshal into the parameter type must
+		// take the json.Unmarshal error path and not invoke the handler.
+		cb([]interface{}{json.RawMessage(`"not-an-int"`)})
+		assert.False(t, called, "malformed json must not invoke the handler")
+	})
+}
+
+// TestParser_WrapCallback_NestedBinary verifies that a typed handler receives
+// an already-decoded value (a map[string]interface{} / []interface{} produced
+// by binary attachment reconstruction) that contains []byte at a nested
+// position. Such values arrive as concrete Go types (not json.RawMessage), so
+// WrapCallback must assign them to the handler parameter directly rather than
+// attempting json.Unmarshal. Previously these only worked via OnAny.
+func TestParser_WrapCallback_NestedBinary(t *testing.T) {
+	t.Parallel()
+	p := newBinaryParser()
+
+	binData := []byte{0x01, 0x02, 0x03, 0x04}
+
+	t.Run("map with nested binary fires typed handler", func(t *testing.T) {
+		called := false
+		var got map[string]interface{}
+		cb := p.WrapCallback(func(m map[string]interface{}) {
+			called = true
+			got = m
+		})
+		require.NotNil(t, cb)
+
+		// Reconstructed payload: a decoded map containing []byte at a key.
+		payload := map[string]interface{}{
+			"name": "avatar",
+			"file": binData,
+		}
+		cb([]interface{}{payload})
+
+		require.True(t, called, "typed handler must fire for nested-binary map")
+		raw, ok := got["file"].([]byte)
+		require.True(t, ok, "expected []byte at key file")
+		assert.Equal(t, binData, raw)
+	})
+
+	t.Run("map containing nested binary slice fires typed handler", func(t *testing.T) {
+		called := false
+		var got map[string]interface{}
+		cb := p.WrapCallback(func(m map[string]interface{}) {
+			called = true
+			got = m
+		})
+		require.NotNil(t, cb)
+
+		// Reconstructed payload: a decoded map whose value is a slice that
+		// contains []byte at an index.
+		payload := map[string]interface{}{
+			"items": []interface{}{"first", binData},
+		}
+		cb([]interface{}{payload})
+
+		require.True(t, called, "typed handler must fire for nested-binary slice")
+		items, ok := got["items"].([]interface{})
+		require.True(t, ok, "expected []interface{} at key items")
+		require.Len(t, items, 2)
+		raw, ok := items[1].([]byte)
+		require.True(t, ok, "expected []byte at index 1")
+		assert.Equal(t, binData, raw)
+	})
+
+	t.Run("decoded value not assignable to param is rejected", func(t *testing.T) {
+		called := false
+		// A decoded map cannot be assigned to an int parameter.
+		cb := p.WrapCallback(func(n int) { called = true })
+		require.NotNil(t, cb)
+		cb([]interface{}{map[string]interface{}{"a": []byte{1}}})
+		assert.False(t, called, "non-assignable decoded value must be rejected")
+	})
 }
 
 func TestParser_HasBinary(t *testing.T) {

--- a/socket.io/v5/parser/default/binary_test.go
+++ b/socket.io/v5/parser/default/binary_test.go
@@ -803,3 +803,45 @@ func TestParser_ParseBinaryAttachmentCount(t *testing.T) {
 		})
 	}
 }
+
+// TestParser_SerializeBinary_NoSurvivingPlaceholders verifies the fallback for
+// payloads where HasBinary saw a []byte but encoding/json drops it (json:"-"):
+// no attachment survives, so the packet must go out as a plain EVENT/ACK
+// instead of a 0-attachment binary packet.
+func TestParser_SerializeBinary_NoSurvivingPlaceholders(t *testing.T) {
+	t.Parallel()
+	p := newBinaryParser()
+
+	type hidden struct {
+		Secret []byte `json:"-"`
+		Name   string `json:"name"`
+	}
+
+	t.Run("event falls back to plain EVENT", func(t *testing.T) {
+		header, attachments, err := p.SerializeBinary(&socketio_v5.Message{
+			Type: socketio_v5.PacketEvent,
+			NS:   "/",
+			Event: &socketio_v5.Event{
+				Name:     "stealth",
+				Payloads: []interface{}{hidden{Secret: []byte{1, 2}, Name: "x"}},
+			},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, attachments)
+		assert.Equal(t, []byte(`2["stealth",{"name":"x"}]`), header)
+	})
+
+	t.Run("ack falls back to plain ACK", func(t *testing.T) {
+		header, attachments, err := p.SerializeBinary(&socketio_v5.Message{
+			Type:  socketio_v5.PacketAck,
+			NS:    "/",
+			AckId: intPtr(3),
+			Event: &socketio_v5.Event{
+				Payloads: []interface{}{hidden{Secret: []byte{1}, Name: "y"}},
+			},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, attachments)
+		assert.Equal(t, []byte(`33[{"name":"y"}]`), header)
+	})
+}

--- a/socket.io/v5/parser/default/binary_test.go
+++ b/socket.io/v5/parser/default/binary_test.go
@@ -209,6 +209,40 @@ func TestParser_HasBinary(t *testing.T) {
 			}},
 			want: false,
 		},
+		{
+			// A nil byte slice is a nullable JSON value (encoding/json renders it
+			// as null), not an empty buffer — it must stay on the text path.
+			name:  "nil byte slice is not binary",
+			event: &socketio_v5.Event{Name: "ev", Payloads: []interface{}{[]byte(nil)}},
+			want:  false,
+		},
+		{
+			name:  "empty non-nil byte slice is binary",
+			event: &socketio_v5.Event{Name: "ev", Payloads: []interface{}{[]byte{}}},
+			want:  true,
+		},
+		{
+			name: "nil byte slice nested in map is not binary",
+			event: &socketio_v5.Event{Name: "ev", Payloads: []interface{}{
+				map[string]interface{}{"file": []byte(nil)},
+			}},
+			want: false,
+		},
+		{
+			// Exercises the reflect path: a nil []byte struct field is null.
+			name: "nil byte slice struct field is not binary",
+			event: &socketio_v5.Event{Name: "ev", Payloads: []interface{}{
+				struct{ File []byte }{File: nil},
+			}},
+			want: false,
+		},
+		{
+			name: "empty non-nil byte slice struct field is binary",
+			event: &socketio_v5.Event{Name: "ev", Payloads: []interface{}{
+				struct{ File []byte }{File: []byte{}},
+			}},
+			want: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -289,6 +323,40 @@ func TestParser_SerializeBinary(t *testing.T) {
 		assert.Equal(t, []byte(`61-/admin,7[{"_placeholder":true,"num":0}]`), header)
 		require.Len(t, attachments, 1)
 		assert.Equal(t, []byte{0xFF}, attachments[0])
+	})
+
+	t.Run("nil byte slice stays null next to real binary", func(t *testing.T) {
+		header, attachments, err := p.SerializeBinary(&socketio_v5.Message{
+			Type: socketio_v5.PacketEvent,
+			NS:   "/",
+			Event: &socketio_v5.Event{
+				Name: "nullable",
+				Payloads: []interface{}{
+					[]byte(nil),
+					map[string]interface{}{"file": []byte(nil), "blob": []byte("data")},
+				},
+			},
+		})
+		require.NoError(t, err)
+		// Only the non-nil slice is lifted; the nil ones are JSON null.
+		assert.Equal(t, []byte(`51-["nullable",null,{"blob":{"_placeholder":true,"num":0},"file":null}]`), header)
+		require.Len(t, attachments, 1)
+		assert.Equal(t, []byte("data"), attachments[0])
+	})
+
+	t.Run("empty non-nil byte slice becomes empty attachment", func(t *testing.T) {
+		header, attachments, err := p.SerializeBinary(&socketio_v5.Message{
+			Type: socketio_v5.PacketEvent,
+			NS:   "/",
+			Event: &socketio_v5.Event{
+				Name:     "emptybuf",
+				Payloads: []interface{}{[]byte{}},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []byte(`51-["emptybuf",{"_placeholder":true,"num":0}]`), header)
+		require.Len(t, attachments, 1)
+		assert.Empty(t, attachments[0])
 	})
 
 	t.Run("nil message", func(t *testing.T) {

--- a/socket.io/v5/parser/default/binary_test.go
+++ b/socket.io/v5/parser/default/binary_test.go
@@ -383,6 +383,20 @@ func TestParser_ReconstructBinary(t *testing.T) {
 		assert.ErrorIs(t, p.ReconstructBinary(msg, [][]byte{{1}}), ErrParseBinary)
 	})
 
+	t.Run("placeholder num is fractional", func(t *testing.T) {
+		// A non-integer index must be rejected, not truncated by int(num) to a
+		// wrong attachment.
+		msg := &socketio_v5.Message{
+			Type:              socketio_v5.PacketBinaryEvent,
+			BinaryAttachments: intPtr(2),
+			Event: &socketio_v5.Event{
+				Name:     "x",
+				Payloads: []interface{}{json.RawMessage(`{"_placeholder":true,"num":1.5}`)},
+			},
+		}
+		assert.ErrorIs(t, p.ReconstructBinary(msg, [][]byte{{1}, {2}}), ErrParseBinary)
+	})
+
 	t.Run("placeholder without num", func(t *testing.T) {
 		msg := &socketio_v5.Message{
 			Type:              socketio_v5.PacketBinaryEvent,

--- a/socket.io/v5/parser/default/binary_test.go
+++ b/socket.io/v5/parser/default/binary_test.go
@@ -61,6 +61,42 @@ func TestParser_WrapCallback_Binary(t *testing.T) {
 		cb([]interface{}{json.RawMessage(`"not-an-int"`)})
 		assert.False(t, called, "malformed json must not invoke the handler")
 	})
+
+	// A reconstructed JSON null arrives as a nil interface{} alongside a binary
+	// attachment; it must bind to the zero value (mirroring json.Unmarshal("null"))
+	// rather than reject the handler, just as on the non-binary path.
+	t.Run("null argument bound to interface is nil", func(t *testing.T) {
+		called := false
+		var gotV interface{} = "x"
+		var gotB []byte
+		cb := p.WrapCallback(func(v interface{}, b []byte) { called = true; gotV = v; gotB = b })
+		require.NotNil(t, cb)
+		cb([]interface{}{nil, []byte("d")})
+		require.True(t, called, "a null argument must not reject a binary callback")
+		assert.Nil(t, gotV)
+		assert.Equal(t, []byte("d"), gotB)
+	})
+
+	t.Run("null argument bound to pointer is nil", func(t *testing.T) {
+		type dto struct{ X int }
+		called := false
+		gotP := &dto{X: 1}
+		cb := p.WrapCallback(func(v *dto) { called = true; gotP = v })
+		require.NotNil(t, cb)
+		cb([]interface{}{nil})
+		require.True(t, called)
+		assert.Nil(t, gotP, "json null binds to a nil pointer")
+	})
+
+	t.Run("null argument bound to non-nilable param is zero", func(t *testing.T) {
+		called := false
+		got := -1
+		cb := p.WrapCallback(func(n int) { called = true; got = n })
+		require.NotNil(t, cb)
+		cb([]interface{}{nil})
+		require.True(t, called, "json null binds to the zero value for non-nilable types")
+		assert.Equal(t, 0, got)
+	})
 }
 
 // TestParser_WrapCallback_NestedBinary verifies that a typed handler receives

--- a/socket.io/v5/parser/default/binary_test.go
+++ b/socket.io/v5/parser/default/binary_test.go
@@ -52,6 +52,31 @@ func TestParser_WrapCallback_Binary(t *testing.T) {
 		assert.False(t, called, "binary payload must not bind to a string parameter")
 	})
 
+	t.Run("byte payload binds to defined byte-slice type", func(t *testing.T) {
+		// A defined type with a plain []byte underlying type is assignable
+		// directly (fast path).
+		type Blob []byte
+		var got Blob
+		cb := p.WrapCallback(func(b Blob) { got = b })
+		require.NotNil(t, cb)
+		cb([]interface{}{[]byte{0xA, 0xB}})
+		assert.Equal(t, Blob{0xA, 0xB}, got)
+	})
+
+	t.Run("byte payload binds to uint8-alias slice type", func(t *testing.T) {
+		// A slice of a DEFINED uint8 element is neither assignable nor
+		// convertible from []byte, but its element kind is Uint8, so the
+		// JSON round-trip (base64) decodes it — exactly as it does when the
+		// same payload arrives as a base64 JSON string.
+		type octet uint8
+		type octetBlob []octet
+		var got octetBlob
+		cb := p.WrapCallback(func(b octetBlob) { got = b })
+		require.NotNil(t, cb)
+		cb([]interface{}{[]byte{0x1, 0x2, 0x3}})
+		assert.Equal(t, octetBlob{0x1, 0x2, 0x3}, got)
+	})
+
 	t.Run("malformed json raw message is rejected", func(t *testing.T) {
 		called := false
 		cb := p.WrapCallback(func(n int) { called = true })

--- a/socket.io/v5/parser/default/callback.go
+++ b/socket.io/v5/parser/default/callback.go
@@ -38,13 +38,36 @@ func (p *SocketIOV5DefaultParser) WrapCallback(callback interface{}) func(in []i
 			// produced by binary attachment reconstruction (e.g. a []byte for a
 			// top-level binary, or a map[string]interface{} / []interface{} that
 			// contains []byte at a nested position). They cannot be JSON
-			// unmarshaled, so assign them to the callback parameter directly via
-			// reflection when the concrete type is assignable.
+			// unmarshaled directly, so first try a zero-cost reflect assignment
+			// when the concrete type already matches the callback parameter
+			// (the fast path for []byte and map[string]interface{} handlers).
 			data, isRaw := in[i].(json.RawMessage)
 			if !isRaw {
 				argValueOf := reflect.ValueOf(in[i])
 				if argValueOf.IsValid() && argValueOf.Type().AssignableTo(argType) {
 					args[i] = argValueOf
+					continue
+				}
+				// A top-level []byte that is not directly assignable must NOT be
+				// silently coerced into a string/other type (it would marshal to a
+				// base64 string), so it is rejected just like before. Other
+				// reconstructed values (e.g. a map[string]interface{} containing
+				// []byte) fall back to a json.Marshal/Unmarshal round-trip so typed
+				// handlers such as func(v struct{ File []byte }) still receive the
+				// value; encoding/json round-trips []byte through base64 back into a
+				// []byte field, reproducing the original bytes.
+				if _, isBytes := in[i].([]byte); !isBytes && argValueOf.IsValid() {
+					converted := reflect.New(argType).Interface()
+					marshaled, err := json.Marshal(in[i])
+					if err != nil {
+						p.logger.Errorf("Error marshaling argument %d (%v): %v\n", i, in[i], err)
+						return
+					}
+					if err := json.Unmarshal(marshaled, converted); err != nil {
+						p.logger.Errorf("Error unmarshaling argument %d (%v): %v\n", i, in[i], err)
+						return
+					}
+					args[i] = reflect.ValueOf(converted).Elem()
 					continue
 				}
 				p.logger.Errorf("Wrong data in %d json entity", i)

--- a/socket.io/v5/parser/default/callback.go
+++ b/socket.io/v5/parser/default/callback.go
@@ -34,12 +34,17 @@ func (p *SocketIOV5DefaultParser) WrapCallback(callback interface{}) func(in []i
 		for i := 0; i < callbackType.NumIn(); i++ {
 			argType := callbackType.In(i)
 
-			// Reconstructed binary attachments arrive as []byte rather than
-			// json.RawMessage. When the callback parameter is []byte, pass the
-			// raw bytes straight through instead of JSON-unmarshaling them.
-			if raw, isBytes := in[i].([]byte); isBytes {
-				if argType == reflect.TypeOf([]byte(nil)) {
-					args[i] = reflect.ValueOf(raw)
+			// Values that are not json.RawMessage are already-decoded Go values
+			// produced by binary attachment reconstruction (e.g. a []byte for a
+			// top-level binary, or a map[string]interface{} / []interface{} that
+			// contains []byte at a nested position). They cannot be JSON
+			// unmarshaled, so assign them to the callback parameter directly via
+			// reflection when the concrete type is assignable.
+			data, isRaw := in[i].(json.RawMessage)
+			if !isRaw {
+				argValueOf := reflect.ValueOf(in[i])
+				if argValueOf.IsValid() && argValueOf.Type().AssignableTo(argType) {
+					args[i] = argValueOf
 					continue
 				}
 				p.logger.Errorf("Wrong data in %d json entity", i)
@@ -47,11 +52,6 @@ func (p *SocketIOV5DefaultParser) WrapCallback(callback interface{}) func(in []i
 			}
 
 			argValue := reflect.New(argType).Interface()
-			data, ok := in[i].(json.RawMessage)
-			if !ok {
-				p.logger.Errorf("Wrong data in %d json entity", i)
-				return
-			}
 			if err := json.Unmarshal(data, argValue); err != nil {
 				p.logger.Errorf("Error unmarshaling argument %d (%v): %v\n", i, in[i], err)
 				return

--- a/socket.io/v5/parser/default/callback.go
+++ b/socket.io/v5/parser/default/callback.go
@@ -33,6 +33,19 @@ func (p *SocketIOV5DefaultParser) WrapCallback(callback interface{}) func(in []i
 		args := make([]reflect.Value, callbackType.NumIn())
 		for i := 0; i < callbackType.NumIn(); i++ {
 			argType := callbackType.In(i)
+
+			// Reconstructed binary attachments arrive as []byte rather than
+			// json.RawMessage. When the callback parameter is []byte, pass the
+			// raw bytes straight through instead of JSON-unmarshaling them.
+			if raw, isBytes := in[i].([]byte); isBytes {
+				if argType == reflect.TypeOf([]byte(nil)) {
+					args[i] = reflect.ValueOf(raw)
+					continue
+				}
+				p.logger.Errorf("Wrong data in %d json entity", i)
+				return
+			}
+
 			argValue := reflect.New(argType).Interface()
 			data, ok := in[i].(json.RawMessage)
 			if !ok {

--- a/socket.io/v5/parser/default/callback.go
+++ b/socket.io/v5/parser/default/callback.go
@@ -60,13 +60,19 @@ func (p *SocketIOV5DefaultParser) WrapCallback(callback interface{}) func(in []i
 				}
 				// A top-level []byte that is not directly assignable must NOT be
 				// silently coerced into a string/other type (it would marshal to a
-				// base64 string), so it is rejected just like before. Other
-				// reconstructed values (e.g. a map[string]interface{} containing
-				// []byte) fall back to a json.Marshal/Unmarshal round-trip so typed
-				// handlers such as func(v struct{ File []byte }) still receive the
-				// value; encoding/json round-trips []byte through base64 back into a
+				// base64 string), so it is rejected just like before — UNLESS the
+				// parameter is itself a uint8-slice kind (a defined byte-slice type
+				// such as `type Blob []Octet` with `type Octet uint8`), which the
+				// round-trip decodes back into the typed bytes exactly as it would
+				// for the equivalent base64 JSON payload. Other reconstructed values
+				// (e.g. a map[string]interface{} containing []byte) fall back to a
+				// json.Marshal/Unmarshal round-trip so typed handlers such as
+				// func(v struct{ File []byte }) still receive the value;
+				// encoding/json round-trips []byte through base64 back into a
 				// []byte field, reproducing the original bytes.
-				if _, isBytes := in[i].([]byte); !isBytes && argValueOf.IsValid() {
+				_, isBytes := in[i].([]byte)
+				bytesTarget := argType.Kind() == reflect.Slice && argType.Elem().Kind() == reflect.Uint8
+				if (!isBytes || bytesTarget) && argValueOf.IsValid() {
 					converted := reflect.New(argType).Interface()
 					marshaled, err := json.Marshal(in[i])
 					if err != nil {

--- a/socket.io/v5/parser/default/callback.go
+++ b/socket.io/v5/parser/default/callback.go
@@ -43,6 +43,16 @@ func (p *SocketIOV5DefaultParser) WrapCallback(callback interface{}) func(in []i
 			// (the fast path for []byte and map[string]interface{} handlers).
 			data, isRaw := in[i].(json.RawMessage)
 			if !isRaw {
+				if in[i] == nil {
+					// A reconstructed JSON null arrives as a nil interface{}, for which
+					// reflect.ValueOf is invalid. Mirror json.Unmarshal("null", ...),
+					// which leaves the target at its zero value for any type (nil for
+					// pointers/interfaces/maps/slices), so a null argument alongside a
+					// binary attachment behaves exactly as it does on the non-binary
+					// path instead of being rejected as "wrong data".
+					args[i] = reflect.Zero(argType)
+					continue
+				}
 				argValueOf := reflect.ValueOf(in[i])
 				if argValueOf.IsValid() && argValueOf.Type().AssignableTo(argType) {
 					args[i] = argValueOf

--- a/socket.io/v5/parser/default/callback.go
+++ b/socket.io/v5/parser/default/callback.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 )
 
+var rawMessageType = reflect.TypeOf(json.RawMessage{})
+
 func (p *SocketIOV5DefaultParser) WrapCallback(callback interface{}) func(in []interface{}) {
 
 	if p.payloadParser != nil {
@@ -54,7 +56,13 @@ func (p *SocketIOV5DefaultParser) WrapCallback(callback interface{}) func(in []i
 					continue
 				}
 				argValueOf := reflect.ValueOf(in[i])
-				if argValueOf.IsValid() && argValueOf.Type().AssignableTo(argType) {
+				// json.RawMessage parameters must always hold valid JSON, but a
+				// reconstructed binary attachment is a plain []byte of arbitrary
+				// bytes — assignable to RawMessage, yet not JSON. Skip the direct
+				// assignment for RawMessage targets so the value takes the
+				// marshal round-trip below, which encodes the bytes as a base64
+				// JSON string (the same representation typed []byte fields see).
+				if argValueOf.IsValid() && argValueOf.Type().AssignableTo(argType) && argType != rawMessageType {
 					args[i] = argValueOf
 					continue
 				}

--- a/socket.io/v5/parser/default/parser.go
+++ b/socket.io/v5/parser/default/parser.go
@@ -21,11 +21,34 @@ func (p *SocketIOV5DefaultParser) checkData(data []byte) (socketio_v5.SocketIOPa
 		return socketio_v5.PacketUnknown, fmt.Errorf("%w: %v", ErrParsePackage, "empty message")
 	}
 	eventType := socketio_v5.SocketIOPacket(data[0] - '0')
-	switch eventType {
-	case socketio_v5.PacketBinaryEvent, socketio_v5.PacketBinaryAck:
-		return eventType, fmt.Errorf("%w: %v", ErrParseEventUnsupported, errors.New("binary events are not supported yet"))
-	}
 	return eventType, nil
+}
+
+// extractBinaryAttachments reads the binary attachment count that prefixes a
+// PacketBinaryEvent/PacketBinaryAck header, e.g. the "1-" in
+// `51-["ev",{"_placeholder":true,"num":0}]`. It records the count on msg and
+// returns the remaining packet bytes (after the '-'). For non-binary packets it
+// is a no-op and returns packetData unchanged.
+func (p *SocketIOV5DefaultParser) extractBinaryAttachments(msg *socketio_v5.Message, packetData []byte) ([]byte, error) {
+	if msg.Type != socketio_v5.PacketBinaryEvent && msg.Type != socketio_v5.PacketBinaryAck {
+		return packetData, nil
+	}
+	end := 0
+	for i, ch := range packetData {
+		if ch < '0' || ch > '9' {
+			break
+		}
+		end = i + 1
+		if end > 18 { // guard against absurdly long counts
+			return nil, fmt.Errorf("%w: %v", ErrParsePackage, errors.New("wrong attachment count"))
+		}
+	}
+	if end == 0 || end >= len(packetData) || packetData[end] != '-' {
+		return nil, fmt.Errorf("%w: %v", ErrParsePackage, errors.New("missing attachment count"))
+	}
+	count, _ := strconv.Atoi(string(packetData[:end]))
+	msg.BinaryAttachments = &count
+	return packetData[end+1:], nil
 }
 
 func (p *SocketIOV5DefaultParser) extractNamespace(msg *socketio_v5.Message, packetData []byte) []byte {
@@ -75,14 +98,26 @@ func (p *SocketIOV5DefaultParser) Parse(data []byte) (*socketio_v5.Message, erro
 
 	packetData := data[1:]
 	if len(packetData) == 0 {
+		switch msg.Type {
+		case socketio_v5.PacketBinaryEvent, socketio_v5.PacketBinaryAck:
+			return nil, fmt.Errorf("%w: %v", ErrParsePackage, errors.New("wrong package payload"))
+		}
 		return msg, nil
+	}
+
+	// Binary packets carry the attachment count (e.g. "1-") immediately after
+	// the type and before the namespace, per the socket.io v5 wire format.
+	packetData, err = p.extractBinaryAttachments(msg, packetData)
+	if err != nil {
+		return nil, err
 	}
 
 	packetData = p.extractNamespace(msg, packetData)
 
 	if len(packetData) == 0 {
 		switch msg.Type {
-		case socketio_v5.PacketEvent, socketio_v5.PacketAck, socketio_v5.PacketConnectError:
+		case socketio_v5.PacketEvent, socketio_v5.PacketAck, socketio_v5.PacketConnectError,
+			socketio_v5.PacketBinaryEvent, socketio_v5.PacketBinaryAck:
 			return nil, fmt.Errorf("%w: %v", ErrParsePackage, errors.New("wrong package payload"))
 		}
 		return msg, nil
@@ -94,15 +129,18 @@ func (p *SocketIOV5DefaultParser) Parse(data []byte) (*socketio_v5.Message, erro
 	}
 	if len(packetData) == 0 {
 		switch msg.Type {
-		case socketio_v5.PacketEvent, socketio_v5.PacketAck, socketio_v5.PacketConnectError:
+		case socketio_v5.PacketEvent, socketio_v5.PacketAck, socketio_v5.PacketConnectError,
+			socketio_v5.PacketBinaryEvent, socketio_v5.PacketBinaryAck:
 			return nil, fmt.Errorf("%w: %v", ErrParsePackage, errors.New("wrong package payload"))
 		}
 		return msg, nil
 	}
 
 	switch msg.Type {
-	case socketio_v5.PacketEvent, socketio_v5.PacketAck:
-		msg.Event, err = p.ParseEvent(packetData, msg.Type == socketio_v5.PacketAck)
+	case socketio_v5.PacketEvent, socketio_v5.PacketAck,
+		socketio_v5.PacketBinaryEvent, socketio_v5.PacketBinaryAck:
+		isAck := msg.Type == socketio_v5.PacketAck || msg.Type == socketio_v5.PacketBinaryAck
+		msg.Event, err = p.ParseEvent(packetData, isAck)
 	case socketio_v5.PacketConnectError:
 		errorMessage := string(packetData)
 		msg.ErrorMessage = &errorMessage

--- a/socket.io/v5/parser/default/parser.go
+++ b/socket.io/v5/parser/default/parser.go
@@ -111,6 +111,12 @@ func (p *SocketIOV5DefaultParser) Parse(data []byte) (*socketio_v5.Message, erro
 	if err != nil {
 		return nil, err
 	}
+	if len(packetData) == 0 {
+		// A truncated binary header (e.g. "51-") leaves nothing after the
+		// attachment count; extractNamespace would index packetData[0] and panic
+		// on this untrusted wire input, so reject it as a malformed packet.
+		return nil, fmt.Errorf("%w: %v", ErrParsePackage, errors.New("wrong package payload"))
+	}
 
 	packetData = p.extractNamespace(msg, packetData)
 

--- a/socket.io/v5/parser/default/parser_test.go
+++ b/socket.io/v5/parser/default/parser_test.go
@@ -102,13 +102,24 @@ func TestSocketIOV5DefaultParser_Parse(t *testing.T) {
 			wantErr: ErrParseEvent,
 		},
 		{
+			name:    "Binary event without attachment count",
+			input:   []byte("5"),
+			want:    nil,
+			wantErr: ErrParsePackage,
+		},
+		{
 			name:  "Binary event message",
-			input: []byte("5"),
+			input: []byte(`51-["binEvent",{"_placeholder":true,"num":0}]`),
 			want: &socketio_v5.Message{
-				Type: socketio_v5.PacketBinaryEvent,
-				NS:   "/",
+				Type:              socketio_v5.PacketBinaryEvent,
+				NS:                "/",
+				BinaryAttachments: intPtr(1),
+				Event: &socketio_v5.Event{
+					Name:     "binEvent",
+					Payloads: []interface{}{json.RawMessage(`{"_placeholder":true,"num":0}`)},
+				},
 			},
-			wantErr: ErrParseEventUnsupported,
+			wantErr: nil,
 		},
 		{
 			name:  "Connect error message",

--- a/socket.io/v5/parser/default/parser_test.go
+++ b/socket.io/v5/parser/default/parser_test.go
@@ -36,6 +36,20 @@ func TestSocketIOV5DefaultParser_Parse(t *testing.T) {
 			wantErr: ErrParsePackage,
 		},
 		{
+			// A binary header with the attachment count but no payload after it
+			// must be rejected, not panic in extractNamespace on empty input.
+			name:    "Truncated binary event header",
+			input:   []byte("51-"),
+			want:    nil,
+			wantErr: ErrParsePackage,
+		},
+		{
+			name:    "Truncated binary ack header",
+			input:   []byte("61-"),
+			want:    nil,
+			wantErr: ErrParsePackage,
+		},
+		{
 			name:  "Connect message",
 			input: []byte("0"),
 			want: &socketio_v5.Message{

--- a/socket.io/v5/parser/default/serializer.go
+++ b/socket.io/v5/parser/default/serializer.go
@@ -13,11 +13,13 @@ func (p *SocketIOV5DefaultParser) validateMessage(msg *socketio_v5.Message) erro
 		return errors.New("empty package")
 	}
 	switch msg.Type {
-	case socketio_v5.PacketBinaryAck, socketio_v5.PacketBinaryEvent:
-		return errors.New("biniary events are not supported yet")
-	case socketio_v5.PacketEvent:
+	case socketio_v5.PacketEvent, socketio_v5.PacketBinaryEvent:
 		if msg.Event == nil || msg.Event.Name == "" {
 			return errors.New("wrong event name")
+		}
+	case socketio_v5.PacketBinaryAck:
+		if msg.Event == nil {
+			return errors.New("wrong ack payload")
 		}
 	}
 	return nil
@@ -65,19 +67,32 @@ func (p *SocketIOV5DefaultParser) prepareSerializationInfo(msg *socketio_v5.Mess
 }
 
 func (p *SocketIOV5DefaultParser) Serialize(msg *socketio_v5.Message) ([]byte, error) {
-
 	err := p.validateMessage(msg)
 	if err != nil {
 		return nil, err
 	}
+	return p.serializeHeader(msg)
+}
 
+// serializeHeader assembles the textual socket.io packet header. For binary
+// packets (BinaryAttachments != nil) it inserts the "<count>-" attachment
+// prefix between the type and the namespace, e.g. "51-/admin,2[...]".
+func (p *SocketIOV5DefaultParser) serializeHeader(msg *socketio_v5.Message) ([]byte, error) {
 	pkgLen, jsonData, ackId, err := p.prepareSerializationInfo(msg)
 	if err != nil {
 		return nil, err
 	}
 
+	var attachmentPrefix []byte
+	if msg.BinaryAttachments != nil {
+		attachmentPrefix = append([]byte(strconv.Itoa(*msg.BinaryAttachments)), '-')
+		pkgLen += len(attachmentPrefix)
+	}
+
 	packet := make([]byte, 1, 1+pkgLen)
 	packet[0] = byte(msg.Type) + 0x30
+
+	packet = append(packet, attachmentPrefix...)
 
 	if msg.NS != "/" && msg.NS != "" {
 		packet = append(packet, []byte(msg.NS)...)

--- a/websocket/native/ws.go
+++ b/websocket/native/ws.go
@@ -35,11 +35,45 @@ func (ws *WebSocketConnection) Send(v []byte) error {
 	return websocket.Message.Send(ws.conn, string(v))
 }
 
+// SendBinary writes v as a WebSocket binary frame (opcode 2). Engine.io v4
+// carries socket.io binary attachments as binary frames over websocket.
+func (ws *WebSocketConnection) SendBinary(v []byte) error {
+	if ws.conn == nil {
+		return ErrNotConnected
+	}
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+	return websocket.Message.Send(ws.conn, v)
+}
+
 func (ws *WebSocketConnection) Receive(v *[]byte) error {
 	if ws.conn == nil {
 		return ErrNotConnected
 	}
 	return websocket.Message.Receive(ws.conn, v)
+}
+
+// ReceiveFrame reads the next frame and reports whether it was a binary frame
+// (opcode 2). It uses a codec that preserves the payload type so the caller can
+// distinguish binary attachments from text packets, which the default
+// websocket.Message codec collapses. Text and binary frames are both returned
+// as raw bytes in *v.
+func (ws *WebSocketConnection) ReceiveFrame(v *[]byte) (isBinary bool, err error) {
+	if ws.conn == nil {
+		return false, ErrNotConnected
+	}
+	pt := byte(websocket.TextFrame)
+	codec := websocket.Codec{
+		Unmarshal: func(data []byte, payloadType byte, dst interface{}) error {
+			pt = payloadType
+			*(dst.(*[]byte)) = data
+			return nil
+		},
+	}
+	if err := codec.Receive(ws.conn, v); err != nil {
+		return false, err
+	}
+	return pt == byte(websocket.BinaryFrame), nil
 }
 
 func (ws *WebSocketConnection) Close() error {

--- a/websocket/native/ws_binary_test.go
+++ b/websocket/native/ws_binary_test.go
@@ -1,0 +1,123 @@
+package ws_native
+
+import (
+	"context"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/websocket"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// binEchoServer starts a websocket server that echoes each frame back,
+// preserving its payload type (binary stays binary, text stays text). It
+// returns the ws:// URL and a cleanup function.
+func binEchoServer(t *testing.T) (string, func()) {
+	t.Helper()
+	handler := websocket.Handler(func(ws *websocket.Conn) {
+		for {
+			// Receive into []byte preserves the frame; echo it back as a binary
+			// frame so the client observes opcode 2.
+			var frame []byte
+			if err := websocket.Message.Receive(ws, &frame); err != nil {
+				return
+			}
+			ws.PayloadType = websocket.BinaryFrame
+			if err := websocket.Message.Send(ws, frame); err != nil {
+				return
+			}
+		}
+	})
+	server := httptest.NewServer(handler)
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	return wsURL, server.Close
+}
+
+func TestWebSocketConnection_SendBinary_NotConnected(t *testing.T) {
+	ws := &WebSocketConnection{}
+	err := ws.SendBinary([]byte{1, 2, 3})
+	assert.ErrorIs(t, err, ErrNotConnected)
+}
+
+func TestWebSocketConnection_ReceiveFrame_NotConnected(t *testing.T) {
+	ws := &WebSocketConnection{}
+	var data []byte
+	_, err := ws.ReceiveFrame(&data)
+	assert.ErrorIs(t, err, ErrNotConnected)
+}
+
+func TestWebSocketConnection_SendBinary_ReceiveFrame(t *testing.T) {
+	wsURL, closeServer := binEchoServer(t)
+	defer closeServer()
+
+	u, err := url.Parse(wsURL)
+	require.NoError(t, err)
+	origin, _ := url.Parse("http://localhost/")
+
+	conn := &WebSocketConnection{}
+	require.NoError(t, conn.Dial(context.Background(), u, origin))
+	defer conn.Close() //nolint:errcheck
+
+	payload := []byte{0x00, 0x01, 0xFF, 0x42}
+	require.NoError(t, conn.SendBinary(payload))
+
+	var received []byte
+	isBinary, err := conn.ReceiveFrame(&received)
+	require.NoError(t, err)
+	assert.True(t, isBinary, "echoed frame should be binary")
+	assert.Equal(t, payload, received)
+}
+
+func TestWebSocketConnection_ReceiveFrame_Error(t *testing.T) {
+	wsURL, closeServer := binEchoServer(t)
+
+	u, err := url.Parse(wsURL)
+	require.NoError(t, err)
+	origin, _ := url.Parse("http://localhost/")
+
+	conn := &WebSocketConnection{}
+	require.NoError(t, conn.Dial(context.Background(), u, origin))
+	defer conn.Close() //nolint:errcheck
+
+	// Close the server so the next ReceiveFrame on the still-open connection
+	// fails inside codec.Receive (exercising the error path, not the nil guard).
+	closeServer()
+
+	var received []byte
+	_, err = conn.ReceiveFrame(&received)
+	assert.Error(t, err)
+}
+
+func TestWebSocketConnection_ReceiveFrame_Text(t *testing.T) {
+	// A text echo server lets us verify ReceiveFrame reports isBinary == false.
+	handler := websocket.Handler(func(ws *websocket.Conn) {
+		var msg string
+		if err := websocket.Message.Receive(ws, &msg); err != nil {
+			return
+		}
+		ws.PayloadType = websocket.TextFrame
+		_ = websocket.Message.Send(ws, msg)
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	u, err := url.Parse("ws" + strings.TrimPrefix(server.URL, "http"))
+	require.NoError(t, err)
+	origin, _ := url.Parse("http://localhost/")
+
+	conn := &WebSocketConnection{}
+	require.NoError(t, conn.Dial(context.Background(), u, origin))
+	defer conn.Close() //nolint:errcheck
+
+	require.NoError(t, conn.Send([]byte("hello")))
+
+	var received []byte
+	isBinary, err := conn.ReceiveFrame(&received)
+	require.NoError(t, err)
+	assert.False(t, isBinary, "echoed text frame should not be binary")
+	assert.Equal(t, []byte("hello"), received)
+}

--- a/websocket/native/ws_binary_test.go
+++ b/websocket/native/ws_binary_test.go
@@ -81,11 +81,12 @@ func TestWebSocketConnection_ReceiveFrame_Error(t *testing.T) {
 
 	conn := &WebSocketConnection{}
 	require.NoError(t, conn.Dial(context.Background(), u, origin))
-	defer conn.Close() //nolint:errcheck
+	defer closeServer()
 
-	// Close the server so the next ReceiveFrame on the still-open connection
-	// fails inside codec.Receive (exercising the error path, not the nil guard).
-	closeServer()
+	// Close the client connection, then attempt to receive. The read fails
+	// inside codec.Receive on the closed connection, exercising the error path
+	// (not the nil guard) without blocking on a frame that never arrives.
+	require.NoError(t, conn.Close())
 
 	var received []byte
 	_, err = conn.ReceiveFrame(&received)

--- a/websocket/native/ws_test.go
+++ b/websocket/native/ws_test.go
@@ -40,22 +40,24 @@ func TestWebSocketConnection_Dial(t *testing.T) {
 	t.Run("Connection error", func(t *testing.T) {
 		t.Parallel()
 		ws := &WebSocketConnection{}
-		err = ws.Dial(ctx, &url.URL{
+		// Use a local error: parallel subtests must not write the shared
+		// variable from the parent scope (data race).
+		dialErr := ws.Dial(ctx, &url.URL{
 			Path:   "invalid-url",
 			Scheme: "ws",
 		}, origin)
-		assert.Error(t, err, "Dial should return an error for invalid URL")
+		assert.Error(t, dialErr, "Dial should return an error for invalid URL")
 		assert.Nil(t, ws.conn, "Connection should not be established")
 	})
 
 	t.Run("Config error", func(t *testing.T) {
 		t.Parallel()
 		ws := &WebSocketConnection{}
-		err = ws.Dial(ctx, &url.URL{
+		dialErr := ws.Dial(ctx, &url.URL{
 			Path:   "invalid-url",
 			Scheme: ";;;",
 		}, origin)
-		assert.Error(t, err, "Dial should return an error for invalid URL")
+		assert.Error(t, dialErr, "Dial should return an error for invalid URL")
 		assert.Nil(t, ws.conn, "Connection should not be established")
 	})
 }
@@ -256,18 +258,17 @@ func createTestServer(t *testing.T, receivedChan chan<- string) *httptest.Server
 			var msg string
 			err := websocket.Message.Receive(ws, &msg)
 			if err != nil {
-				// Игнорируем ошибку EOF, так как она ожидаема при закрытии соединения
-				if err.Error() != "EOF" {
-					t.Logf("Server received an error: %v", err)
-				}
+				// Receive errors (EOF, connection reset) are expected when the
+				// client side of a finished test tears the connection down. The
+				// handler goroutine may outlive the test, so it must not call
+				// t.Logf/t.Errorf here — logging after the test completes panics.
 				return
 			}
 			if receivedChan != nil {
 				receivedChan <- msg
 			}
-			// Echo the message back
+			// Echo the message back. Send errors are likewise teardown noise.
 			if err := websocket.Message.Send(ws, msg); err != nil {
-				t.Errorf("Server failed to send message: %v", err)
 				return
 			}
 		}


### PR DESCRIPTION
Implements #28.

Implements the Socket.IO v5 binary-attachment mechanism end to end so the client can send and receive binary payloads (`[]byte`) over both WebSocket and HTTP long-polling.

## Parser (`socket.io/v5`)
- Parse the attachment count from `BINARY_EVENT` (5) / `BINARY_ACK` (6) headers and **stage** the message until all attachment frames have arrived, then substitute the `{"_placeholder":true,"num":N}` markers with the raw buffers.
- Serialize `[]byte` payloads back into placeholders + attachment frames, emitting the correct attachment count.
- Reassembly is keyed so concurrent partial messages don't interleave.

## Engine.IO (`engine.io/v4`)
- **WebSocket:** deliver binary frames (opcode 2) up to the socket.io layer.
- **Polling:** decode the base64 `b`-prefixed binary payloads.

Binary data is exposed as `[]byte` in `Event.Payloads`; text events are unchanged.

## Tests
- Unit tests: round-trip (serialize→parse), multi-attachment, placeholder edge cases.
- An e2e binary-echo scenario added to the Docker suite.
- Reported 100% coverage on changed packages.

## Status / note
This PR is opened to get CI + automated review on the branch. It was produced in a long, contended session and **has not yet been independently re-verified** by me end-to-end (build/vet/gofmt/`-race`/coverage and the e2e binary test); I'll review the CI results and the diff and follow up. Treat bot/CI findings as the source of truth.

https://claude.ai/code/session_01Gkv7LscaX5vY63HQFudXTi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gkv7LscaX5vY63HQFudXTi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clients can send/receive raw binary attachments via a dedicated binary send path and a binary event handler; websocket frames preserve binary/text distinction.

* **Parser / Protocol**
  * Engine.IO and Socket.IO support binary headers + attachments, base64 long-polling binary records, multi-attachment messages, and safe reconstruction/validation.

* **Transport**
  * Binary delivery implemented for WebSocket and long-polling (including encoding/POST for polling).

* **Tests / E2E**
  * Extensive unit, concurrency, and end-to-end tests added across transports and ACK paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->